### PR TITLE
CFY 6280. Do not include es data in snapshots

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/es_snapshot.py
+++ b/workflows/cloudify_system_workflows/snapshots/es_snapshot.py
@@ -90,19 +90,6 @@ class ElasticSearch(object):
             # Snapshot has events in ES but the manager does not
             return self._cloudify_events_to_logstash(tempdir)
 
-    def dump_logs_and_events(self, tempdir, es, metadata):
-        has_cloudify_events = es.indices.exists(index=self._EVENTS_INDEX_NAME)
-        event_scan = elasticsearch_helpers.scan(
-            es,
-            index=self._EVENTS_INDEX_NAME if
-            has_cloudify_events else 'logstash-*'
-        )
-
-        with open(os.path.join(tempdir, self._ELASTICSEARCH), 'w') as f:
-            for item in event_scan:
-                f.write(json.dumps(item) + os.linesep)
-        metadata[M_HAS_CLOUDIFY_EVENTS] = has_cloudify_events
-
     @staticmethod
     def _manager_has_cloudify_events(es):
         return es.indices.exists(index=ElasticSearch._EVENTS_INDEX_NAME)

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_create.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_create.py
@@ -27,7 +27,6 @@ from .agents import Agents
 from .influxdb import InfluxDB
 from .postgres import Postgres
 from .credentials import Credentials
-from .es_snapshot import ElasticSearch
 
 
 class SnapshotCreate(object):
@@ -51,7 +50,6 @@ class SnapshotCreate(object):
             manager_version = utils.get_manager_version(self._client)
 
             self._dump_files()
-            self._dump_elasticsearch_events(metadata)
             self._dump_postgres()
             self._dump_influxdb()
             self._dump_credentials()
@@ -81,15 +79,6 @@ class SnapshotCreate(object):
             self._tempdir,
             self._config,
             to_archive=True
-        )
-
-    def _dump_elasticsearch_events(self, metadata):
-        ctx.logger.info('Dumping elasticsearch data')
-        es = utils.get_es_client(self._config)
-        ElasticSearch().dump_logs_and_events(
-            self._tempdir,
-            es,
-            metadata
         )
 
     def _dump_postgres(self):

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -83,7 +83,7 @@ class SnapshotRestore(object):
             es = utils.get_es_client(self._config)
 
             with Postgres(self._config) as postgres:
-                self._restore_db(es, postgres)
+                self._restore_db(postgres)
                 self._restore_files_to_manager()
                 self._restore_events(es, metadata)
                 self._restore_plugins(existing_plugins)
@@ -119,7 +119,7 @@ class SnapshotRestore(object):
             new_tenant=new_tenant
         )
 
-    def _restore_db(self, es, postgres):
+    def _restore_db(self, postgres):
         ctx.logger.info('Restoring database')
         if self._snapshot_version >= V_4_0_0:
             postgres.restore(self._tempdir)
@@ -135,7 +135,6 @@ class SnapshotRestore(object):
                 self._tempdir,
                 tenant_name
             )
-            es.indices.flush()
 
     def _should_clean_old_db_for_3_x_snapshot(self):
         """The one case in which the DB should be cleared is when restoring


### PR DESCRIPTION
In this PR, events stored in Elasticsearch are no longer included in snapshots.

There is another part to consider the issue resolved, which would be making sure that an old snapshot with elasticsearch data is restored by correctly inserting event information in postgres. That will be addressed in a separate PR.