### PR TITLE
CFY-5643 404 when getting node-instances for nonexistent deployment

### DIFF
--- a/rest-service/manager_rest/resources.py
+++ b/rest-service/manager_rest/resources.py
@@ -978,6 +978,9 @@ class NodeInstances(SecuredResource):
         """
         args = self._args_parser.parse_args()
         deployment_id = args.get('deployment_id')
+        if deployment_id:
+            get_blueprints_manager().get_deployment(deployment_id,
+                                                    include=['id'])
         node_id = args.get('node_name')
         params_filter = BlueprintsManager.create_filters_dict(
             deployment_id=deployment_id, node_id=node_id)

--- a/rest-service/manager_rest/resources_v2.py
+++ b/rest-service/manager_rest/resources_v2.py
@@ -630,6 +630,10 @@ class NodeInstances(resources.NodeInstances):
         """
         List node instances
         """
+        deployment_id = filters.get('deployment_id')
+        if deployment_id:
+            get_blueprints_manager().get_deployment(deployment_id,
+                                                    include=['id'])
         node_instances = get_storage_manager().list_node_instances(
             include=_include, filters=filters,
             pagination=pagination, sort=sort)

--- a/rest-service/manager_rest/test/endpoints/test_nodes.py
+++ b/rest-service/manager_rest/test/endpoints/test_nodes.py
@@ -33,6 +33,11 @@ class NodesTest(base_test.BaseServerTestCase):
     the requests.
     """
 
+    def test_list_missing_deployment(self):
+        with self.assertRaises(CloudifyClientError) as cm:
+            self.client.node_instances.list(deployment_id='nonexistent')
+        self.assertEqual(cm.exception.status_code, 404)
+
     def test_get_nonexisting_node(self):
         response = self.get('/node-instances/1234')
         self.assertEqual(404, response.status_code)
@@ -270,6 +275,15 @@ class NodesTest(base_test.BaseServerTestCase):
     @attr(client_min_version=2,
           client_max_version=base_test.LATEST_API_VERSION)
     def test_list_node_instances_multiple_value_filter(self):
+        self.put_deployment(
+            blueprint_id='blueprint1',
+            deployment_id='111',
+            blueprint_file_name='empty.yaml')
+        self.put_deployment(
+            blueprint_id='blueprint2',
+            deployment_id='222',
+            blueprint_file_name='empty.yaml')
+
         self.put_node_instance(node_id='1', instance_id='11',
                                deployment_id='111')
         self.put_node_instance(node_id='1', instance_id='12',
@@ -295,6 +309,15 @@ class NodesTest(base_test.BaseServerTestCase):
         self.assertEquals(4, len(dep1_node_instances))
 
     def test_list_node_instances(self):
+        self.put_deployment(
+            blueprint_id='blueprint1',
+            deployment_id='111',
+            blueprint_file_name='empty.yaml')
+        self.put_deployment(
+            blueprint_id='blueprint2',
+            deployment_id='222',
+            blueprint_file_name='empty.yaml')
+
         self.put_node_instance(node_id='1', instance_id='11',
                                deployment_id='111')
         self.put_node_instance(node_id='1', instance_id='12',

--- a/rest-service/manager_rest/test/mock_blueprint/empty.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/empty.yaml
@@ -1,0 +1,6 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+- cloudify/types/types.yaml
+
+node_templates: {}


### PR DESCRIPTION
This makes node-instances endpoint's behaviour consistent with what
others (executions) do. Also note that the CLI expects the REST service
to throw 404 in that case.
