### PR TITLE
Added CORS headers to response

### DIFF
--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -381,6 +381,17 @@ def _detect_debug_environment():
 app = setup_app(load_configuration())
 
 
+@app.after_request
+def after_request(response):
+    '''Post-processes requests. Adds CORS headers'''
+    response.headers.add('Access-Control-Allow-Origin', '*')
+    response.headers.add('Access-Control-Allow-Headers',
+                         'Content-Type,Authorization')
+    response.headers.add('Access-Control-Allow-Methods',
+                         'GET,PUT,POST,DELETE')
+    return response
+
+
 @app.errorhandler(500)
 def internal_error(e):
     # app.logger.exception(e)  # gets logged automatically


### PR DESCRIPTION
I didn't get a response in chat if anyone was against adding CORS support to the REST service, so here's the proposed patch.  This will allow third party web-based applications (ie. JavaScript) to make calls to the REST service.  
