### PR TITLE
CFY-6317 Protect default tenant

### DIFF
--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -27,7 +27,6 @@ class Config(object):
         self.postgresql_username = None
         self.postgresql_password = None
         self.postgresql_bin_path = None
-        self.default_tenant_name = None
         self.amqp_address = 'localhost'
         self.amqp_username = 'guest'
         self.amqp_password = 'guest'

--- a/rest-service/manager_rest/constants.py
+++ b/rest-service/manager_rest/constants.py
@@ -31,6 +31,7 @@ CURRENT_TENANT_CONFIG = 'current_tenant'
 DEFAULT_TENANT_NAME = 'default_tenant'
 
 BOOTSTRAP_ADMIN_ID = 0
+DEFAULT_TENANT_ID = 0
 
 ADMIN_ROLE = 'administrator'
 USER_ROLE = 'user'

--- a/rest-service/manager_rest/flask_utils.py
+++ b/rest-service/manager_rest/flask_utils.py
@@ -1,0 +1,80 @@
+#########
+# Copyright (c) 2013 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+
+from collections import namedtuple
+
+from flask import Flask
+from flask_security import Security
+
+from manager_rest.storage import user_datastore, db
+
+
+def setup_flask_app(manager_ip='localhost', driver=''):
+    """Setup a functioning flask app, when working outside the rest-service
+
+    :param manager_ip: The IP of the manager
+    :param driver: SQLA driver for postgres (e.g. pg8000)
+    :return: A Flask app
+    """
+    app = Flask(__name__)
+    db_uri = _get_postgres_db_uri(manager_ip, driver)
+    app.config['SQLALCHEMY_DATABASE_URI'] = db_uri
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    set_flask_security_config(app)
+    Security(app=app, datastore=user_datastore)
+    db.init_app(app)
+    app.app_context().push()
+    return app
+
+
+def _get_postgres_db_uri(manager_ip, driver):
+    """Get a valid SQLA DB URI
+    """
+    dialect = 'postgresql+{0}'.format(driver) if driver else 'postgres'
+    conf = get_postgres_conf()
+    return '{dialect}://{username}:{password}@{host}/{db_name}'.format(
+        dialect=dialect,
+        username=conf.username,
+        password=conf.password,
+        host=manager_ip,
+        db_name=conf.db_name
+    )
+
+
+def get_postgres_conf():
+    """Return a namedtuple with info used to connect to cloudify's PG DB
+    """
+    conf = namedtuple('PGConf', 'username password db_name')
+    return conf(
+        username='cloudify',
+        password='cloudify',
+        db_name='cloudify_db'
+    )
+
+
+def set_flask_security_config(app):
+    """Set all necessary Flask-Security configurations
+
+    :param app: Flask app object
+    """
+    # Make sure that it's possible to get users from the datastore
+    # by username and not just by email (the default behavior)
+    app.config['SECURITY_USER_IDENTITY_ATTRIBUTES'] = 'username, email'
+    app.config['SECURITY_PASSWORD_HASH'] = 'pbkdf2_sha256'
+    app.config['SECURITY_TOKEN_MAX_AGE'] = 36000  # 10 hours
+
+    # TODO: Move the secret key and the salt to config/envvar
+    app.config['SECURITY_PASSWORD_SALT'] = 'abckjshd0-dsi;dlksP0980!*'
+    app.config['SECRET_KEY'] = 'secret_key_as;ldk34!@##;lKSDLK'

--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -25,7 +25,7 @@ from flask_security import Security
 
 from manager_rest import config
 from manager_rest.storage import db, user_datastore
-from manager_rest.utils import set_flask_security_config
+from manager_rest.flask_utils import set_flask_security_config
 from manager_rest.security.user_handler import user_loader
 from manager_rest.maintenance import maintenance_mode_handler
 from manager_rest.rest.endpoint_mapper import setup_resources

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -19,7 +19,8 @@ from flask_security import SQLAlchemyUserDatastore, UserMixin, RoleMixin
 from manager_rest.constants import (ADMIN_ROLE,
                                     USER_ROLE,
                                     SUSPENDED_ROLE,
-                                    BOOTSTRAP_ADMIN_ID)
+                                    BOOTSTRAP_ADMIN_ID,
+                                    DEFAULT_TENANT_ID)
 
 from .models_base import db, SQLModelBase, UTCDateTime
 from .relationships import many_to_many_relationship
