### PR TITLE
Cache tox environment in circle ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,8 @@ dependencies:
   override:
     - pip install tox
     - pip install setuptools --upgrade
+    - tox -c ./rest-service --notest
+    - tox -c ./workflows --notest
 
 # Endpoints V1 runs with Infra V1
 # flake runs with Endpoints V2

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,9 @@ dependencies:
     - pip install setuptools --upgrade
     - tox -c ./rest-service --notest
     - tox -c ./workflows --notest
+  cache_directories:
+    - ./rest-service/.tox
+    - ./workflows/.tox
 
 # Endpoints V1 runs with Infra V1
 # flake runs with Endpoints V2

--- a/circle.yml
+++ b/circle.yml
@@ -15,8 +15,8 @@ dependencies:
   override:
     - pip install tox
     - pip install setuptools --upgrade
-    - tox -c ./rest-service --notest
-    - tox -c ./workflows --notest
+    - tox -c ./rest-service/tox.ini --notest
+    - tox -c ./workflows/tox.ini --notest
   cache_directories:
     - ./rest-service/.tox
     - ./workflows/.tox


### PR DESCRIPTION
In this PR, the configuration for Circle CI is updated to generate the tox virtualenvs during the dependencies phase, so that they can be cached. This way, there is no need to re-create them for every test run.

From what I've seen what is saved is just a few seconds, but still for a so small diff, I think it's worth the change.