### PR TITLE
CFY 6332. Fix events integration tests cases

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -253,7 +253,8 @@ class Events(SecuredResource):
                 event[key] = '{}Z'.format(value.isoformat()[:-3])
 
         # Keep only keys passed in the _include request argument
-        event = dicttoolz.keyfilter(lambda key: key in _include, event)
+        if _include is not None:
+            event = dicttoolz.keyfilter(lambda key: key in _include, event)
 
         return event
 

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -374,7 +374,7 @@ class Events(SecuredResource):
             'offset': pagination['offset'],
         }
 
-        count_query = self._build_count_query(filters)
+        count_query = self._build_count_query(filters, range_filters)
         total = count_query.params(**params).scalar()
 
         select_query = self._build_select_query(

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -227,6 +227,9 @@ class Events(SecuredResource):
 
         if 'execution_id' in filters:
             events_query.filter(Execution.id == bindparam('execution_id'))
+        if 'deployment_id' in filters:
+            events_query = events_query.filter(
+                Deployment.id.in_(filters['deployment_id']))
 
         if 'cloudify_log' in filters['type']:
             logs_query = (
@@ -239,6 +242,9 @@ class Events(SecuredResource):
             if 'execution_id' in filters:
                 logs_query = logs_query.filter(
                     Execution.id == bindparam('execution_id'))
+            if 'deployment_id' in filters:
+                logs_query = logs_query.filter(
+                    Deployment.id.in_(filters['deployment_id']))
 
             query = db.session.query(
                 events_query.subquery().c.count +

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -18,7 +18,9 @@ from datetime import datetime
 
 from flask_restful_swagger import swagger
 from sqlalchemy import (
+    asc,
     bindparam,
+    desc,
     func,
     literal_column,
 )
@@ -133,13 +135,12 @@ class Events(SecuredResource):
         if 'execution_id' in filters:
             query = query.filter(Execution.id == bindparam('execution_id'))
 
-        if '@timestamp' not in sort or sort['@timestamp'] != 'asc':
-            raise manager_exceptions.BadParametersError(
-                'Sorting ascending by `timestamp` is expected')
+        if '@timestamp' in sort:
+            order_func = asc if sort['@timestamp'] == 'asc' else desc
+            query.order_by(order_func('timestamp'))
 
         query = (
             query
-            .order_by('timestamp')
             .limit(bindparam('limit'))
             .offset(bindparam('offset'))
         )

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -144,7 +144,7 @@ class Events(SecuredResource):
 
         if '@timestamp' in sort:
             order_func = asc if sort['@timestamp'] == 'asc' else desc
-            query.order_by(order_func('timestamp'))
+            query = query.order_by(order_func('timestamp'))
 
         query = (
             query

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -226,6 +226,7 @@ class Events(SecuredResource):
             attr: getattr(sql_event, attr)
             for attr in sql_event.keys()
         }
+        event['@timestamp'] = event['timestamp']
 
         event['message'] = {
             'text': event['message']

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -112,8 +112,11 @@ class Events(SecuredResource):
             )
         )
 
+        if 'deployment_id' in filters:
+            query = query.filter(Deployment.id.in_(filters['deployment_id']))
+
         if 'cloudify_log' in filters['type']:
-            query = query.union(
+            logs_query = (
                 db.session.query(
                     Log.timestamp.label('timestamp'),
                     Deployment.id.label('deployment_id'),
@@ -131,6 +134,10 @@ class Events(SecuredResource):
                     Execution._deployment_fk == Deployment._storage_id,
                 )
             )
+            if 'deployment_id' in filters:
+                logs_query = logs_query.filter(
+                    Deployment.id.in_(filters['deployment_id']))
+            query = query.union(logs_query)
 
         if 'execution_id' in filters:
             query = query.filter(Execution.id == bindparam('execution_id'))

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -109,7 +109,7 @@ class Events(SecuredResource):
             if not hasattr(model, field):
                 raise manager_exceptions.BadParametersError(
                     'Unknown field to filter by range: {}'.format(field))
-            query = Events._apply_range_filters(
+            query = Events._apply_range_filter(
                 query, model, field, range_filter)
         return query
 

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -73,9 +73,11 @@ class Events(SecuredResource):
             # Drop `@` prefix for compatibility
             # with old Elasticsearch based implementation
             field = field.lstrip('@')
-            if hasattr(model, field):
-                query = Events._apply_range_filters(
-                    query, model, field, range_filter)
+            if not hasattr(model, field):
+                raise manager_exceptions.BadParametersError(
+                    'Unknown field to filter by range: {}'.format(field))
+            query = Events._apply_range_filters(
+                query, model, field, range_filter)
         return query
 
     @staticmethod

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -176,6 +176,7 @@ class Events(SecuredResource):
             db.session.query(func.count('*').label('count'))
             .filter(
                 Event._execution_fk == Execution._storage_id,
+                Execution._deployment_fk == Deployment._storage_id,
             )
         )
 
@@ -187,6 +188,7 @@ class Events(SecuredResource):
                 db.session.query(func.count('*').label('count'))
                 .filter(
                     Log._execution_fk == Execution._storage_id,
+                    Execution._deployment_fk == Deployment._storage_id,
                 )
             )
             if 'execution_id' in filters:

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -69,7 +69,7 @@ class Events(SecuredResource):
         :rtype: :class:`sqlalchemy.orm.query.Query`
 
         """
-        for field, range_filter in range_filters:
+        for field, range_filter in range_filters.items():
             # Drop `@` prefix for compatibility
             # with old Elasticsearch based implementation
             field = field.lstrip('@')

--- a/rest-service/manager_rest/rest/resources_v2/events.py
+++ b/rest-service/manager_rest/rest/resources_v2/events.py
@@ -99,7 +99,7 @@ class Events(resources_v1.Events):
         if 'execution_id' in filters:
             params['execution_id'] = filters['execution_id'][0]
 
-        count_query = self._build_count_query(filters)
+        count_query = self._build_count_query(filters, range_filters)
         total = count_query.params(**params).scalar()
 
         select_query = self._build_select_query(

--- a/rest-service/manager_rest/rest/resources_v2/events.py
+++ b/rest-service/manager_rest/rest/resources_v2/events.py
@@ -102,11 +102,10 @@ class Events(resources_v1.Events):
         count_query = self._build_count_query(filters)
         total = count_query.params(**params).scalar()
 
-        select_query = self._build_select_query(
-            _include, filters, pagination, sort)
+        select_query = self._build_select_query(filters, pagination, sort)
 
         results = [
-            self._map_event_to_es(event)
+            self._map_event_to_es(_include, event)
             for event in select_query.params(**params).all()
         ]
 

--- a/rest-service/manager_rest/rest/resources_v2/events.py
+++ b/rest-service/manager_rest/rest/resources_v2/events.py
@@ -91,15 +91,13 @@ class Events(resources_v1.Events):
         :rtype: :class:`manager_rest.storage.storage_manager.ListResult`
 
         """
-        if 'execution_id' not in filters:
-            raise manager_exceptions.BadParametersError(
-                'Expected execution_id parameter')
-
         params = {
-            'execution_id': filters['execution_id'][0],
             'limit': pagination.get('size', self.DEFAULT_SEARCH_SIZE),
             'offset': pagination.get('offset', 0),
         }
+
+        if 'execution_id' in filters:
+            params['execution_id'] = filters['execution_id'][0]
 
         count_query = self._build_count_query(filters)
         total = count_query.params(**params).scalar()

--- a/rest-service/manager_rest/rest/resources_v2/events.py
+++ b/rest-service/manager_rest/rest/resources_v2/events.py
@@ -96,9 +96,6 @@ class Events(resources_v1.Events):
             'offset': pagination.get('offset', 0),
         }
 
-        if 'execution_id' in filters:
-            params['execution_id'] = filters['execution_id'][0]
-
         count_query = self._build_count_query(filters, range_filters)
         total = count_query.params(**params).scalar()
 

--- a/rest-service/manager_rest/rest/resources_v2/events.py
+++ b/rest-service/manager_rest/rest/resources_v2/events.py
@@ -102,7 +102,8 @@ class Events(resources_v1.Events):
         count_query = self._build_count_query(filters)
         total = count_query.params(**params).scalar()
 
-        select_query = self._build_select_query(filters, pagination, sort)
+        select_query = self._build_select_query(
+            filters, pagination, sort, range_filters)
 
         results = [
             self._map_event_to_es(_include, event)

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -199,6 +199,7 @@ class MapEventToEsTest(TestCase):
             },
             'event_type': '<event_type>',
             'timestamp': '2016-12-09T00:00Z',
+            '@timestamp': '2016-12-09T00:00Z',
             'message': {
                 'arguments': None,
                 'text': '<message>',
@@ -207,7 +208,7 @@ class MapEventToEsTest(TestCase):
             'type': 'cloudify_event',
         }
 
-        es_event = Events._map_event_to_es(sql_event)
+        es_event = Events._map_event_to_es(None, sql_event)
         self.assertDictEqual(es_event, expected_es_event)
 
     def test_map_log(self):
@@ -232,11 +233,13 @@ class MapEventToEsTest(TestCase):
             },
             'level': '<level>',
             'timestamp': '2016-12-09T00:00Z',