@@ -49,6 +50,10 @@ class Tenant(SQLModelBase):
         tenant_dict['groups'] = all_groups_names
         tenant_dict['users'] = all_users_names
         return tenant_dict
+
+    @property
+    def is_default_tenant(self):
+        return self.id == DEFAULT_TENANT_ID
 
 
 class Group(SQLModelBase):

--- a/rest-service/manager_rest/storage/storage_utils.py
+++ b/rest-service/manager_rest/storage/storage_utils.py
@@ -1,0 +1,54 @@
+#########
+# Copyright (c) 2013 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+
+from flask_security.utils import encrypt_password
+
+from manager_rest import constants
+from manager_rest.storage import user_datastore, db
+from manager_rest.storage.management_models import Tenant
+
+
+def create_default_user_tenant_and_roles(admin_username, admin_password):
+    """Create the bootstrap admin, the default tenant and the security roles
+
+    :return: The default tenant
+    """
+    admin_role = _create_roles()
+    default_tenant = _create_default_tenant()
+
+    admin_user = user_datastore.create_user(
+        id=constants.BOOTSTRAP_ADMIN_ID,
+        username=admin_username,
+        password=encrypt_password(admin_password),
+        roles=[admin_role]
+    )
+    admin_user.tenants.append(default_tenant)
+    user_datastore.commit()
+    return default_tenant
+
+
+def _create_roles():
+    for role in constants.ALL_ROLES:
+        user_datastore.create_role(name=role)
+    return user_datastore.find_role(constants.ADMIN_ROLE)
+
+
+def _create_default_tenant():
+    default_tenant = Tenant(
+        id=constants.DEFAULT_TENANT_ID,
+        name=constants.DEFAULT_TENANT_NAME
+    )
+    db.session.add(default_tenant)
+    return default_tenant

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -21,6 +21,8 @@ from nose.plugins.attrib import attr
 
 from manager_rest.test import base_test
 from manager_rest import manager_exceptions
+from manager_rest.constants import DEFAULT_TENANT_NAME
+
 from cloudify_rest_client.exceptions import CloudifyClientError
 
 
@@ -319,7 +321,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
         config = self.server_configuration
         deployment_folder = os.path.join(config.file_server_root,
                                          config.file_server_deployments_folder,
-                                         'default_tenant',
+                                         DEFAULT_TENANT_NAME,
                                          deployment_id)
         try:
             os.makedirs(deployment_folder)

--- a/rest-service/manager_rest/test/security/test_base.py
+++ b/rest-service/manager_rest/test/security/test_base.py
@@ -24,6 +24,10 @@ from manager_rest.constants import DEFAULT_TENANT_NAME, CLOUDIFY_TENANT_HEADER
 
 
 class SecurityTestBase(BaseServerTestCase):
+    def setUp(self):
+        super(SecurityTestBase, self).setUp()
+        add_users_to_db(get_test_users())
+
     @staticmethod
     def _get_app(flask_app):
         # Overriding the base class' app, because otherwise a custom
@@ -43,10 +47,6 @@ class SecurityTestBase(BaseServerTestCase):
         headers = headers or create_auth_header(**kwargs)
         headers.setdefault(CLOUDIFY_TENANT_HEADER, DEFAULT_TENANT_NAME)
         return self.create_client(headers)
-
-    def _init_admin_user(self, user_datastore):
-        super(SecurityTestBase, self)._init_admin_user(user_datastore)
-        add_users_to_db(user_datastore, get_test_users(), self.default_tenant)
 
     def _assert_user_authorized(self, headers=None, **kwargs):
         with self.use_secured_client(headers, **kwargs):

--- a/rest-service/manager_rest/test/security_utils.py
+++ b/rest-service/manager_rest/test/security_utils.py
@@ -15,7 +15,12 @@
 
 from flask_security.utils import encrypt_password
 
