### PR TITLE
CFY-6344 Fix a bug in getting/listing tenants

### DIFF
--- a/rest-service/manager_rest/security/tenant_authorization.py
+++ b/rest-service/manager_rest/security/tenant_authorization.py
@@ -33,8 +33,7 @@ class TenantAuthorization(object):
             )
 
         logger.debug('User attempting to connect with {0}'.format(tenant))
-        if tenant not in user.get_all_tenants() \
-                and admin_role not in user.roles:
+        if tenant not in user.all_tenants and admin_role not in user.roles:
             raise_unauthorized_user_error(
                 '{0} is not associated with {1}'.format(user, tenant)
             )

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -177,7 +177,7 @@ class SQLStorageManager(object):
         if current_user.is_admin and all_tenants:
             tenants = []
         elif all_tenants:
-            tenants = current_user.get_all_tenants()
+            tenants = current_user.all_tenants
         else:
             tenants = [self.current_tenant]
 


### PR DESCRIPTION
 * Tenant get/list returns all users linked to the tenant (including those linked through user-groups).
 * Tenant/Group/User names are sorted in tenant/user/user-group responses.