### PR TITLE
Always upgrade packages in tox virtualenvs 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,7 @@ dependencies:
     - pip install setuptools --upgrade
     - ./run-tests.sh --install-dependencies
   cache_directories:
+    - ~/.cache/pip
     - ./rest-service/.tox
     - ./workflows/.tox
 

--- a/rest-service/tox.ini
+++ b/rest-service/tox.ini
@@ -3,6 +3,7 @@
 envlist=clientV{1,2,2_1,3}-{endpoints,infrastructure}
 
 [testenv]
+install_command = pip install -U {opts} {packages}
 basepython = python2.7
 deps =
     -rdev-requirements.txt

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -18,6 +18,8 @@ install_dependencies() {
             tox -c $REST_CONFIG -e clientV3-endpoints --notest
             tox -c $REST_CONFIG -e clientV3-infrastructure --notest
             ;;
+        *)
+            echo "Not running in fist node. Skipping..."
     esac
 }
 

--- a/workflows/tox.ini
+++ b/workflows/tox.ini
@@ -3,6 +3,7 @@
 envlist=py27
 
 [testenv]
+install_command = pip install -U {opts} {packages}
 deps =
     -rdev-requirements.txt
     nose


### PR DESCRIPTION
In this PR, the `install_command` used in tox configuration files is updated to include the `-U` flag. This should take care of the case in which a cloudify package has been cached in a tox virtualenv, but it's been updated later by pushing a new change to github using the same version number. 