-from manager_rest.constants import ADMIN_ROLE, USER_ROLE, SUSPENDED_ROLE
+from manager_rest.storage.models import Tenant
+from manager_rest.storage import user_datastore
+from manager_rest.constants import (ADMIN_ROLE,
+                                    USER_ROLE,
+                                    SUSPENDED_ROLE,
+                                    DEFAULT_TENANT_ID)
 
 
 def get_admin_user():
@@ -52,7 +57,8 @@ def get_test_users():
     return test_users
 
 
-def add_users_to_db(user_datastore, user_list, default_tenant):
+def add_users_to_db(user_list):
+    default_tenant = Tenant.query.get(DEFAULT_TENANT_ID)
     for user in user_list:
         role = user_datastore.find_role(user['role'])
         user_obj = user_datastore.create_user(

--- a/tests/integration_tests/tests/agentless_tests/test_deployment_resource.py
+++ b/tests/integration_tests/tests/agentless_tests/test_deployment_resource.py
@@ -22,6 +22,8 @@ import sh
 from integration_tests import AgentlessTestCase
 from integration_tests.tests.utils import get_resource as resource
 
+from manager_rest.constants import DEFAULT_TENANT_NAME
+
 
 RESOURCE_PATH = 'resources/resource.txt'
 RESOURCE_CONTENT = 'this is a deployment resource'
@@ -34,8 +36,8 @@ class DeploymentResourceTest(AgentlessTestCase):
         deployment_id = blueprint_id
         blueprint_path = resource('dsl/deployment_resource.yaml')
         deployment_folder_on_manager = \
-            '/opt/manager/resources/deployments/default_tenant/{0}'.format(
-                deployment_id)
+            '/opt/manager/resources/deployments/{0}/{1}'.format(
+                DEFAULT_TENANT_NAME, deployment_id)
         full_resource_path = os.path.join(deployment_folder_on_manager,
                                           RESOURCE_PATH)
         self.execute_on_manager('mkdir -p {0}/resources'.format(

--- a/tests/integration_tests/tests/agentless_tests/test_script_mapping.py
+++ b/tests/integration_tests/tests/agentless_tests/test_script_mapping.py
@@ -20,6 +20,8 @@ import tempfile
 from integration_tests import AgentlessTestCase
 from integration_tests.tests.utils import get_resource as resource
 
+from manager_rest.constants import DEFAULT_TENANT_NAME
+
 
 class TestScriptMapping(AgentlessTestCase):
 
@@ -42,7 +44,7 @@ class TestScriptMapping(AgentlessTestCase):
             workflow_script_content = f.read()
 
         deployment_folder = ('/opt/manager/resources/deployments/{0}/{1}'
-                             .format('default_tenant', deployment.id))
+                             .format(DEFAULT_TENANT_NAME, deployment.id))
         workflow_folder = os.path.join(deployment_folder, 'scripts/workflows')
         try:
             self.execute_on_manager('mkdir -p {0}'.format(workflow_folder))

--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -184,7 +184,7 @@ class TestSnapshot(AgentlessTestCase):
                                   num_of_outputs,
                                   num_of_executions,
                                   num_of_events=4,
-                                  tenant_name='default_tenant'):
+                                  tenant_name=DEFAULT_TENANT_NAME):
         self.client.blueprints.get(blueprint_id)
         self._assert_deployment_restored(
             blueprint_id=blueprint_id,

--- a/tests/integration_tests/tests/agentless_tests/test_workflow.py
+++ b/tests/integration_tests/tests/agentless_tests/test_workflow.py
@@ -33,6 +33,8 @@ from integration_tests.tests.utils import (
     verify_deployment_environment_creation_complete
 )
 
+from manager_rest.constants import DEFAULT_TENANT_NAME
+
 
 class BasicWorkflowsTest(AgentlessTestCase):
     def test_execute_operation(self):
@@ -466,8 +468,10 @@ class BasicWorkflowsTest(AgentlessTestCase):
         deployment, _ = self.deploy_application(dsl_path)
 
         deployment_dir_path = os.path.join(
-                '/opt/mgmtworker/work/deployments/default_tenant',
-                deployment.id)
+            '/opt/mgmtworker/work/deployments',
+            DEFAULT_TENANT_NAME,
+            deployment.id
+        )
 
         self.execute_on_manager('test -d {0}'.format(deployment_dir_path))
 

