### PR TITLE
Reduce test case output verbosity

### DIFF
--- a/rest-service/tox.ini
+++ b/rest-service/tox.ini
@@ -14,7 +14,7 @@ deps =
     {[testenv]deps}
     # overriding the REST client with a V1 client
     cloudify-rest-client==3.2.1
-commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 1 <= client_max_version' -v --nocapture --nologcapture --with-cov --cov manager_rest --cov-report term-missing
+commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 1 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
 
 [testenv:clientV1_infrastructure]
 basepython=python2.7
@@ -23,8 +23,8 @@ deps =
     # overriding the REST client with a V1 client
     cloudify-rest-client==3.2.1
 commands=
-    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 1 <= client_max_version' -v --nocapture --nologcapture --with-cov --cov manager_rest --cov-report term-missing
-    nosetests manager_rest/test/security -A 'client_min_version <= 1 <= client_max_version' -v --nocapture --nologcapture --with-cov --cov manager_rest --cov-report term-missing
+    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 1 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
+    nosetests manager_rest/test/security -A 'client_min_version <= 1 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
 
 [testenv:clientV2_endpoints]
 basepython=python2.7
@@ -32,7 +32,7 @@ deps =
     {[testenv]deps}
     # overriding the REST client with a V2 client
     cloudify-rest-client==3.3.1
-commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 2 <= client_max_version' -v --nocapture --nologcapture --with-cov --cov manager_rest --cov-report term-missing
+commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 2 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
 
 [testenv:clientV2_infrastructure]
 basepython=python2.7
@@ -41,8 +41,8 @@ deps =
     # overriding the REST client with a V2 client
     cloudify-rest-client==3.3.1
 commands=
-    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 2 <= client_max_version' -v --nocapture --nologcapture --with-cov --cov manager_rest --cov-report term-missing
-    nosetests manager_rest/test/security -A 'client_min_version <= 2 <= client_max_version' -v --nocapture --nologcapture --with-cov --cov manager_rest --cov-report term-missing
+    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 2 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
+    nosetests manager_rest/test/security -A 'client_min_version <= 2 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
 
 [testenv:clientV2_1_endpoints]
 basepython=python2.7
@@ -50,7 +50,7 @@ deps =
     {[testenv]deps}
     # overriding the REST client with a V2.1 client
     cloudify-rest-client==3.4
-commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 2.1 <= client_max_version' -v --nocapture --nologcapture --with-cov --cov manager_rest --cov-report term-missing
+commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 2.1 <= client_max_version' -with-cov --cov manager_rest --cov-report term-missing {posargs}
 
 [testenv:clientV2_1_infrastructure]
 basepython=python2.7
@@ -59,19 +59,19 @@ deps =
     # overriding the REST client with a V2.1 client
     cloudify-rest-client==3.4
 commands=
-    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 2.1 <= client_max_version' -v --nocapture --nologcapture --with-cov --cov manager_rest --cov-report term-missing
-    nosetests manager_rest/test/security -A 'client_min_version <= 2.1 <= client_max_version' -v --nocapture --nologcapture --with-cov --cov manager_rest --cov-report term-missing
+    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 2.1 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
+    nosetests manager_rest/test/security -A 'client_min_version <= 2.1 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
 
 [testenv:clientV3_endpoints]
 basepython=python2.7
 deps =
     {[testenv]deps}
-commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 3 <= client_max_version' -v --nocapture --nologcapture --with-cov --cov manager_rest --cov-report term-missing
+commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 3 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
 
 [testenv:clientV3_infrastructure]
 basepython=python2.7
 deps =
     {[testenv]deps}
 commands=
-    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 3 <= client_max_version' -v --nocapture --nologcapture --with-cov --cov manager_rest --cov-report term-missing
-    nosetests manager_rest/test/security -A 'client_min_version <= 3 <= client_max_version' -v --nocapture --nologcapture --with-cov --cov manager_rest --cov-report term-missing
+    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 3 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
+    nosetests manager_rest/test/security -A 'client_min_version <= 3 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}

