### PR TITLE
corrected sudo argument to be use_sudo

### DIFF
--- a/plugins/agent-installer/worker_installer/tests/test_configuration.py
+++ b/plugins/agent-installer/worker_installer/tests/test_configuration.py
@@ -394,7 +394,7 @@ class MockFabricRunner(FabricRunner):
     def __init__(self):
         self.put_files = {}
 
-    def put(self, file_path, content, sudo=False):
+    def put(self, file_path, content, use_sudo=False):
         self.put_files[file_path] = content
 
 


### PR DESCRIPTION
I checked a few different versions and it's always use_sudo http://pydoc.net/Python/Fabric/1.9.1/fabric.operations/

Output from tests: 

```
# nosetests test_configuration.py
..............E
======================================================================
ERROR: test_prepare_configuration (worker_installer.tests.test_configuration.ConfigurationCreationTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/rbs-cloudify-agent-installer/worker_installer/tests/test_configuration.py", line 433, in test_prepare_configuration
    self.get_resource)
  File "/root/rbs-cloudify-agent-installer/worker_installer/tasks.py", line 359, in create_celery_configuration
    runner.put(agent_config['config_file'], config, use_sudo=use_sudo)
TypeError: put() got an unexpected keyword argument 'use_sudo'
```

after correcting:

```
worker_installer/tests# nosetests test_configuration.py
...............
----------------------------------------------------------------------
Ran 15 tests in 0.114s

OK
```
