### PR TITLE
CFY-6350 Add ability to make rest calls without tenant header

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/tokens.py
+++ b/rest-service/manager_rest/rest/resources_v1/tokens.py
@@ -22,10 +22,10 @@ from manager_rest.rest.rest_decorators import (
     exceptions_handled,
     marshal_with,
 )
-from manager_rest.security import SecuredResource
+from manager_rest.security import SecuredResourceSkipTenantAuth
 
 
-class Tokens(SecuredResource):
+class Tokens(SecuredResourceSkipTenantAuth):
 
     @swagger.operation(
         responseClass=responses.Tokens,

--- a/rest-service/manager_rest/rest/resources_v1/version.py
+++ b/rest-service/manager_rest/rest/resources_v1/version.py
@@ -22,10 +22,10 @@ from manager_rest.rest.rest_decorators import (
     exceptions_handled,
     marshal_with,
 )
-from manager_rest.security import SecuredResource
+from manager_rest.security import SecuredResourceSkipTenantAuth
 
 
-class Version(SecuredResource):
+class Version(SecuredResourceSkipTenantAuth):
 
     @swagger.operation(
         responseClass=responses.Version,

--- a/rest-service/manager_rest/rest/resources_v3.py
+++ b/rest-service/manager_rest/rest/resources_v3.py
@@ -34,15 +34,17 @@ try:
                                   SecuredMultiTenancyResource,
                                   ClusterResourceBase,
                                   ClusterState,
-                                  ClusterNode)
+                                  ClusterNode,
+                                  SecuredMultiTenancyResourceSkipTenantAuth)
 except ImportError:
     TenantResponse, GroupResponse, UserResponse, ClusterNode, ClusterState = \
         (BaseResponse, ) * 5
     SecuredMultiTenancyResource = MissingPremiumFeatureResource
     ClusterResourceBase = MissingPremiumFeatureResource
+    SecuredMultiTenancyResourceSkipTenantAuth = MissingPremiumFeatureResource
 
 
-class Tenants(SecuredMultiTenancyResource):
+class Tenants(SecuredMultiTenancyResourceSkipTenantAuth):
     @rest_decorators.exceptions_handled
     @rest_decorators.marshal_with(TenantResponse)
     @rest_decorators.create_filters(models.Tenant)

--- a/rest-service/manager_rest/security/__init__.py
+++ b/rest-service/manager_rest/security/__init__.py
@@ -14,5 +14,6 @@
 #  * limitations under the License.
 
 # Setting NOQA to avoid flake errors - these are convenience imports
-from .secured_resource import SecuredResource                  # NOQA
-from .secured_resource import MissingPremiumFeatureResource    # NOQA
+from .secured_resource import SecuredResource                   # NOQA
+from .secured_resource import SecuredResourceSkipTenantAuth     # NOQA
+from .secured_resource import MissingPremiumFeatureResource     # NOQA

--- a/rest-service/manager_rest/test/security/test_authentication.py
+++ b/rest-service/manager_rest/test/security/test_authentication.py
@@ -16,9 +16,11 @@
 from nose.plugins.attrib import attr
 from base64 import urlsafe_b64encode
 
-from manager_rest.constants import ADMIN_ROLE, USER_ROLE
 from manager_rest.test.base_test import LATEST_API_VERSION
 from manager_rest.utils import BASIC_AUTH_PREFIX, CLOUDIFY_AUTH_HEADER
+from manager_rest.constants import (ADMIN_ROLE,
+                                    USER_ROLE,
+                                    CLOUDIFY_TENANT_HEADER)
 
 from .test_base import SecurityTestBase
 
@@ -98,3 +100,11 @@ class AuthenticationTests(SecurityTestBase):
             self.client.maintenance_mode.activate()
             response = self.client.maintenance_mode.status()
         self.assertEqual(response.requested_by, 'alice')
+
+    def test_token_does_not_require_tenant_header(self):
+        with self.use_secured_client(username='alice',
+                                     password='alice_password'):
+            # Remove the the tenant header from the client
+            self.client._client.headers.pop(CLOUDIFY_TENANT_HEADER, None)
+            token = self.client.tokens.get()
+        self._assert_user_authorized(token=token.value)


### PR DESCRIPTION
 - For selected calls, the tenant authorization will be skipped
 - Currently 3 calls will not require a tenant in the request header - version get, tenants list and tokens get