### PR TITLE
CFY-6382. Add service_name property to AgentConfig

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -507,6 +507,12 @@ data_types:
                        This method is only supported for specific IaaS plugins.
         type: string
         required: true
+      service_name:
+        description: |
+          Used to set the the cloudify agent service name.
+          It takes precedence over the deprecated 'cloudify.nodes.Compute.cloudify_agent.name'.
+        type: string
+        required: false
       user:
         description: >
           For host agents, the agent will be installed for this user.

--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -510,7 +510,15 @@ data_types:
       service_name:
         description: |
           Used to set the the cloudify agent service name.
-          It takes precedence over the deprecated 'cloudify.nodes.Compute.cloudify_agent.name'.
+
+          If not set, the default value for the service name is:
+          - Linux: 'celery-<id>'
+          - Windows: '<id>'
+
+          where 'id' is the instance id of the compute node in which the agent is running.
+
+          Note: the value in this field, takes precedence over the deprecated
+          'cloudify.nodes.Compute.cloudify_agent.name'.
         type: string
         required: false
       user:


### PR DESCRIPTION
In this PR, the `service_name` property is added to the `cloudify.datatypes.AgentConfig`