### PR TITLE
CFY 6090. Add missing node_id and operation to events

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -98,6 +98,7 @@ class Events(SecuredResource):
                 Event.message,
                 Event.message_code,
                 Event.event_type,
+                Event.operation,
                 literal_column('NULL').label('logger'),
                 literal_column('NULL').label('level'),
                 literal_column("'cloudify_event'").label('type'),
@@ -117,6 +118,7 @@ class Events(SecuredResource):
                     Log.message,
                     literal_column('NULL').label('message_code'),
                     literal_column('NULL').label('event_type'),
+                    Log.operation,
                     Log.logger,
                     Log.level,
                     literal_column("'cloudify_log'").label('type'),
@@ -213,9 +215,11 @@ class Events(SecuredResource):
             'text': event['message']
         }
         event['context'] = {
-            'deployment_id': event['deployment_id']
+            'deployment_id': event['deployment_id'],
+            'operation': event['operation'],
         }
         del event['deployment_id']
+        del event['operation']
         if event['type'] == 'cloudify_event':
             event['message']['arguments'] = None
             del event['logger']

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -99,6 +99,7 @@ class Events(SecuredResource):
                 Event.message_code,
                 Event.event_type,
                 Event.operation,
+                Event.node_id,
                 literal_column('NULL').label('logger'),
                 literal_column('NULL').label('level'),
                 literal_column("'cloudify_event'").label('type'),
@@ -119,6 +120,7 @@ class Events(SecuredResource):
                     literal_column('NULL').label('message_code'),
                     literal_column('NULL').label('event_type'),
                     Log.operation,
+                    Log.node_id,
                     Log.logger,
                     Log.level,
                     literal_column("'cloudify_log'").label('type'),
@@ -214,12 +216,19 @@ class Events(SecuredResource):
         event['message'] = {
             'text': event['message']
         }
+
+        context_fields = [
+            'deployment_id',
+            'operation',
+            'node_id',
+        ]
         event['context'] = {
-            'deployment_id': event['deployment_id'],
-            'operation': event['operation'],
+            field: event[field]
+            for field in context_fields
         }
-        del event['deployment_id']
-        del event['operation']
+        for field in context_fields:
+            del event[field]
+
         if event['type'] == 'cloudify_event':
             event['message']['arguments'] = None
             del event['logger']

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -188,6 +188,7 @@ class Event(DerivedResource):
     message = db.Column(db.Text)
     message_code = db.Column(db.Text)
     event_type = db.Column(db.Text)
+    operation = db.Column(db.Text)
 
     _execution_fk = foreign_key(Execution._storage_id, nullable=False)
 
@@ -215,9 +216,9 @@ class Log(DerivedResource):
     timestamp = db.Column(UTCDateTime, nullable=False, index=True)
     message = db.Column(db.Text)
     message_code = db.Column(db.Text)
-
     logger = db.Column(db.Text)
     level = db.Column(db.Text)
+    operation = db.Column(db.Text)
 
     _execution_fk = foreign_key(Execution._storage_id, nullable=False)
 

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -189,6 +189,7 @@ class Event(DerivedResource):
     message_code = db.Column(db.Text)
     event_type = db.Column(db.Text)
     operation = db.Column(db.Text)
+    node_id = db.Column(db.Text)
 
     _execution_fk = foreign_key(Execution._storage_id, nullable=False)
 
@@ -219,6 +220,7 @@ class Log(DerivedResource):
     logger = db.Column(db.Text)
     level = db.Column(db.Text)
     operation = db.Column(db.Text)
+    node_id = db.Column(db.Text)
 
     _execution_fk = foreign_key(Execution._storage_id, nullable=False)
 

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -28,14 +28,16 @@ from manager_rest.test import base_test
 EventResultTuple = namedtuple(
     'EventResult',
     [
-        'deployment_id',
-        'event_type',
-        'level',
         'timestamp',
+        'deployment_id',
         'message',
         'message_code',
-        'type',
+        'event_type',
+        'operation',
+        'node_id',
+        'level',
         'logger',
+        'type',
     ],
 )
 
@@ -192,18 +194,22 @@ class MapEventToEsTest(TestCase):
     def test_map_event(self):
         """Map event as returned by SQL query to elasticsearch style output."""
         sql_event = EventResult(
-            deployment_id='<deployment_id>',
-            event_type='<event_type>',
-            level=None,
             timestamp=datetime(2016, 12, 9),
+            deployment_id='<deployment_id>',
             message='<message>',
             message_code=None,
-            type='cloudify_event',
+            event_type='<event_type>',
+            operation='<operation>',
+            node_id='<node_id>',
             logger=None,
+            level=None,
+            type='cloudify_event',
         )
         expected_es_event = {
             'context': {
                 'deployment_id': '<deployment_id>',
+                'operation': '<operation>',
+                'node_id': '<node_id>',
             },
             'event_type': '<event_type>',
             'timestamp': '2016-12-09T00:00Z',
@@ -221,18 +227,22 @@ class MapEventToEsTest(TestCase):
     def test_map_log(self):
         """Map log as returned by SQL query to elasticsearch style output."""
         sql_log = EventResult(
-            deployment_id='<deployment_id>',
-            event_type=None,
-            level='<level>',
             timestamp=datetime(2016, 12, 9),
+            deployment_id='<deployment_id>',
             message='<message>',
             message_code=None,
-            type='cloudify_log',
+            event_type=None,
+            operation='<operation>',
+            node_id='<node_id>',
+            level='<level>',
             logger='<logger>',
+            type='cloudify_log',
         )
         expected_es_log = {
             'context': {
                 'deployment_id': '<deployment_id>',
+                'operation': '<operation>',
+                'node_id': '<node_id>',
             },
             'level': '<level>',
             'timestamp': '2016-12-09T00:00Z',


### PR DESCRIPTION
In this PR, the `node_id` and `operation` columns are added to the `events`/`logs` tables. This is needed because otherwise the output logs miss this information.

Before the changes:
`2017-01-26 16:16:17.946  CFY <my-deployment> Sending task 'cloudify_agent.installer.operations.create'`

After the changes:
`2017-01-26 16:16:17.946  CFY <my-deployment> [vm_xiz0br.create] Sending task 'cloudify_agent.installer.operations.create'`

where `vm_xiz0br` is the `node_id` and `create` the `operation`.