### PR TITLE
CFY-6582 Fix problems related to docl

### DIFF
--- a/tests/integration_tests/framework/constants.py
+++ b/tests/integration_tests/framework/constants.py
@@ -23,3 +23,5 @@ BRANCH_NAME_CORE = 'BRANCH_NAME_CORE'
 ##########################################
 DOCL_CONTAINER_IP = 'DOCL_CONTAINER_IP'
 CLOUDIFY_REST_PORT = 'CLOUDIFY_REST_PORT'
+
+PLUGIN_STORAGE_DIR = '/opt/integration-plugin-storage'

--- a/tests/integration_tests/framework/docl.py
+++ b/tests/integration_tests/framework/docl.py
@@ -110,6 +110,7 @@ def init(expose=None, resources=None):
     :param resources: List of {'src':'', 'dst':''} dicts
     """
     docl_home = _docl_home()
+    resource_tar_name = 'cloudify-manager-resources.tar.gz'
     work_dir = os.path.join(docl_home, 'work')
     if not os.path.exists(docl_home):
         os.makedirs(docl_home)
@@ -117,10 +118,10 @@ def init(expose=None, resources=None):
         os.makedirs(work_dir)
     with open(os.path.expanduser('~/.docl/config.yaml')) as f:
         conf = yaml.safe_load(f)
-    resources_tar_path = os.path.join(conf['workdir'], 'resources.tar.gz')
+    resources_tar_path = os.path.join(conf['workdir'], resource_tar_name)
     if os.path.exists(resources_tar_path):
         os.symlink(resources_tar_path,
-                   os.path.join(work_dir, 'resources.tar.gz'))
+                   os.path.join(work_dir, resource_tar_name))
     conf['expose'] += list(expose or [])
     conf['resources'] += list(resources or [])
     conf['workdir'] = work_dir

--- a/tests/integration_tests/framework/env.py
+++ b/tests/integration_tests/framework/env.py
@@ -89,6 +89,12 @@ class BaseTestEnvironment(object):
             self.destroy()
             raise
 
+    @staticmethod
+    def _set_permissions():
+        docl.execute('chown -R mgmtworker:mgmtworker {0}'.format(
+            constants.PLUGIN_STORAGE_DIR
+        ))
+
     def on_environment_created(self):
         raise NotImplementedError
 
@@ -99,6 +105,7 @@ class BaseTestEnvironment(object):
         self.on_manager_created()
 
     def on_manager_created(self):
+        self._set_permissions()
         self.start_events_printer()
 
     def _build_resource_mapping(self):
@@ -115,7 +122,7 @@ class BaseTestEnvironment(object):
         # test can later read.
         resources = [{
             'src': self.plugins_storage_dir,
-            'dst': '/opt/integration-plugin-storage',
+            'dst': constants.PLUGIN_STORAGE_DIR,
             'write': True
         }]
 


### PR DESCRIPTION
* resources.tar.gz is now renamed to cloudify-manager-resources.tar.gz.
  This is due to the fact that the "cloudify-manager-resources" is used
  elsewhere in the code