### PR TITLE
CFY 6395. Filter by either events or logs

### DIFF
--- a/rest-service/dev-requirements.txt
+++ b/rest-service/dev-requirements.txt
@@ -5,3 +5,4 @@ https://github.com/cloudify-cosmo/cloudify-rest-client/archive/master.zip
 mock
 python-dateutil
 wagon==0.3.2
+faker

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -258,6 +258,7 @@ class Events(SecuredResource):
 
         query = (
             db.session.query(
+                select_column('id'),
                 select_column('timestamp'),
                 Deployment.id.label('deployment_id'),
                 select_column('message'),

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -160,7 +160,7 @@ class Events(SecuredResource):
         return query
 
     @staticmethod
-    def _build_select_query(filters, pagination, sort, range_filters):
+    def _build_select_query(filters, sort, range_filters):
         """Build query used to list events for a given execution.
 
         :param filters:
@@ -461,8 +461,7 @@ class Events(SecuredResource):
         count_query = Events._build_count_query(filters, range_filters)
         total = count_query.params(**params).scalar()
 
-        select_query = self._build_select_query(
-            filters, pagination, sort, range_filters)
+        select_query = self._build_select_query(filters, sort, range_filters)
 
         events = [
             self._map_event_to_es(_include, event)

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -204,17 +204,16 @@ class Events(SecuredResource):
         :rtype: :class:`sqlalchemy.orm.query.Query`
 
         """
-        if not isinstance(filters, dict) or 'type' not in filters:
-            raise manager_exceptions.BadParametersError(
-                'Filter by type is expected')
+        assert isinstance(filters, dict), \
+            'Filters is expected to be a dictionary'
 
         subqueries = []
-        if 'cloudify_event' in filters['type']:
+        if 'type' not in filters or 'cloudify_event' in filters['type']:
             events_query = Events._build_select_subquery(
                 Event, filters, range_filters)
             subqueries.append(events_query)
 
-        if 'cloudify_log' in filters['type']:
+        if 'type' not in filters or 'cloudify_log' in filters['type']:
             logs_query = Events._build_select_subquery(
                 Log, filters, range_filters)
             subqueries.append(logs_query)
@@ -316,17 +315,16 @@ class Events(SecuredResource):
         :rtype: :class:`sqlalchemy.orm.query.Query`
 
         """
-        if not isinstance(filters, dict) or 'type' not in filters:
-            raise manager_exceptions.BadParametersError(
-                'Filter by type is expected')
+        assert isinstance(filters, dict), \
+            'Filters is expected to be a dictionary'
 
         subqueries = []
-        if 'cloudify_event' in filters['type']:
+        if 'type' not in filters or 'cloudify_event' in filters['type']:
             events_query = Events._build_count_subquery(
                 Event, filters, range_filters)
             subqueries.append(events_query)
 
-        if 'cloudify_log' in filters['type']:
+        if 'type' not in filters or 'cloudify_log' in filters['type']:
             logs_query = Events._build_count_subquery(
                 Log, filters, range_filters)
             subqueries.append(logs_query)

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -253,7 +253,7 @@ class Events(SecuredResource):
 
             """
             if hasattr(model, column_name):
-                return getattr(model, column_name)
+                return getattr(model, column_name).label(column_name)
             return literal_column('NULL').label(column_name)
 
         query = (

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -52,10 +52,10 @@ class Events(SecuredResource):
     """
 
     DEFAULT_SEARCH_SIZE = 10000
-    ALLOWED_FILTERS = [
-        (Execution, 'execution_id'),
-        (Deployment, 'deployment_id'),
-    ]
+    ALLOWED_FILTERS = {
+        'execution_id': Execution,
+        'deployment_id': Deployment,
+    }
 
     @staticmethod
     def _apply_filters(query, filters):
@@ -70,9 +70,15 @@ class Events(SecuredResource):
         :type filters: dict(str, list(str))
 
         """
-        for model, field in Events.ALLOWED_FILTERS:
-            if field in filters:
-                query = query.filter(model.id.in_(filters[field]))
+        for field, filter_ in filters.items():
+            if field == 'type':
+                # Filter by type is handled while building the query
+                continue
+            if field not in Events.ALLOWED_FILTERS:
+                raise manager_exceptions.BadParametersError(
+                    'Unknown field to filter by: {}'.format(field))
+            model = Events.ALLOWED_FILTERS[field]
+            query = query.filter(model.id.in_(filter_))
         return query
 
     @staticmethod

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -184,11 +184,6 @@ class Events(SecuredResource):
             filtering by a deployment and an execution that doesn't belong to
             that deployment won't return any result.
         :type filters: dict(str, str)
-        :param pagination:
-            Parameters used to limit results returned in a single query.
-            Expected values `size` and `offset` are mapped into SQL as `LIMIT`
-            and `OFFSET`.
-        :type pagination: dict(str, int)
         :param sort:
             Result sorting order.
 

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -261,6 +261,7 @@ class Events(SecuredResource):
                 select_column('id'),
                 select_column('timestamp'),
                 Deployment.id.label('deployment_id'),
+                Execution.id.label('execution_id'),
                 select_column('message'),
                 select_column('message_code'),
                 select_column('event_type'),

--- a/rest-service/manager_rest/rest/resources_v2/events.py
+++ b/rest-service/manager_rest/rest/resources_v2/events.py
@@ -99,8 +99,7 @@ class Events(resources_v1.Events):
         count_query = self._build_count_query(filters, range_filters)
         total = count_query.params(**params).scalar()
 
-        select_query = self._build_select_query(
-            filters, pagination, sort, range_filters)
+        select_query = self._build_select_query(filters, sort, range_filters)
 
         results = [
             self._map_event_to_es(_include, event)

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -220,6 +220,19 @@ class SelectEventsFilterTest(SelectEventsBaseTest):
             for event in events
         ))
 
+    def test_filter_by_unknown(self):
+        """Filter events by an unknown field."""
+        filters = {
+            'unknown': ['<value>'],
+            'type': ['cloudify_event', 'cloudify_log']
+        }
+        with self.assertRaises(BadParametersError):
+            Events._build_select_query(
+                filters,
+                self.DEFAULT_SORT,
+                self.DEFAULT_RANGE_FILTERS,
+            )
+
 
 class SelectEventsFilterTypeTest(SelectEventsBaseTest):
 
@@ -352,7 +365,7 @@ class SelectEventsSortTest(SelectEventsBaseTest):
         self._sort_by_timestamp('@timestamp', 'desc')
 
 
-class SelectEventRangeFilterTest(SelectEventsBaseTest):
+class SelectEventsRangeFilterTest(SelectEventsBaseTest):
 
     """Filter out events not included in a range."""
 
@@ -409,6 +422,15 @@ class SelectEventRangeFilterTest(SelectEventsBaseTest):
     def test_filter_by_at_timestamp_range(self):
         """Filter by @timestamp range."""
         self._filter_by_timestamp_range('@timestamp')
+
+    def test_filter_by_unknown_range(self):
+        """Filter by unknown field range."""
+        with self.assertRaises(BadParametersError):
+            Events._build_select_query(
+                self.DEFAULT_FILTERS,
+                self.DEFAULT_SORT,
+                {'unknown': {'from': 'a', 'to': 'b'}},
+            )
 
 
 @attr(client_min_version=1, client_max_version=base_test.LATEST_API_VERSION)

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -301,11 +301,16 @@ class SelectEventsSortTest(SelectEventsBaseTest):
         'offset': 0,
     }
 
-    def test_sort_by_timestamp_ascending(self):
-        """Sort by timestamp ascending."""
-        sort = {
-            'timestamp': 'asc',
-        }
+    def _sort_by_timestamp(self, field, direction):
+        """Sort by a given field.
+
+        :param field: Field name (timestamp/@timestamp)
+        :type field: str
+        :param direction: Sorting direction (asc/desc)
+        :type direction: str
+
+        """
+        sort = {field: direction}
         query = Events._build_select_query(
             self.DEFAULT_FILTERS,
             sort,
@@ -318,6 +323,7 @@ class SelectEventsSortTest(SelectEventsBaseTest):
         expected_events = sorted(
             self.events,
             key=lambda event: event.timestamp,
+            reverse=direction == 'desc',
         )
         expected_event_timestamps = [
             event.timestamp
@@ -325,30 +331,13 @@ class SelectEventsSortTest(SelectEventsBaseTest):
         ]
         self.assertListEqual(event_timestamps, expected_event_timestamps)
 
+    def test_sort_by_timestamp_ascending(self):
+        """Sort by timestamp ascending."""
+        self._sort_by_timestamp('timestamp', 'asc')
+
     def test_sort_by_timestamp_descending(self):
         """Sort by timestamp descending."""
-        sort = {
-            'timestamp': 'desc',
-        }
-        query = Events._build_select_query(
-            self.DEFAULT_FILTERS,
-            sort,
-            self.DEFAULT_RANGE_FILTERS,
-        )
-        event_timestamps = [
-            event.timestamp
-            for event in query.params(**self.DEFAULT_PAGINATION).all()
-        ]
-        expected_events = sorted(
-            self.events,
-            key=lambda event: event.timestamp,
-            reverse=True
-        )
-        expected_event_timestamps = [
-            event.timestamp
-            for event in expected_events
-        ]
-        self.assertListEqual(event_timestamps, expected_event_timestamps)
+        self._sort_by_timestamp('timestamp', 'desc')
 
     def test_sort_at_by_timestamp_ascending(self):
         """Sort by @timestamp ascending.
@@ -357,27 +346,7 @@ class SelectEventsSortTest(SelectEventsBaseTest):
         implementation.
 
         """
-        sort = {
-            '@timestamp': 'asc',
-        }
-        query = Events._build_select_query(
-            self.DEFAULT_FILTERS,
-            sort,
-            self.DEFAULT_RANGE_FILTERS,
-        )
-        event_timestamps = [
-            event.timestamp
-            for event in query.params(**self.DEFAULT_PAGINATION).all()
-        ]
-        expected_events = sorted(
-            self.events,
-            key=lambda event: event.timestamp,
-        )
-        expected_event_timestamps = [
-            event.timestamp
-            for event in expected_events
-        ]
-        self.assertListEqual(event_timestamps, expected_event_timestamps)
+        self._sort_by_timestamp('@timestamp', 'asc')
 
     def test_sort_by_at_timestamp_descending(self):
         """Sort by @timestamp descending.
@@ -386,28 +355,7 @@ class SelectEventsSortTest(SelectEventsBaseTest):
         implementation.
 
         """
-        sort = {
-            '@timestamp': 'desc',
-        }
-        query = Events._build_select_query(
-            self.DEFAULT_FILTERS,
-            sort,
-            self.DEFAULT_RANGE_FILTERS,
-        )
-        event_timestamps = [
-            event.timestamp
-            for event in query.params(**self.DEFAULT_PAGINATION).all()
-        ]
-        expected_events = sorted(
-            self.events,
-            key=lambda event: event.timestamp,
-            reverse=True
-        )
-        expected_event_timestamps = [
-            event.timestamp
-            for event in expected_events
-        ]
-        self.assertListEqual(event_timestamps, expected_event_timestamps)
+        self._sort_by_timestamp('@timestamp', 'desc')
 
 
 class SelectEventRangeFilterTest(SelectEventsBaseTest):

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -221,7 +221,6 @@ class SelectEventsFilterTest(SelectEventsBaseTest):
         ))
 
 
