### PR TITLE
FS scripts: Don't rely on `ctx runtime-props undefined` returning empty

### DIFF
--- a/resources/rest-service/cloudify/fs/fdisk.sh
+++ b/resources/rest-service/cloudify/fs/fdisk.sh
@@ -8,7 +8,7 @@ partition_number=1
 # device name is injected by using get_attribute on the target node.
 device_name=${device_name}
 
-partitioned=$(ctx source instance runtime-properties partitioned)
+partitioned=$(ctx source instance runtime-properties partitioned || true)
 
 
 if [[ -z "${use_external_resource}" && -z "${partitioned}" ]]; then

--- a/resources/rest-service/cloudify/fs/mkfs.sh
+++ b/resources/rest-service/cloudify/fs/mkfs.sh
@@ -4,7 +4,7 @@ use_external_resource=$(ctx node properties use_external_resource)
 fs_type=$(ctx node properties fs_type)
 filesys=$(ctx instance runtime-properties filesys)
 
-created=$(ctx instance runtime-properties created)
+created=$(ctx instance runtime-properties created || true)
 
 if [[ -z "${use_external_resource}" && -z "${created}" ]]; then
     mkfs_executable=''

--- a/resources/rest-service/cloudify/fs/mount-docker.sh
+++ b/resources/rest-service/cloudify/fs/mount-docker.sh
@@ -3,7 +3,7 @@
 fs_mount_path=$(ctx source node properties fs_mount_path)
 filesys=$(ctx source instance runtime-properties filesys)
 fs_type=$(ctx source node properties fs_type)
-ever_mounted=$(ctx source instance runtime-properties ever_mounted)
+ever_mounted=$(ctx source instance runtime-properties ever_mounted || true)
 
 ctx logger info "Checking whether docker is installed"
 set +e


### PR DESCRIPTION
`ctx runtime-properties` throws an error when looking up an undefined
runtime property. Scripts looking up runtime props that might not be
defined, need to guard against that.