### PR TITLE
CFY-5218 Store the ES client to use connection pooling

### DIFF
--- a/rest-service/manager_rest/es_storage_manager.py
+++ b/rest-service/manager_rest/es_storage_manager.py
@@ -56,11 +56,14 @@ class ESStorageManager(object):
     def __init__(self, host, port):
         self.es_host = host
         self.es_port = port
+        self._es_connection = None
 
     @property
     def _connection(self):
-        return Elasticsearch(hosts=[{'host': self.es_host,
-                                     'port': self.es_port}])
+        if self._es_connection is None:
+            self._es_connection = Elasticsearch(
+                hosts=[{'host': self.es_host, 'port': self.es_port}])
+        return self._es_connection
 
     def _list_docs(self, doc_type, model_class, body=None, fields=None):
         include = list(fields) if fields else True


### PR DESCRIPTION
The Elasticsearch python client maintains a connection pool using
keepalive to talk to elasticsearch over persistent connections.
Store the client rather than creating a new one on each access,
to allow it to use the persistent connections.