### PR TITLE
CFY 6280. Restore es_data into postgres

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -216,6 +216,7 @@ class Event(DerivedResource):
         return one_to_many_relationship(cls, Execution, cls._execution_fk)
 
     execution_id = association_proxy('execution', 'id')
+    _tenant_id = association_proxy('execution', '_tenant_id')
 
     @hybrid_property
     def parent(self):
@@ -247,6 +248,7 @@ class Log(DerivedResource):
         return one_to_many_relationship(cls, Execution, cls._execution_fk)
 
     execution_id = association_proxy('execution', 'id')
+    _tenant_id = association_proxy('execution', '_tenant_id')
 
     @hybrid_property
     def parent(self):

--- a/workflows/cloudify_system_workflows/snapshots/estopg.py
+++ b/workflows/cloudify_system_workflows/snapshots/estopg.py
@@ -42,6 +42,7 @@ class EsToPg(object):
         self._plugins_path = '{0}.plugins'.format(es_dump_path)
         self._executions_path = '{0}.executions'.format(es_dump_path)
         self._events_path = '{0}.events'.format(es_dump_path)
+        self._logs_path = '{0}.logs'.format(es_dump_path)
 
     def _get_storage_manager(self, tenant_name):
         app = setup_flask_app()
@@ -188,6 +189,7 @@ class EsToPg(object):
         dump_files['executions'] = open(self._executions_path, 'w')
         dump_files['plugins'] = open(self._plugins_path, 'w')
         dump_files['events'] = open(self._events_path, 'w')
+        dump_files['logs'] = open(self._logs_path, 'w')
         for line in open(self._es_dump_path, 'r'):
             try:
                 elem = json.loads(line)
@@ -210,9 +212,10 @@ class EsToPg(object):
                     dump_files['executions'].write(line)
                 elif node_type == 'plugin':
                     dump_files['plugins'].write(line)
-                elif node_type in ['cloudify_event',
-                                   'cloudify_log']:
+                elif node_type == 'cloudify_event':
                     dump_files['events'].write(line)
+                elif node_type == 'cloudify_log':
+                    dump_files['logs'].write(line)
                 else:
                     raise Exception('Undefined type {0}'.format(node_type))
             except Exception as ex:

--- a/workflows/cloudify_system_workflows/snapshots/estopg.py
+++ b/workflows/cloudify_system_workflows/snapshots/estopg.py
@@ -18,7 +18,6 @@ import sys
 import json
 import logging
 import argparse
-from shutil import move
 
 from manager_rest.flask_utils import setup_flask_app
 from manager_rest.constants import CURRENT_TENANT_CONFIG, DEFAULT_TENANT_NAME
@@ -221,8 +220,6 @@ class EsToPg(object):
                 continue
         for index, dump_file in dump_files.items():
             dump_file.close()
-        move(self._es_dump_path, '{0}.backup'.format(self._es_dump_path))
-        move(self._events_path, self._es_dump_path)
 
     def _update_deployment(self, dep_dict):
         workflows = dep_dict['workflows']

--- a/workflows/cloudify_system_workflows/snapshots/estopg.py
+++ b/workflows/cloudify_system_workflows/snapshots/estopg.py
@@ -217,7 +217,7 @@ class EsToPg(object):
             try:
                 execution = self._storage_manager.get(
                     models.Execution,
-                    es_log['context']['execution_id'],
+                    execution_id,
                 )
             except manager_exceptions.NotFoundError:
                 logger.warning(

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -87,7 +87,6 @@ class SnapshotRestore(object):
             with Postgres(self._config) as postgres:
                 self._restore_db(postgres)
                 self._restore_files_to_manager()
-                self._restore_events(metadata)
                 self._restore_plugins(existing_plugins)
                 self._restore_influxdb()
                 self._restore_credentials(postgres)
@@ -226,18 +225,6 @@ class SnapshotRestore(object):
             plugin['distribution'] == dist,
             plugin['distribution_release'] == release
         ]))
-
-    def _restore_events(self, metadata):
-        ctx.logger.warning('NOT IMPLEMENTED. '
-                           'Events are now stored in pg, not es')
-        # ctx.logger.info('Restoring ElasticSearch data '
-        #                 '[timeout={0} sec]'.format(self._timeout))
-        # ElasticSearch().restore_logs_and_events(
-        #     es,
-        #     self._tempdir,
-        #     metadata,
-        #     bulk_read_timeout=self._timeout
-        # )
 
     def _restore_influxdb(self):
         ctx.logger.info('Restoring InfluxDB metrics')

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -83,12 +83,11 @@ class SnapshotRestore(object):
 
             existing_plugins = self._get_existing_plugin_names()
             existing_dep_envs = self._get_existing_dep_envs()
-            es = utils.get_es_client(self._config)
 
             with Postgres(self._config) as postgres:
                 self._restore_db(postgres)
                 self._restore_files_to_manager()
-                self._restore_events(es, metadata)
+                self._restore_events(metadata)
                 self._restore_plugins(existing_plugins)
                 self._restore_influxdb()
                 self._restore_credentials(postgres)
@@ -228,7 +227,7 @@ class SnapshotRestore(object):
             plugin['distribution_release'] == release
         ]))
 
-    def _restore_events(self, es, metadata):
+    def _restore_events(self, metadata):
         ctx.logger.warning('NOT IMPLEMENTED. '
                            'Events are now stored in pg, not es')
         # ctx.logger.info('Restoring ElasticSearch data '

--- a/workflows/cloudify_system_workflows/snapshots/utils.py
+++ b/workflows/cloudify_system_workflows/snapshots/utils.py
@@ -20,8 +20,6 @@ import shutil
 import subprocess
 import zipfile
 
-from elasticsearch import Elasticsearch
-
 from cloudify import constants
 from cloudify.workflows import ctx
 from cloudify.utils import ManagerVersion
@@ -147,11 +145,6 @@ def run(command, ignore_failures=False, redirect_output_path=None):
                 command_str, proc.aggr_stderr)
             raise RuntimeError(msg)
     return proc
-
-
-def get_es_client(config):
-    return Elasticsearch(hosts=[{'host': config.db_address,
-                                 'port': int(config.db_port)}])
 
 
 def get_manager_version(client):


### PR DESCRIPTION
In this PR, the ability to restore events/logs from a 3.4.2 snapshot into a 4.0 manager has been added.

It has been tested by creating a snapshot in a 3.4.2 manager and restoring it in a 4.0 one. After that the events/logs could be retrieved for the new tenant created during the restore process.

The only thing that looks weird is that the `restore_snapshot` execution remains with `started` state after the restore has finished. I've verified that this happens also with the current code in `master`, so it's not related to this branch.  In any case, it would be worth investigating it.