### PR TITLE
Readable circleci config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,13 +21,55 @@ dependencies:
 # System workflows runs with Infra V2
 test:
   override:
-    - case $CIRCLE_NODE_INDEX in 0) ./run-tests.sh test-rest-service-endpoints-v1-client ;; 1) ./run-tests.sh test-rest-service-endpoints-v2-client ;; 2) ./run-tests.sh test-rest-service-infrastructure-v2-client ;; 3) ./run-tests.sh test-rest-service-endpoints-v2_1-client ;; 4) ./run-tests.sh test-rest-service-infrastructure-v2_1-client ;; 5) ./run-tests.sh test-rest-service-endpoints-v3-client ;; 6) ./run-tests.sh test-rest-service-infrastructure-v3-client ;; esac:
+    - ? |
+        case $CIRCLE_NODE_INDEX in
+        0)
+          ./run-tests.sh test-rest-service-endpoints-v1-client
+          ;;
+        1)
+          ./run-tests.sh test-rest-service-endpoints-v2-client
+          ;;
+        2)
+          ./run-tests.sh test-rest-service-infrastructure-v2-client
+          ;;
+        3)
+          ./run-tests.sh test-rest-service-endpoints-v2_1-client
+          ;;
+        4)
+          ./run-tests.sh test-rest-service-infrastructure-v2_1-client
+          ;;
+        5)
+          ./run-tests.sh test-rest-service-endpoints-v3-client
+          ;;
+        6)
+          ./run-tests.sh test-rest-service-infrastructure-v3-client
+          ;;
+        esac
+      :
         parallel: true
-    - case $CIRCLE_NODE_INDEX in 0) ./run-tests.sh test-rest-service-infrastructure-v1-client ;; esac:
+    - ? |
+        case $CIRCLE_NODE_INDEX in
+        0)
+          ./run-tests.sh test-rest-service-infrastructure-v1-client
+          ;;
+        esac
+      :
         parallel: true
-    - case $CIRCLE_NODE_INDEX in 1) ./run-tests.sh flake8 ;; esac:
+    - ? |
+        case $CIRCLE_NODE_INDEX in
+        1)
+          ./run-tests.sh flake8
+          ;;
+        esac
+      :
         parallel: true
-    - case $CIRCLE_NODE_INDEX in 2) ./run-tests.sh test-system-workflows ;; esac:
+    - ? |
+        case $CIRCLE_NODE_INDEX in
+        2)
+          ./run-tests.sh test-system-workflows
+          ;;
+        esac
+      :
         parallel: true
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -25,12 +25,15 @@ test:
         case $CIRCLE_NODE_INDEX in
         0)
           ./run-tests.sh test-rest-service-endpoints-v1-client
+          ./run-tests.sh test-rest-service-infrastructure-v1-client
           ;;
         1)
           ./run-tests.sh test-rest-service-endpoints-v2-client
+          ./run-tests.sh flake8
           ;;
         2)
           ./run-tests.sh test-rest-service-infrastructure-v2-client
+          ./run-tests.sh test-system-workflows
           ;;
         3)
           ./run-tests.sh test-rest-service-endpoints-v2_1-client
@@ -43,30 +46,6 @@ test:
           ;;
         6)
           ./run-tests.sh test-rest-service-infrastructure-v3-client
-          ;;
-        esac
-      :
-        parallel: true
-    - ? |
-        case $CIRCLE_NODE_INDEX in
-        0)
-          ./run-tests.sh test-rest-service-infrastructure-v1-client
-          ;;
-        esac
-      :
-        parallel: true
-    - ? |
-        case $CIRCLE_NODE_INDEX in
-        1)
-          ./run-tests.sh flake8
-          ;;
-        esac
-      :
-        parallel: true
-    - ? |
-        case $CIRCLE_NODE_INDEX in
-        2)
-          ./run-tests.sh test-system-workflows
           ;;
         esac
       :


### PR DESCRIPTION
In this PR, the test commands in the circleci file have been consolidated into a single one using multi line strings to improve readability.

Note: while I was looking at the code and the test case output, I realized that only 7 out of 8 containers were being used. In the last one (number 7) the dependencies were installed, but no test case was executed since there was no match in the `case` statement. Hence, I've updated the project configuration in circleci to request only 7 containers. I thought about splitting the load using the empty container, but the jobs that take the longer (nodes 3 and 5) already run a single command, so it wouldn't have improved the overall build time.