### PR TITLE
Remove six dependency

### DIFF
--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -19,7 +19,6 @@ from setuptools import setup
 
 
 install_requires = [
-    'six==1.8.0',
     'Flask==0.10.1',
     'flask-restful==0.2.5',
     'flask-restful-swagger==0.12',


### PR DESCRIPTION
Test cases have started failing all of sudden apparently because `six==1.10.0` is required in some dependency while the rest service itself required `six==1.8.0`. However, I haven't seen any place in which the rest service code makes use `six`, so it makes sense to remove the dependency from `setup.py` to fix the conflict.