### PR TITLE
CFY-6408. Support more filter fields

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -46,7 +46,7 @@ class Events(SecuredResource):
 
     """Events resource.
 
-    Throgh the events endpoint a user can retrieve both events and logs as
+    Through the events endpoint a user can retrieve both events and logs as
     stored in the SQL database.
 
     """

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -94,7 +94,12 @@ class Events(SecuredResource):
                 continue
             if filter_field not in Events.ALLOWED_FILTERS:
                 raise manager_exceptions.BadParametersError(
-                    'Unknown field to filter by: {}'.format(filter_field))
+                    'Unknown field to filter by: {0}\n'
+                    'Allowed values: {1}'
+                    .format(
+                        filter_field,
+                        ', '.join(sorted(Events.ALLOWED_FILTERS.keys())),
+                    ))
             model_field, filter_type = Events.ALLOWED_FILTERS[filter_field]
             if isinstance(model_field, str):
                 model_field = getattr(model, model_field)
@@ -106,7 +111,10 @@ class Events(SecuredResource):
                     query = query.filter(model_field.ilike(filter_element))
             else:
                 raise ValueError(
-                    'Unknown filter type: {0}'.format(filter_type))
+                    'Unknown filter type: {0}\n'
+                    'Allowed values: ilike, in'
+                    .format(filter_type)
+                )
 
         return query
 

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -35,6 +35,7 @@ from manager_rest.rest.rest_utils import get_json_and_verify_params
 from manager_rest.security import SecuredResource
 from manager_rest.storage.models_base import db
 from manager_rest.storage.resource_models import (
+    Blueprint,
     Deployment,
     Execution,
     Event,
@@ -53,6 +54,7 @@ class Events(SecuredResource):
 
     DEFAULT_SEARCH_SIZE = 10000
     ALLOWED_FILTERS = {
+        'blueprint_id': Blueprint.id,
         'execution_id': Execution.id,
         'deployment_id': Deployment.id,
         'event_type': Event.event_type,
@@ -264,6 +266,7 @@ class Events(SecuredResource):
             db.session.query(
                 select_column('id'),
                 select_column('timestamp'),
+                Blueprint.id.label('blueprint_id'),
                 Deployment.id.label('deployment_id'),
                 Execution.id.label('execution_id'),
                 select_column('message'),
@@ -280,6 +283,7 @@ class Events(SecuredResource):
             .filter(
                 model._execution_fk == Execution._storage_id,
                 Execution._deployment_fk == Deployment._storage_id,
+                Deployment._blueprint_fk == Blueprint._storage_id,
             )
         )
 

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -94,7 +94,7 @@ class Events(SecuredResource):
                 continue
             if filter_field not in Events.ALLOWED_FILTERS:
                 raise manager_exceptions.BadParametersError(
-                    'Unknown field to filter by: {0}\n'
+                    'Unknown field to filter by: {0}. '
                     'Allowed values: {1}'
                     .format(
                         filter_field,
@@ -111,7 +111,7 @@ class Events(SecuredResource):
                     query = query.filter(model_field.ilike(filter_element))
             else:
                 raise ValueError(
-                    'Unknown filter type: {0}\n'
+                    'Unknown filter type: {0}. '
                     'Allowed values: ilike, in'
                     .format(filter_type)
                 )

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -257,11 +257,21 @@ class SelectEventsFilterTest(SelectEventsBaseTest):
             self.DEFAULT_SORT,
             self.DEFAULT_RANGE_FILTERS,
         )
-        events = query.params(**self.DEFAULT_PAGINATION).all()
-        self.assertTrue(all(
-            event.deployment_id == deployment.id
-            for event in events
-        ))
+        event_ids = [
+            event.id
+            for event in query.params(**self.DEFAULT_PAGINATION).all()
+        ]
+        expected_executions_id = [
+            execution._storage_id
+            for execution in self.executions
+            if execution._deployment_fk == deployment._storage_id
+        ]
+        expected_event_ids = [
+            event.id
+            for event in self.events
+            if event._execution_fk in expected_executions_id
+        ]
+        self.assertListEqual(event_ids, expected_event_ids)
 
     def test_filter_by_execution(self):
         """Filter events by execution."""
@@ -275,11 +285,16 @@ class SelectEventsFilterTest(SelectEventsBaseTest):
             self.DEFAULT_SORT,
             self.DEFAULT_RANGE_FILTERS,
         )
-        events = query.params(**self.DEFAULT_PAGINATION).all()
-        self.assertTrue(all(
-            event.execution_id == execution.id
-            for event in events
-        ))
+        event_ids = [
+            event.id
+            for event in query.params(**self.DEFAULT_PAGINATION).all()
+        ]
+        expected_event_ids = [
+            event.id
+            for event in self.events
+            if event._execution_fk == execution._storage_id
+        ]
+        self.assertListEqual(event_ids, expected_event_ids)
 
     def test_filter_by_event_type(self):
         """Filter events by event_type."""


### PR DESCRIPTION
In this PR, support for the following filters is added to the events endpoint: `blueprint_id`, `event_type`, `level` and `message`/`message.text`.

Note: For the `message`/`message.text` filter the `ILIKE` operator is used which is not equivalent to full text search. Consequently, even if filtering by message is supported, it is not equivalent in terms of functionality or performance to what it was available when data was indexed through Elasticsearch.