### PR TITLE
CFY 6557. Support empty values in rangeable decorator

### DIFF
--- a/rest-service/manager_rest/rest/rest_decorators.py
+++ b/rest-service/manager_rest/rest/rest_decorators.py
@@ -272,7 +272,7 @@ def rangeable(func):
     schema = Schema(
         All(
             ExactSequence([
-                str,
+                basestring,
                 Any(valid_datetime, ''),
                 Any(valid_datetime, ''),
             ]),

--- a/rest-service/manager_rest/rest/rest_decorators.py
+++ b/rest-service/manager_rest/rest/rest_decorators.py
@@ -244,16 +244,16 @@ def rangeable(func):
 
         :param datetime: Datetime value to parse
         :type datetime: str
-        :return: The same value that was passed
-        :rtype: str
+        :return: The datetime value after parsing
+        :rtype: :class:`datetime.datetime`
 
         """
         try:
-            parse_datetime(datetime)
+            parsed_datetime = parse_datetime(datetime)
         except Exception:
             raise Invalid('Datetime parsing error')
 
-        return datetime
+        return parsed_datetime
 
     def from_or_to_present(range_param):
         """Make sure that at least one of from or to are present.

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -68,6 +68,7 @@ class EventResult(EventResultTuple):
         return self._fields
 
 
+@attr(client_min_version=1, client_max_version=base_test.LATEST_API_VERSION)
 class SelectEventsBaseTest(TestCase):
 
     """Select events test case base with database."""
@@ -171,6 +172,7 @@ class SelectEventsBaseTest(TestCase):
         self.events = sorted_events
 
 
+@attr(client_min_version=1, client_max_version=base_test.LATEST_API_VERSION)
 class SelectEventsFilterTest(SelectEventsBaseTest):
 
     """Filter events by deployment/execution."""
@@ -234,6 +236,7 @@ class SelectEventsFilterTest(SelectEventsBaseTest):
             )
 
 
+@attr(client_min_version=1, client_max_version=base_test.LATEST_API_VERSION)
 class SelectEventsFilterTypeTest(SelectEventsBaseTest):
 
     """Filter events by type."""
@@ -310,6 +313,7 @@ class SelectEventsFilterTypeTest(SelectEventsBaseTest):
         self._get_events_by_type(['cloudify_log'])
 
 
+@attr(client_min_version=1, client_max_version=base_test.LATEST_API_VERSION)
 class SelectEventsSortTest(SelectEventsBaseTest):
 
     """Sort events by timestamp ascending/descending."""
@@ -380,6 +384,7 @@ class SelectEventsSortTest(SelectEventsBaseTest):
         self._sort_by_timestamp('@timestamp', 'desc')
 
 
+@attr(client_min_version=1, client_max_version=base_test.LATEST_API_VERSION)
 class SelectEventsRangeFilterTest(SelectEventsBaseTest):
 
     """Filter out events not included in a range."""

--- a/rest-service/manager_rest/test/endpoints/test_rest_decorators.py
+++ b/rest-service/manager_rest/test/endpoints/test_rest_decorators.py
@@ -152,6 +152,32 @@ class RangeableTest(TestCase):
                 request.args.getlist.return_value = [valid_value]
                 rangeable(self.verify(expected_value))()
 
+    def test_unicode(self):
+        """Unicode values pass validation."""
+
+        valid_datetime_str = '2016-09-12T00:00:00.0Z'
+        valid_datetime = parse_datetime(valid_datetime_str)
+
+        with patch('manager_rest.rest.rest_decorators.request') as request:
+            data = [
+                (
+                    u'field,{0},{0}'.format(valid_datetime_str),
+                    {'field': {'from': valid_datetime, 'to': valid_datetime}},
+                ),
+                (
+                    u'field,{0},'.format(valid_datetime_str),
+                    {'field': {'from': valid_datetime}},
+                ),
+                (
+                    u'field,,{0}'.format(valid_datetime_str),
+                    {'field': {'to': valid_datetime}},
+                ),
+            ]
+
+            for (valid_value, expected_value) in data:
+                request.args.getlist.return_value = [valid_value]
+                rangeable(self.verify(expected_value))()
+
 
 @attr(client_min_version=2, client_max_version=base_test.LATEST_API_VERSION)
 class SortableTest(TestCase):

--- a/rest-service/manager_rest/test/endpoints/test_rest_decorators.py
+++ b/rest-service/manager_rest/test/endpoints/test_rest_decorators.py
@@ -76,15 +76,18 @@ class RangeableTest(TestCase):
 
     """Rangeable decorator test cases."""
 
+    def verify(self, expected_value):
+        """Verify range_filters arguments matches expected value."""
+        def verify_helper(range_filters):
+            self.assertDictEqual(range_filters, expected_value)
+            return Mock()
+        return verify_helper
+
     def test_empty(self):
         """No range arguments mapped to an empty dictionary."""
-        def verify(range_filters):
-            self.assertDictEqual(range_filters, {})
-            return Mock()
-
         with patch('manager_rest.rest.rest_decorators.request') as request:
             request.args.getlist.return_value = []
-            rangeable(verify)()
+            rangeable(self.verify({}))()
 
     def test_invalid(self):
         """Exception is raised for invalid values."""
@@ -109,12 +112,6 @@ class RangeableTest(TestCase):
             '20170316T123301Z',
         )
 
-        def verify(expected_value):
-            def verify_helper(range_filters):
-                self.assertDictEqual(range_filters, expected_value)
-                return Mock()
-            return verify_helper
-
         with patch('manager_rest.rest.rest_decorators.request') as request:
             for valid_datetime_str in valid_datetime_strs:
                 valid_value = 'field,{0},{0}'.format(valid_datetime_str)