--- a/rest-service/tox.ini
+++ b/rest-service/tox.ini
@@ -14,7 +14,7 @@ deps =
     {[testenv]deps}
     # overriding the REST client with a V1 client
     cloudify-rest-client==3.2.1
-commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 1 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
+commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 1 <= client_max_version' {posargs}
 
 [testenv:clientV1_infrastructure]
 basepython=python2.7
@@ -23,8 +23,8 @@ deps =
     # overriding the REST client with a V1 client
     cloudify-rest-client==3.2.1
 commands=
-    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 1 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
-    nosetests manager_rest/test/security -A 'client_min_version <= 1 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
+    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 1 <= client_max_version' {posargs}
+    nosetests manager_rest/test/security -A 'client_min_version <= 1 <= client_max_version' {posargs}
 
 [testenv:clientV2_endpoints]
 basepython=python2.7
@@ -32,7 +32,7 @@ deps =
     {[testenv]deps}
     # overriding the REST client with a V2 client
     cloudify-rest-client==3.3.1
-commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 2 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
+commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 2 <= client_max_version' {posargs}
 
 [testenv:clientV2_infrastructure]
 basepython=python2.7
@@ -41,8 +41,8 @@ deps =
     # overriding the REST client with a V2 client
     cloudify-rest-client==3.3.1
 commands=
-    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 2 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
-    nosetests manager_rest/test/security -A 'client_min_version <= 2 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
+    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 2 <= client_max_version' {posargs}
+    nosetests manager_rest/test/security -A 'client_min_version <= 2 <= client_max_version' {posargs}
 
 [testenv:clientV2_1_endpoints]
 basepython=python2.7
@@ -50,7 +50,7 @@ deps =
     {[testenv]deps}
     # overriding the REST client with a V2.1 client
     cloudify-rest-client==3.4
-commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 2.1 <= client_max_version' -with-cov --cov manager_rest --cov-report term-missing {posargs}
+commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 2.1 <= client_max_version' {posargs}
 
 [testenv:clientV2_1_infrastructure]
 basepython=python2.7
@@ -59,19 +59,19 @@ deps =
     # overriding the REST client with a V2.1 client
     cloudify-rest-client==3.4
 commands=
-    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 2.1 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
-    nosetests manager_rest/test/security -A 'client_min_version <= 2.1 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
+    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 2.1 <= client_max_version' {posargs}
+    nosetests manager_rest/test/security -A 'client_min_version <= 2.1 <= client_max_version' {posargs}
 
 [testenv:clientV3_endpoints]
 basepython=python2.7
 deps =
     {[testenv]deps}
-commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 3 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
+commands=nosetests manager_rest/test/endpoints -A 'client_min_version <= 3 <= client_max_version' {posargs}
 
 [testenv:clientV3_infrastructure]
 basepython=python2.7
 deps =
     {[testenv]deps}
 commands=
-    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 3 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
-    nosetests manager_rest/test/security -A 'client_min_version <= 3 <= client_max_version' --with-cov --cov manager_rest --cov-report term-missing {posargs}
+    nosetests manager_rest/test/infrastructure -A 'client_min_version <= 3 <= client_max_version' {posargs}
+    nosetests manager_rest/test/security -A 'client_min_version <= 3 <= client_max_version' {posargs}

--- a/workflows/tox.ini
+++ b/workflows/tox.ini
@@ -7,4 +7,4 @@ deps =
     -rdev-requirements.txt
     nose
     nose-cov
-commands=nosetests -sv 
+commands=nosetests {posargs}


### PR DESCRIPTION
In this PR, the test case output verbosity is reduced by removing the `-v` and `-s` flags from `nosetests` commands being executed. The reason for this is that currently the test case output is so verbose that it's not possible to check the output when an error happens in circleci without downloading the log file because the web UI doesn't display huge files.

In addition to this, coverage reporting options are removed as well because that data isn't being for anything currently. They will be added in the future if this changes.

Note that [arguments passing through tox](http://tox.readthedocs.io/en/latest/example/general.html#interactively-passing-positional-arguments) has been enabled, so if anybody needs to set any of those flags to run the test cases locally it's still possible to do so as follows: `tox -- -s -v` 