### PR TITLE
CircleCI cache tox in first node

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,10 +7,10 @@ install_dependencies() {
     echo "### Installing dependencies..."
     case $CIRCLE_NODE_INDEX in
         0)
+            pip install flake8
             tox -c $REST_CONFIG -e clientV1-endpoints --notest
             tox -c $REST_CONFIG -e clientV1-infrastructure --notest
             tox -c $REST_CONFIG -e clientV2-endpoints --notest
-            pip install flake8
             tox -c $REST_CONFIG -e clientV2-infrastructure --notest
             tox -c $WORKFLOWS_CONFIG --notest
             tox -c $REST_CONFIG -e clientV2_1-endpoints --notest
@@ -24,13 +24,15 @@ install_dependencies() {
 run() {
     echo "### Running tests..."
     case $CIRCLE_NODE_INDEX in
+        0)
+            flake8 plugins/riemann-controller/ workflows/ rest-service/ tests/
+            ;;
         1)
             tox -c $REST_CONFIG -e clientV1-endpoints
             tox -c $REST_CONFIG -e clientV1-infrastructure
             ;;
         2)
             tox -c $REST_CONFIG -e clientV2-endpoints
-            flake8 plugins/riemann-controller/ workflows/ rest-service/ tests/
             ;;
         3)
             tox -c $REST_CONFIG -e clientV2-infrastructure

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,11 +8,11 @@ install_dependencies() {
     case $CIRCLE_NODE_INDEX in
         0)
             pip install flake8
+            tox -c $WORKFLOWS_CONFIG --notest
             tox -c $REST_CONFIG -e clientV1-endpoints --notest
             tox -c $REST_CONFIG -e clientV1-infrastructure --notest
             tox -c $REST_CONFIG -e clientV2-endpoints --notest
             tox -c $REST_CONFIG -e clientV2-infrastructure --notest
-            tox -c $WORKFLOWS_CONFIG --notest
             tox -c $REST_CONFIG -e clientV2_1-endpoints --notest
             tox -c $REST_CONFIG -e clientV2_1-infrastructure --notest
             tox -c $REST_CONFIG -e clientV3-endpoints --notest
@@ -26,28 +26,26 @@ run() {
     case $CIRCLE_NODE_INDEX in
         0)
             flake8 plugins/riemann-controller/ workflows/ rest-service/ tests/
-            ;;
-        1)
             tox -c $REST_CONFIG -e clientV1-endpoints
             tox -c $REST_CONFIG -e clientV1-infrastructure
             ;;
-        2)
+        1)
             tox -c $REST_CONFIG -e clientV2-endpoints
             ;;
-        3)
+        2)
             tox -c $REST_CONFIG -e clientV2-infrastructure
             tox -c $WORKFLOWS_CONFIG
             ;;
-        4)
+        3)
             tox -c $REST_CONFIG -e clientV2_1-endpoints
             ;;
-        5)
+        4)
             tox -c $REST_CONFIG -e clientV2_1-infrastructure
             ;;
-        6)
+        5)
             tox -c $REST_CONFIG -e clientV3-endpoints
             ;;
-        7)
+        6)
             tox -c $REST_CONFIG -e clientV3-infrastructure
             ;;
     esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,25 +9,13 @@ install_dependencies() {
         0)
             tox -c $REST_CONFIG -e clientV1-endpoints --notest
             tox -c $REST_CONFIG -e clientV1-infrastructure --notest
-            ;;
-        1)
             tox -c $REST_CONFIG -e clientV2-endpoints --notest
             pip install flake8
-            ;;
-        2)
             tox -c $REST_CONFIG -e clientV2-infrastructure --notest
             tox -c $WORKFLOWS_CONFIG --notest
-            ;;
-        3)
             tox -c $REST_CONFIG -e clientV2_1-endpoints --notest
-            ;;
-        4)
             tox -c $REST_CONFIG -e clientV2_1-infrastructure --notest
-            ;;
-        5)
             tox -c $REST_CONFIG -e clientV3-endpoints --notest
-            ;;
-        6)
             tox -c $REST_CONFIG -e clientV3-infrastructure --notest
             ;;
     esac
@@ -36,28 +24,28 @@ install_dependencies() {
 run() {
     echo "### Running tests..."
     case $CIRCLE_NODE_INDEX in
-        0)
+        1)
             tox -c $REST_CONFIG -e clientV1-endpoints
             tox -c $REST_CONFIG -e clientV1-infrastructure
             ;;
-        1)
+        2)
             tox -c $REST_CONFIG -e clientV2-endpoints
             flake8 plugins/riemann-controller/ workflows/ rest-service/ tests/
             ;;
-        2)
+        3)
             tox -c $REST_CONFIG -e clientV2-infrastructure
             tox -c $WORKFLOWS_CONFIG
             ;;
-        3)
+        4)
             tox -c $REST_CONFIG -e clientV2_1-endpoints
             ;;
-        4)
+        5)
             tox -c $REST_CONFIG -e clientV2_1-infrastructure
             ;;
-        5)
+        6)
             tox -c $REST_CONFIG -e clientV3-endpoints
             ;;
-        6)
+        7)
             tox -c $REST_CONFIG -e clientV3-infrastructure
             ;;
     esac


### PR DESCRIPTION
In this PR, the tox virtual environments that were created in different CircleCI nodes are now created just in the first node. This is because, I've realized that, when parallelism is set, CircleCI uses the first node to decide what needs to be cached. Hence, all the tox environments should be created in the same node to take full advantage of caching.