@@ -127,19 +124,13 @@ class RangeableTest(TestCase):
                 }
 
                 request.args.getlist.return_value = [valid_value]
-                rangeable(verify(expected_value))()
+                rangeable(self.verify(expected_value))()
 
     def test_from_to_optional(self):
         """From/to are optional and validation passes if one is missing."""
 
         valid_datetime_str = '2016-09-12T00:00:00.0Z'
         valid_datetime = parse_datetime(valid_datetime_str)
-
-        def verify(expected_value):
-            def verify_helper(range_filters):
-                self.assertDictEqual(range_filters, expected_value)
-                return Mock()
-            return verify_helper
 
         with patch('manager_rest.rest.rest_decorators.request') as request:
             data = [
@@ -159,7 +150,7 @@ class RangeableTest(TestCase):
 
             for (valid_value, expected_value) in data:
                 request.args.getlist.return_value = [valid_value]
-                rangeable(verify(expected_value))()
+                rangeable(self.verify(expected_value))()
 
 
 @attr(client_min_version=2, client_max_version=base_test.LATEST_API_VERSION)

--- a/rest-service/manager_rest/test/endpoints/test_rest_decorators.py
+++ b/rest-service/manager_rest/test/endpoints/test_rest_decorators.py
@@ -99,8 +99,36 @@ class RangeableTest(TestCase):
                 with self.assertRaises(Invalid):
                     rangeable(Mock)()
 
-    def test_valid(self):
-        """Valid value should pass validation as expected."""
+    def test_iso8601_datetime(self):
+        """ISO8601 datetimes are valid and pass validation."""
+        valid_datetimes = (
+            '2017-03-16',
+            '2017-03-16T12:33:01+00:00',
+            '2017-03-16T12:33:01Z',
+            '20170316T123301Z',
+        )
+
+        def verify(expected_value):
+            def verify_helper(range_filters):
+                self.assertDictEqual(range_filters, expected_value)
+                return Mock()
+            return verify_helper
+
+        with patch('manager_rest.rest.rest_decorators.request') as request:
+            for valid_datetime in valid_datetimes:
+                expected_value = {
+                    'field': {
+                        'from': valid_datetime,
+                        'to': valid_datetime,
+                    }
+                }
+                valid_value = 'field,{0},{0}'.format(valid_datetime)
+
+                request.args.getlist.return_value = [valid_value]
+                rangeable(verify(expected_value))()
+
+    def test_from_to_optional(self):
+        """From/to are optional and validation passes if one is missing."""
 
         valid_datetime = '2016-09-12T00:00:00.0Z'
 

--- a/rest-service/manager_rest/test/endpoints/test_rest_decorators.py
+++ b/rest-service/manager_rest/test/endpoints/test_rest_decorators.py
@@ -17,6 +17,7 @@
 from unittest import TestCase
 
 
+from dateutil.parser import parse as parse_datetime
 from mock import Mock, patch, MagicMock
 from nose.plugins.attrib import attr
 from voluptuous import Invalid
@@ -101,7 +102,7 @@ class RangeableTest(TestCase):
 
     def test_iso8601_datetime(self):
         """ISO8601 datetimes are valid and pass validation."""
-        valid_datetimes = (
+        valid_datetime_strs = (
             '2017-03-16',
             '2017-03-16T12:33:01+00:00',
             '2017-03-16T12:33:01Z',
@@ -115,14 +116,15 @@ class RangeableTest(TestCase):
             return verify_helper
 
         with patch('manager_rest.rest.rest_decorators.request') as request:
-            for valid_datetime in valid_datetimes:
+            for valid_datetime_str in valid_datetime_strs:
+                valid_value = 'field,{0},{0}'.format(valid_datetime_str)
+                valid_datetime = parse_datetime(valid_datetime_str)
                 expected_value = {
                     'field': {
                         'from': valid_datetime,
                         'to': valid_datetime,
                     }
                 }
-                valid_value = 'field,{0},{0}'.format(valid_datetime)
 
                 request.args.getlist.return_value = [valid_value]
                 rangeable(verify(expected_value))()
@@ -130,7 +132,8 @@ class RangeableTest(TestCase):
     def test_from_to_optional(self):
         """From/to are optional and validation passes if one is missing."""
 
-        valid_datetime = '2016-09-12T00:00:00.0Z'
+        valid_datetime_str = '2016-09-12T00:00:00.0Z'
+        valid_datetime = parse_datetime(valid_datetime_str)
 
         def verify(expected_value):
             def verify_helper(range_filters):
@@ -141,15 +144,15 @@ class RangeableTest(TestCase):
         with patch('manager_rest.rest.rest_decorators.request') as request:
             data = [
                 (
-                    'field,{0},{0}'.format(valid_datetime),
+                    'field,{0},{0}'.format(valid_datetime_str),
                     {'field': {'from': valid_datetime, 'to': valid_datetime}},
                 ),
                 (
-                    'field,,{0}'.format(valid_datetime),
+                    'field,,{0}'.format(valid_datetime_str),
                     {'field': {'to': valid_datetime}},
                 ),
                 (
-                    'field,{0},'.format(valid_datetime),
+                    'field,{0},'.format(valid_datetime_str),
                     {'field': {'from': valid_datetime}},
                 ),
             ]


### PR DESCRIPTION
In this PR, support for empty values has been added back to the `rangeable` rest decorator. This means that instead filtering by `field,from,to`, it's possible not to include one of the `from`/`to` fields: `field,,to` or `field,from,`. This way it's possible to use the filter when only an upper/lower limit is needed.

Datetime parsing has been improved as well by using `dateutil.parser.parse` because from what I've seen the `Datetime` validator from `voluptuous` wasn't accepting iso8601 datetime which should be accepted by the events endpoint. 