+            '@timestamp': '2016-12-09T00:00Z',
             'message': {'text': '<message>'},
             'message_code': None,
             'type': 'cloudify_log',
             'logger': '<logger>',
         }
 
-        es_log = Events._map_event_to_es(sql_log)
+        es_log = Events._map_event_to_es(None, sql_log)
+
         self.assertDictEqual(es_log, expected_es_log)

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -87,19 +87,34 @@ class BuildSelectQueryTest(TestCase):
         """
         db_patcher = patch('manager_rest.rest.resources_v1.events.db')
         self.db = db_patcher.start()
+
+        # Set column descriptions (used by sorting functionality)
+        column_descriptions = [
+                {'name': 'timestamp'},
+        ]
+        self.db.session.query().filter().column_descriptions = (
+            column_descriptions)
+        self.db.session.query().filter().union().column_descriptions = (
+            column_descriptions)
         self.addCleanup(db_patcher.stop)
 
     def test_from_events(self):
         """Query against events table."""
         Events._build_select_query(**self.DEFAULT_PARAMS)
-        self.assertFalse(self.db.session.query().filter().union.called)
+        self.assertLessEqual(
+            self.db.session.query().filter().union.call_count,
+            1,
+        )
 
     def test_from_logs(self):
         """Query against both events and logs tables."""
         params = deepcopy(self.DEFAULT_PARAMS)
         params['filters']['type'].append('cloudify_log')
         Events._build_select_query(**params)
-        self.assertTrue(self.db.session.query().filter().union.called)
+        self.assertGreater(
+            self.db.session.query().filter().union.call_count,
+            1,
+        )
 
     def test_filter_required(self):
         """Filter parameter is expected to be dictionary."""

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -142,34 +142,39 @@ class BuildCountQueryTest(TestCase):
     def test_from_events(self):
         """Query against events table."""
         filters = {'type': ['cloudify_event']}
-        Events._build_count_query(filters)
+        range_filters = {}
+        Events._build_count_query(filters, range_filters)
         self.assertEqual(
             self.db.session.query().filter().subquery.call_count, 1)
 
     def test_from_logs(self):
         """Query against both events and logs tables."""
         filters = {'type': ['cloudify_event', 'cloudify_log']}
-        Events._build_count_query(filters)
+        range_filters = {}
+        Events._build_count_query(filters, range_filters)
         self.assertEqual(
             self.db.session.query().filter().subquery.call_count, 2)
 
     def test_filter_required(self):
         """Filter parameter is expected to be dictionary."""
         filters = None
+        range_filters = {}
         with self.assertRaises(BadParametersError):
-            Events._build_count_query(filters)
+            Events._build_count_query(filters, range_filters)
 
     def test_filter_type_required(self):
         """Filter by type is expected."""
         filters = {}
+        range_filters = {}
         with self.assertRaises(BadParametersError):
-            Events._build_count_query(filters)
+            Events._build_count_query(filters, range_filters)
 
     def test_filter_type_event(self):
         """Filter is set at least to cloudify_event."""
         filters = {'type': ['cloudify_log']}
+        range_filters = {}
         with self.assertRaises(BadParametersError):
-            Events._build_count_query(filters)
+            Events._build_count_query(filters, range_filters)
 
 
 @attr(client_min_version=1, client_max_version=base_test.LATEST_API_VERSION)

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -65,7 +65,6 @@ class BuildSelectQueryTest(TestCase):
     # Parameters passed ot the _build_select_query_method
     # Each tests overwrites different fields as needed.
     DEFAULT_PARAMS = {
-        '_include': None,
         'filters': {
             'type': ['cloudify_event'],
         },
@@ -76,6 +75,7 @@ class BuildSelectQueryTest(TestCase):
         'sort': {
             '@timestamp': 'asc',
         },
+        'range_filters': {},
     }
 
     def setUp(self):

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -101,13 +101,6 @@ class BuildSelectQueryTest(TestCase):
         Events._build_select_query(**params)
         self.assertTrue(self.db.session.query().filter().union.called)
 
-    def test_include_set_to_none(self):
-        """Include parameter is expected to be set to None."""
-        params = deepcopy(self.DEFAULT_PARAMS)
-        params['_include'] = '<invalid>'
-        with self.assertRaises(BadParametersError):
-            Events._build_select_query(**params)
-
     def test_filter_required(self):
         """Filter parameter is expected to be dictionary."""
         params = deepcopy(self.DEFAULT_PARAMS)
@@ -126,13 +119,6 @@ class BuildSelectQueryTest(TestCase):
         """Filter is set at least to cloudify_event."""
         params = deepcopy(self.DEFAULT_PARAMS)
         params['filters'] = {'type': ['cloudify_log']}
-        with self.assertRaises(BadParametersError):
-            Events._build_select_query(**params)
-
-    def test_sort_by_timestamp_required(self):
-        """Ordering by timestamp expected."""
-        params = deepcopy(self.DEFAULT_PARAMS)
-        params['sort'] = {'<field>': 'asc'}
         with self.assertRaises(BadParametersError):
             Events._build_select_query(**params)
 


### PR DESCRIPTION
In this PR code has been updated to support parameters that were not part of the initial implementation like `_include` to apply projections and `_range` to filter by timestamp. This means that the integration test cases that depend on this behavior have been fixed.

Note that there are still a couple of test cases that need to be fixed that depend on a `message.text` parameter that was used to match messages using full-text search. This will be addressed in a separate PR.