### PR TITLE
CFY-6577 Fix agents upgrade after snapshot restore

### DIFF
--- a/resources/rest-service/cloudify/install_agent_template.py
+++ b/resources/rest-service/cloudify/install_agent_template.py
@@ -34,9 +34,7 @@ from cloudify.constants import CLOUDIFY_TOKEN_AUTHENTICATION_HEADER
 CELERY_CONFIG_ENV_VARS = ['CELERY_CONFIG_MODULE', 'CELERY_WORK_DIR',
                           'CELERY_BROKER_URL']
 
-
-REST_TOKEN = """{{ auth_token_value }}"""
-SSL_CERT_CONTENT = """{{ ssl_cert_content }}"""
+CREDENTIALS_URL = "{{ creds_url }}"
 
 
 def get_cloudify_agent():
@@ -54,6 +52,8 @@ class CommandRunner(object):
 
     def __init__(self, logger):
         self.logger = logger
+        self.rest_token = None
+        self._cert_file = get_local_rest_certificate()
 
     def run(self, command, execution_env=None):
         self.logger.debug('run: {0}'.format(command))
@@ -85,15 +85,9 @@ class CommandRunner(object):
     def download(self, url, destination=None):
         self.logger.debug('Retrieving file from {0}'.format(url))
 
-        # Overwrite the old certificate with the new manager's certificate
-        cert_file_location = get_local_rest_certificate()
-        with open(cert_file_location, 'w') as cert_file:
-            cert_file.write(SSL_CERT_CONTENT)
-
-        headers = {CLOUDIFY_TOKEN_AUTHENTICATION_HEADER: REST_TOKEN}
+        headers = {CLOUDIFY_TOKEN_AUTHENTICATION_HEADER: self.rest_token}
         response = requests.get(url, stream=True, headers=headers,
-                                verify=cert_file_location)
-
+                                verify=self._cert_file)
         if destination:
             destination_file = open(destination, 'wb')
         else:
@@ -105,6 +99,24 @@ class CommandRunner(object):
                 f.write(chunk)
 
         return destination
+
+    def download_credentials(self, destination):
+        # The credentials file resides in a location that doesn't require
+        # authorization, and we use verify=False to skip SSL verification
+        response = requests.get(CREDENTIALS_URL, stream=True, verify=False)
+        with open(destination, 'wb') as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+
+        # Load the credentials dict to memory
+        with open(destination, 'r') as f:
+            credentials = json.load(f)
+
+        # Overwrite the old certificate with the new manager's certificate
+        with open(self._cert_file, 'w') as cert_file:
+            cert_file.write(credentials['ssl_cert_content'])
+
+        self.rest_token = credentials['rest_token']
 
     def rm_dir(self, directory):
         shutil.rmtree(directory)
@@ -166,6 +178,8 @@ class Installer(object):
         path = tempfile.mkdtemp()
         try:
             package_path = os.path.join(path, self.runner.archive_name())
+            creds_path = os.path.join(path, 'creds.json')
+            self.runner.download_credentials(creds_path)
             self.runner.download(
                 url=self.cloudify_agent['package_url'],
                 destination=package_path)
@@ -177,9 +191,11 @@ class Installer(object):
             agent_cmd = self.runner.env_command(path, 'cfy-agent')
             command = ('{0} install-local'
                        ' --agent-file {1}'
-                       ' --output-agent-file {2}').format(
+                       ' --rest-token {2}'
+                       ' --output-agent-file {3}').format(
                            agent_cmd,
                            agent_config_path,
+                           self.runner.rest_token,
                            agent_output_path)
             self.runner.run(command)
             with open(agent_output_path) as agent_file:

--- a/resources/rest-service/cloudify/install_agent_template.py
+++ b/resources/rest-service/cloudify/install_agent_template.py
@@ -34,6 +34,7 @@ from cloudify.constants import CLOUDIFY_TOKEN_AUTHENTICATION_HEADER
 CELERY_CONFIG_ENV_VARS = ['CELERY_CONFIG_MODULE', 'CELERY_WORK_DIR',
                           'CELERY_BROKER_URL']
 
+# This variable will be filled in using a template during `install_new_agents`
 CREDENTIALS_URL = "{{ creds_url }}"
 
 
@@ -116,6 +117,7 @@ class CommandRunner(object):
         with open(self._cert_file, 'w') as cert_file:
             cert_file.write(credentials['ssl_cert_content'])
 
+        # Set the rest token, to be used later on to download other files
         self.rest_token = credentials['rest_token']
 
     def rm_dir(self, directory):

--- a/workflows/cloudify_system_workflows/snapshots/agents.py
+++ b/workflows/cloudify_system_workflows/snapshots/agents.py
@@ -18,6 +18,7 @@ import json
 
 from cloudify.workflows import ctx
 from cloudify.context import BootstrapContext
+from cloudify.utils import get_broker_ssl_cert_path
 
 from .utils import is_compute
 
@@ -51,6 +52,10 @@ class Agents(object):
     @staticmethod
     def _get_defaults(manager_version):
         broker_config = BootstrapContext(ctx.bootstrap_context).broker_config()
+        if not broker_config.get('broker_ssl_cert'):
+            with open(get_broker_ssl_cert_path(), 'r') as f:
+                broker_config['broker_ssl_cert'] = f.read()
+
         return {
             'version': str(manager_version),
             'broker_config': broker_config


### PR DESCRIPTION
The new agents upgrade process is as follows:
 * Upon issue of a `cfy agents install` command, a new
   `install_agent.py` script is rendered, with a REST token and the SSL
   certificate inside it.
 * It is then moved to a special location inside the file server
   (/resources/cloudify_agent), with a fresh UUID prepended to it.
 * The request is sent to the celery client on the agent machine,
   and processed by the worker thread there (this is as it was before)
 * The old agent downloads the script, which holds all the info
   necessary to update the SSL certificate, and then proceed to
   download and install the new agent package, as before