### PR TITLE
Update python version to 2.7.11 in Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   python:
-    version: 2.7.9
+    version: 2.7.11
 
 checkout:
   post:


### PR DESCRIPTION
In this PR, the python version used to run the test cases is updated from 2.7.9 to 2.7.11.

The reason for this is that version 2.7.9 is not installed by default in the default image in Circle
CI and the installation takes around 2 minutes for every test run and container.

I don't know if there's a strict requirement about the python version, but the on that I get in a VM with CentOS 7 that I've used to bootstrap a manager is 2.7.5, so it seems that really any 2.7.x version might be in use depending on the image.