-
 class SelectEventsFilterTypeTest(SelectEventsBaseTest):
 
     """Filter events by type."""

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -282,9 +282,24 @@ class SelectEventsFilterTypeTest(SelectEventsBaseTest):
         ]
         self.assertListEqual(event_ids, expected_event_ids)
 
-    def test_get_events_and_logs(self):
-        """Get both events and logs."""
+    def test_get_events_and_logs_explicit(self):
+        """Get both events and logs explicitly by passing filters."""
         self._get_events_by_type(['cloudify_event', 'cloudify_log'])
+
+    def test_get_events_and_logs_implicit(self):
+        """Get both events and logs implicitly without passing any filter."""
+        filters = {}
+        query = Events._build_select_query(
+            filters,
+            self.DEFAULT_SORT,
+            self.DEFAULT_RANGE_FILTERS,
+        )
+        event_ids = [
+            event.id
+            for event in query.params(**self.DEFAULT_PAGINATION).all()
+        ]
+        expected_event_ids = [event.id for event in self.events]
+        self.assertListEqual(event_ids, expected_event_ids)
 
     def test_get_events(self):
         """Get only events."""
@@ -492,14 +507,7 @@ class BuildSelectQueryTest(TestCase):
         """Filter parameter is expected to be dictionary."""
         params = deepcopy(self.DEFAULT_PARAMS)
         params['filters'] = None
