### PR TITLE
CFY 6333. Port enable zip64 in snapshots

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/snapshot_create.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_create.py
@@ -112,9 +112,9 @@ class SnapshotCreate(object):
 
     def _create_archive(self):
         snapshot_archive_name = self._get_snapshot_archive_name()
-        ctx.logger.info('Creating snapshot archive: {0}'
-                        .format(snapshot_archive_name))
-        shutil.make_archive(snapshot_archive_name, 'zip', self._tempdir)
+        ctx.logger.info(
+            'Creating snapshot archive: {0}'.format(snapshot_archive_name))
+        utils.make_zip64_archive(snapshot_archive_name, self._tempdir)
 
     def _get_snapshot_archive_name(self):
         """Return the base name for the snapshot archive
@@ -122,7 +122,7 @@ class SnapshotCreate(object):
         snapshots_dir = self._get_and_create_snapshots_dir()
         snapshot_dir = os.path.join(snapshots_dir, self._snapshot_id)
         os.makedirs(snapshot_dir)
-        return os.path.join(snapshot_dir, self._snapshot_id)
+        return os.path.join(snapshot_dir, '{}.zip'.format(self._snapshot_id))
 
     def _get_and_create_snapshots_dir(self):
         """Create (if necessary) and return the snapshots directory

--- a/workflows/cloudify_system_workflows/snapshots/utils.py
+++ b/workflows/cloudify_system_workflows/snapshots/utils.py
@@ -18,6 +18,7 @@ import json
 import shlex
 import shutil
 import subprocess
+import zipfile
 
 from elasticsearch import Elasticsearch
 
@@ -170,3 +171,46 @@ def get_manager_version(client):
 
 def is_compute(node):
     return COMPUTE_NODE_TYPE in node.type_hierarchy
+
+
+def make_zip64_archive(zip_filename, directory):
+    """Create zip64 archive that contains all files in a directory.
+
+    zip64 is a set of extensions on top of the zip file format that allows to
+    have files larger than 2GB. This is important in snapshots where the amount
+    of data to backup might be huge.
+
+    Note that `shutil` provides a method to register new formats based on the
+    extension of the target file, since a `.zip` extension is still desired,
+    using such an extension mechanism is not an option to avoid patching the
+    already registered zip format.
+
+    In any case, this function is heavily inspired in stdlib's
+    `shutil._make_zipfile`.
+
+    :param zip_filename: Path to the zip file to be created
+    :type zip_filename: str
+    :path directory: Path to directory where all files to compress are located
+    :type directory: str
+
+    """
+    zip_context_manager = zipfile.ZipFile(
+        zip_filename,
+        'w',
+        compression=zipfile.ZIP_DEFLATED,
+        allowZip64=True,
+    )
+
+    with zip_context_manager as zip_file:
+        path = os.path.normpath(directory)
+        zip_file.write(path)
+        for dirpath, dirnames, filenames in os.walk(directory):
+            for dirname in sorted(dirnames):
+                path = os.path.normpath(os.path.join(dirpath, dirname))
+                zip_file.write(path)
+            for filename in filenames:
+                path = os.path.normpath(os.path.join(dirpath, filename))
+                # Not sure why this check is needed,
+                # but it's in the original stdlib's implementation
+                if os.path.isfile(path):
+                    zip_file.write(path)

--- a/workflows/cloudify_system_workflows/tests/snapshots/__init__.py
+++ b/workflows/cloudify_system_workflows/tests/snapshots/__init__.py
@@ -1,0 +1,1 @@
+"""Snapshots test cases."""

--- a/workflows/cloudify_system_workflows/tests/snapshots/tests_utils.py
+++ b/workflows/cloudify_system_workflows/tests/snapshots/tests_utils.py
@@ -1,0 +1,68 @@
+"""Snapshot utilities test cases."""
+
+import os
+import shutil
+import subprocess
+import unittest
+import tempfile
+
+from cloudify_system_workflows.snapshots.utils import make_zip64_archive
+
+
+class MakeZip64Test(unittest.TestCase):
+
+    """Ensure huge zip files can be created."""
+
+    def setUp(self):
+        """Create temporary directory with long files."""
+        base_dir = tempfile.mkdtemp(prefix='make_zip_test_')
+        data_dir = os.path.join(base_dir, 'data')
+        os.mkdir(data_dir)
+
+        dir_count = 5
+        file_count = 5
+
+        for dir_number in range(dir_count):
+            directory = os.path.join(data_dir, 'dir_{}'.format(dir_number))
+            os.mkdir(directory)
+
+            for file_number in range(file_count):
+                path = os.path.join(directory, 'file_{}'.format(file_number))
+                self._create_random_file(path)
+
+        self.base_dir = base_dir
+        self.data_dir = data_dir
+
+        self.addCleanup(shutil.rmtree, base_dir)
+
+    def _create_random_file(
+            self, filename, chunk_size=2**20, chunk_count=100):
+        """Create random file efficiently
+
+        The size of the random file (100 MB by default) can be controlled by
+        setting `chunk_size` (1 MB by default) and `chunk_count` (100 by
+        default).
+
+        This functionality could be implemented with python code, but it won't
+        be as fast as the `dd` binary.
+
+        """
+        subprocess.call([
+            'dd',
+            'if=/dev/urandom',
+            'of={}'.format(filename),
+            'bs={}'.format(chunk_size),
+            'count={}'.format(chunk_count),
+        ])
+
+    def test_huge_file(self):
+        """Size should not be be a problem with zip64 enabled."""
+        zip_filename = os.path.join(self.base_dir, 'snapshot.zip')
+        make_zip64_archive(zip_filename, self.data_dir)
+
+        # When zip64 extensions are not enabled, zip fails around 2.1 GB,
+        # so if the file size is greater than 2.2 GB it should be
+        self.assertGreater(
+            os.path.getsize(zip_filename),
+            2.2 * 2**30,  # 2.2GB
+        )

--- a/workflows/cloudify_system_workflows/tests/snapshots/tests_utils.py
+++ b/workflows/cloudify_system_workflows/tests/snapshots/tests_utils.py
@@ -6,6 +6,8 @@ import subprocess
 import unittest
 import tempfile
 
+from nose.tools import nottest
+
 from cloudify_system_workflows.snapshots.utils import make_zip64_archive
 
 
@@ -55,8 +57,17 @@ class MakeZip64Test(unittest.TestCase):
             'count={}'.format(chunk_count),
         ])
 
+    @nottest
     def test_huge_file(self):
-        """Size should not be be a problem with zip64 enabled."""
+        """Size should not be be a problem with zip64 enabled.
+
+        Note: This test case is disabled by default because it takes very long
+        to complete in a CI environment and it just makes sure that python's
+        zip64 implementation works, so it doesn't make much sense to execute it
+        for every commit being pushed. To run it in your own machine delete the
+        `nottest` decorator above.
+
+        """
         zip_filename = os.path.join(self.base_dir, 'snapshot.zip')
         make_zip64_archive(zip_filename, self.data_dir)
 


### PR DESCRIPTION
This PR is port of the fix to enable zip64 in 3.4.2 to 4.0.

Related: #706 