--- a/tests/integration_tests/tests/utils.py
+++ b/tests/integration_tests/tests/utils.py
@@ -24,7 +24,6 @@ from contextlib import contextmanager
 from cloudify.utils import setup_logger
 from cloudify_rest_client.executions import Execution
 from integration_tests.framework import utils, postgresql, docl
-from manager_rest.storage import get_storage_manager
 
 
 logger = setup_logger('testenv.utils')
@@ -197,13 +196,6 @@ def patch_yaml(yaml_path, is_json=False, default_flow_style=True):
                            is_json=is_json,
                            default_flow_style=default_flow_style) as patch:
         yield patch
-
-
-def get_remote_storage_manager():
-    """Return the SQL storage manager connected to the remote manager
-    """
-    postgresql.setup_flask_app()
-    return get_storage_manager()
 
 
 def delete_provider_context():

--- a/workflows/cloudify_system_workflows/snapshots/estopg.py
+++ b/workflows/cloudify_system_workflows/snapshots/estopg.py
@@ -22,12 +22,9 @@ from shutil import move
 
 from flask import _request_ctx_stack as flask_global_stack
 
-from manager_rest.utils import setup_flask_app
+from manager_rest.flask_utils import setup_flask_app
 from manager_rest.constants import CURRENT_TENANT_CONFIG, DEFAULT_TENANT_NAME
-from manager_rest.storage import (db,
-                                  models,
-                                  user_datastore,
-                                  get_storage_manager)
+from manager_rest.storage import models, get_storage_manager
 
 format_str = '%(asctime)s [%(name)s] %(levelname)s: %(message)s'
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format=format_str)
@@ -50,7 +47,7 @@ class EsToPg(object):
         self._events_path = '{0}.events'.format(es_dump_path)
 
     def _get_storage_manager(self, tenant_name):
-        app = setup_flask_app(db, user_datastore)
+        app = setup_flask_app()
         admin = self._set_current_user(app)
         storage_manager = get_storage_manager()
         tenant = self._get_or_create_tenant(tenant_name)

--- a/workflows/cloudify_system_workflows/snapshots/postgres.py
+++ b/workflows/cloudify_system_workflows/snapshots/postgres.py
@@ -95,7 +95,7 @@ class Postgres(object):
                "is_system_workflow, " \
                "status, workflow_id, tenant_id, creator_id) " \
                "VALUES ('{0}', '{1}', 't', " \
-               "'started', 'restore_snapshot', '1', 0);"\
+               "'started', 'restore_snapshot', 0, 0);"\
             .format(ctx.execution_id, record_creation_date)
 
     def clean_db(self):
@@ -109,7 +109,7 @@ class Postgres(object):
         queries.append("INSERT INTO users_roles (user_id, role_id)"
                        "VALUES (0, 1);")
         queries.append("INSERT INTO users_tenants (user_id, tenant_id)"
-                       "VALUES (0, 1);")
+                       "VALUES (0, 0);")
         for query in queries:
             self.run_query(query)
 
@@ -239,14 +239,14 @@ class Postgres(object):
 
     def _add_preserve_defaults_queries(self, queries):
         """Replace regular truncate queries for users/tenants with ones that
-        preserve the default user (id=0)/tenant (id=1)
+        preserve the default user (id=0)/tenant (id=0)
         Used when restoring old snapshots that will not have those entities
         :param queries: List of truncate queries
         """
         queries.remove(self._TRUNCATE_QUERY.format('users'))
         queries.append('DELETE FROM users CASCADE WHERE id != 0;')
         queries.remove(self._TRUNCATE_QUERY.format('tenants'))
-        queries.append('DELETE FROM tenants CASCADE WHERE id != 1;')
+        queries.append('DELETE FROM tenants CASCADE WHERE id != 0;')
 
     def _get_all_tables(self):
         result = self.run_query("SELECT tablename "


### PR DESCRIPTION
 - Make the default tenant ID constant (set to 0)
 - Prevent deletion of the default tenant
 - Streamline the creation of the default tenant
 - Make more use of the default tenant constants (instead of strings)