### PR TITLE
CFY-5286 Don't hide 404 errors

### DIFF
--- a/rest-service/manager_rest/maintenance.py
+++ b/rest-service/manager_rest/maintenance.py
@@ -60,6 +60,10 @@ def prepare_maintenance_dict(status,
 
 def maintenance_mode_handler():
 
+    # failed to route the request - this is a 404. Abort early.
+    if not request.endpoint:
+        return
+
     # enabling internal requests
     if _is_internal_request() and is_bypass_maintenance_mode():
         return

--- a/rest-service/manager_rest/test/test_app.py
+++ b/rest-service/manager_rest/test/test_app.py
@@ -1,0 +1,33 @@
+#########
+# Copyright (c) 2016 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+
+"""Test the basic HTTP interface, app-wide error handling
+"""
+
+from nose.plugins.attrib import attr
+
+from manager_rest.test import base_test
+
+
+@attr(client_min_version=1, client_max_version=base_test.LATEST_API_VERSION)
+class AppTestCase(base_test.BaseServerTestCase):
+    def test_get_root_404(self):
+        """GET / returns a 404.
+
+        Check that the app can handle requests that couldn't be routed,
+        doesn't break with a 500.
+        """
+        resp = self.app.get('/')
+        self.assertEqual(404, resp.status_code)


### PR DESCRIPTION
A 404 error could result in a 500, which obscured it, leading to an
unhelpful error. Make sure the maintenance mode handler doesn't
break on un-routed requests.