-        with self.assertRaises(BadParametersError):
-            Events._build_select_query(**params)
-
-    def test_filter_type_required(self):
-        """Filter by type is expected."""
-        params = deepcopy(self.DEFAULT_PARAMS)
-        del params['filters']['type']
-        with self.assertRaises(BadParametersError):
+        with self.assertRaises(AssertionError):
             Events._build_select_query(**params)
 
 
@@ -539,14 +547,7 @@ class BuildCountQueryTest(TestCase):
         """Filter parameter is expected to be dictionary."""
         filters = None
         range_filters = {}
-        with self.assertRaises(BadParametersError):
-            Events._build_count_query(filters, range_filters)
-
-    def test_filter_type_required(self):
-        """Filter by type is expected."""
-        filters = {}
-        range_filters = {}
-        with self.assertRaises(BadParametersError):
+        with self.assertRaises(AssertionError):
             Events._build_count_query(filters, range_filters)
 
 

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -130,14 +130,6 @@ class BuildSelectQueryTest(TestCase):
         with self.assertRaises(BadParametersError):
             Events._build_select_query(**params)
 
-    def test_filter_type_event(self):
-        """Filter is set at least to cloudify_event."""
-        params = deepcopy(self.DEFAULT_PARAMS)
-        params['filters'] = {'type': ['cloudify_log']}
-        with self.assertRaises(BadParametersError):
-            Events._build_select_query(**params)
-
-
 @attr(client_min_version=1, client_max_version=base_test.LATEST_API_VERSION)
 class BuildCountQueryTest(TestCase):
 
@@ -180,13 +172,6 @@ class BuildCountQueryTest(TestCase):
     def test_filter_type_required(self):
         """Filter by type is expected."""
         filters = {}
-        range_filters = {}
-        with self.assertRaises(BadParametersError):
-            Events._build_count_query(filters, range_filters)
-
-    def test_filter_type_event(self):
-        """Filter is set at least to cloudify_event."""
-        filters = {'type': ['cloudify_log']}
         range_filters = {}
         with self.assertRaises(BadParametersError):
             Events._build_count_query(filters, range_filters)


### PR DESCRIPTION
In this PR, the filtering implementation is updated so that is no longer needed to always get events. Now both events and logs are optional and any of them (or both) can be retrieved in an API request.