### PR TITLE
uninstall worker does not remove the includes file

### DIFF
--- a/plugins/agent-installer/worker_installer/tasks.py
+++ b/plugins/agent-installer/worker_installer/tasks.py
@@ -157,7 +157,8 @@ def uninstall(ctx, runner, agent_config, **kwargs):
         'Uninstalling celery worker [cloudify_agent={0}]'.format(agent_config))
 
     files_to_delete = [
-        agent_config['init_file'], agent_config['config_file']
+        agent_config['init_file'], agent_config['config_file'],
+        agent_config['includes_file']
     ]
     folders_to_delete = [agent_config['base_dir']]
     delete_files_if_exist(ctx, agent_config, runner, files_to_delete)


### PR DESCRIPTION
Noticed a lot of leftover "include" files on disk, I suppose we should delete those
