### PR TITLE
types.yaml: set install_new_agents.install_script default to null

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -497,7 +497,7 @@ workflows:
       install:
         default: True
       install_script:
-        default: ''
+        default: null
 
 ##################################################################################
 # Base data type definitions


### PR DESCRIPTION
Empty string is actually passed to the agent, breaking the download