### PR TITLE
Add missing exports to integration tests readme

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -108,6 +108,8 @@ To test everything is working as it should, run:
 
 ```
 $ cd <root directory of cloudify-manager repository>
+$ export CLOUDIFY_USERNAME=admin
+$ export CLOUDIFY_PASSWORD=admin
 $ nosetests -s tests/integration_tests/tests/agentless_tests/test_workflow.py:BasicWorkflowsTest.test_execute_operation
 ```
 


### PR DESCRIPTION
In this PR, the environment variables needed to run the integration tests are added to the readme file.
