### PR TITLE
CFY-5185 use ES for the version checking when updating instances

### DIFF
--- a/rest-service/manager_rest/file_server.py
+++ b/rest-service/manager_rest/file_server.py
@@ -43,15 +43,18 @@ class FileServer(object):
                 stderr=FNULL)
         else:
             self.process.start()
+            while not self.is_alive():
+                time.sleep(0.1)
 
     def stop(self):
         import logging
         logging.basicConfig(level=logging.INFO)
+        if not self.process.is_alive():
+            return
         try:
             pid = self.process.pid
             self.process.terminate()
-            while self.is_alive():
-                time.sleep(0.1)
+            self.process.join()
         except BaseException as e:
             exc_type, exc, traceback = sys.exc_info()
             logging.info('Failed to stop file_server, error: {0}'
@@ -63,10 +66,6 @@ class FileServer(object):
                 logging.info('stopped file server process, pid unknown')
 
     def start_impl(self):
-        import logging
-        logging.basicConfig(level=logging.DEBUG)
-        logging.info('Starting file server and serving files from: %s',
-                     self.root_path)
         os.chdir(self.root_path)
 
         class TCPServer(SocketServer.TCPServer):

--- a/rest-service/manager_rest/file_storage_manager.py
+++ b/rest-service/manager_rest/file_storage_manager.py
@@ -229,6 +229,13 @@ class FileStorageManager(object):
                 "Node {0} not found".format(node_update.id))
         node = data[NODE_INSTANCES][node_update.id]
 
+        if node.version is not None and node_update.version is not None:
+            if node_update.version <= node.version:
+                raise manager_exceptions.ConflictError(
+                    'Node instance update conflict [current_version={0}, '
+                    'updated_version={1}]'.format(
+                        node.version, node_update.version))
+
         if node_update.state is not None:
             node.state = node_update.state
         if node_update.runtime_properties is not None:

--- a/rest-service/manager_rest/resources.py
+++ b/rest-service/manager_rest/resources.py
@@ -14,6 +14,7 @@
 #  * limitations under the License.
 #
 
+import collections
 import os
 import zipfile
 import urllib
@@ -1038,27 +1039,17 @@ class NodeInstancesId(SecuredResource):
     @exceptions_handled
     @marshal_with(responses.NodeInstance)
     def patch(self, node_instance_id, **kwargs):
-        """
-        Update node instance by id
-        """
+        """Update node instance by id."""
         verify_json_content_type()
-        if request.json.__class__ is not dict or \
-            'version' not in request.json or \
-                request.json['version'].__class__ is not int:
 
-            if request.json.__class__ is not dict:
-                message = 'Request body is expected to be a map containing ' \
-                          'a "version" field and optionally ' \
-                          '"runtimeProperties" and/or "state" fields'
-            elif 'version' not in request.json:
-                message = 'Request body must be a map containing a ' \
-                          '"version" field'
-            else:
-                message = \
-                    "request body's 'version' field must be an int but" \
-                    " is of type {0}".format(request.json['version']
-                                             .__class__.__name__)
-            raise manager_exceptions.BadParametersError(message)
+        if not isinstance(request.json, collections.Mapping):
+            raise manager_exceptions.BadParametersError(
+                'Request body is expected to be a map containing a "version" '
+                'field and optionally "runtimeProperties" and/or "state" '
+                'fields')
+
+        verify_parameter_in_request_body('version', request.json,
+                                         param_type=int)
 
         node = models.DeploymentNodeInstance(
             id=node_instance_id,

--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -250,7 +250,7 @@ def init_secured_app(_app):
             config.instance().security_auth_token_generator)
 
     # init and configure flask-securest
-    secure_app = SecuREST(_app)
+    _app.extensions['securest'] = secure_app = SecuREST(_app)
     secure_app.logger = create_logger(
         logger_name='flask-securest',
         log_level=cfy_config.security_audit_log_level,

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -202,8 +202,10 @@ class BaseServerTestCase(unittest.TestCase):
         os.close(fd)
         self.file_server = FileServer(self.tmpdir)
         self.maintenance_mode_dir = tempfile.mkdtemp(prefix='maintenance-')
+
         self.addCleanup(self.cleanup)
         self.file_server.start()
+
         storage_manager.storage_manager_module_name = \
             STORAGE_MANAGER_MODULE_NAME
 
@@ -228,7 +230,7 @@ class BaseServerTestCase(unittest.TestCase):
         self.server_configuration = self.create_configuration()
         server.reset_state(self.server_configuration)
         utils.copy_resources(config.instance().file_server_root)
-        server.setup_app()
+        self.flask_app = server.setup_app()
         server.app.config['Testing'] = True
         self.app = server.app.test_client()
         self.client = self.create_client()

--- a/rest-service/manager_rest/test/security/test_userstore_and_roles_reload.py
+++ b/rest-service/manager_rest/test/security/test_userstore_and_roles_reload.py
@@ -44,6 +44,10 @@ class TestUserstoreReloadFile(SecurityTestBase):
         self.restore_userstore_file()
         self.restore_roles_config()
         super(TestUserstoreReloadFile, self).setUp()
+        self.addCleanup(self.stopsec)
+
+    def stopsec(self):
+        self.flask_app.extensions['securest'].userstore_driver.observer.stop()
 
     def create_configuration(self):
         test_config = super(TestUserstoreReloadFile, self).\


### PR DESCRIPTION
Instead of comparing `node_instance.version` inside the rest service, use
elasticsearch's index API: it does the version check itself.

Checking on the rest service side has a race condition problem because
when handling multiple update requests in parallel, separate concurrent rest
service processes will fetch the old version at the same time, do the check
independently, and will all write.