### PR TITLE
Minimum and maximum number of instances

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -479,6 +479,16 @@ workflows:
             and this property is 'true', operate on the compute node instead
             of the specified node.
         default: false
+      min_instances:
+        description: The minimum number of allowed instances (default 0)
+        default: 0
+        type: integer
+      max_instances:
+        description: >
+          The maximum number of allowed instances A negative number means
+          no limits (default -1)
+        default: -1
+        type: integer
       ignore_failure:
         default: false
         type: boolean

--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -485,7 +485,7 @@ workflows:
         type: integer
       max_instances:
         description: >
-          The maximum number of allowed instances A negative number means
+          The maximum number of allowed instances. A negative number means
           no limits (default -1)
         default: -1
         type: integer


### PR DESCRIPTION
Added support for minimum and maximum number of instances in scale workflow.
The cloudify/plugins/workflows.py script in cloudify-plugins-common project has been modified as well in order to enforce these rules.
