### PR TITLE
Cfy 2173 configure riemann for external hosts

### DIFF
--- a/plugins/riemann-controller/riemann_controller/resources/manager.config
+++ b/plugins/riemann-controller/riemann_controller/resources/manager.config
@@ -77,7 +77,7 @@
 
 (defn- amqp-connection-conf
   []
-  {:host (or (System/getenv "RABBITMQ_HOST") "localhost")})
+  {:host (or (System/getenv "RABBITMQ_HOST") "rabbitmq")})
 
 (defrecord AMQPConnection [connection]
   ServiceEquiv

--- a/plugins/riemann-controller/riemann_controller/resources/manager.config
+++ b/plugins/riemann-controller/riemann_controller/resources/manager.config
@@ -75,6 +75,10 @@
     (let [event (json/parse-string (String. payload) true)]
       (riemann.core/stream! core event))))
 
+(defn- amqp-connection-conf
+  []
+  {:host (or (System/getenv "HOSTING_VM") "rabbitmq")})
+
 (defrecord AMQPConnection [connection]
   ServiceEquiv
   (equiv? [this other]
@@ -90,7 +94,7 @@
   (start! [this]
     (locking this
       (when (not @connection)
-        (let [new-connection (l-core/connect)]
+        (let [new-connection (l-core/connect (amqp-connection-conf))]
           (info "AMQP connection opened")
           (reset! connection new-connection)))))
 
@@ -104,7 +108,7 @@
 (defn amqp-connection []
   ; connection is opened here because we need to make sure
   ; it is started before the manager queue service is started
-  (let [new-connection (l-core/connect)]
+  (let [new-connection (l-core/connect (amqp-connection-conf))]
     (info "AMQP connection opened")
     (service! (AMQPConnection. (atom new-connection)))))
 
@@ -585,7 +589,7 @@
                   :deployment_id (last pair)
                   :time 0})
                pairs)
-      connection (l-core/connect)
+      connection (l-core/connect (amqp-connection-conf))
       channel (l-channel/open connection)
       exchange-name "cloudify-monitoring"
       routing-key "manager-riemann"

--- a/plugins/riemann-controller/riemann_controller/resources/manager.config
+++ b/plugins/riemann-controller/riemann_controller/resources/manager.config
@@ -77,7 +77,7 @@
 
 (defn- amqp-connection-conf
   []
-  {:host (or (System/getenv "HOSTING_VM") "rabbitmq")})
+  {:host (or (System/getenv "RABBITMQ_HOST") "localhost")})
 
 (defrecord AMQPConnection [connection]
   ServiceEquiv

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -69,6 +69,7 @@ run_intergration_tests()
     wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.3.2.deb
     sudo dpkg -i elasticsearch-1.3.2.deb
     export PATH=/usr/share/elasticsearch/bin:$PATH
+    export HOSTING_VM='localhost'
     sudo mkdir -p /usr/share/elasticsearch/data
     sudo chmod 777 /usr/share/elasticsearch/data
     wget http://aphyr.com/riemann/riemann_0.2.6_all.deb

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -69,7 +69,6 @@ run_intergration_tests()
     wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.3.2.deb
     sudo dpkg -i elasticsearch-1.3.2.deb
     export PATH=/usr/share/elasticsearch/bin:$PATH
-    export HOSTING_VM='localhost'
     sudo mkdir -p /usr/share/elasticsearch/data
     sudo chmod 777 /usr/share/elasticsearch/data
     wget http://aphyr.com/riemann/riemann_0.2.6_all.deb

--- a/tests/testenv/processes/riemann.py
+++ b/tests/testenv/processes/riemann.py
@@ -69,6 +69,7 @@ class RiemannProcess(object):
             return
 
         env = os.environ.copy()
+        env['RABBITMQ_HOST'] = 'localhost'
         env['LANGOHR_JAR'] = self._langohr_jar_path()
         env['MANAGEMENT_IP'] = '127.0.0.1'
         env['MANAGER_REST_PORT'] = str(MANAGER_REST_PORT)


### PR DESCRIPTION
Riemann now receives an environment variable called HOSTING_VM to allow it to connect to different host other than localhost when initiating an AMQP connection.