### PR TITLE
CFY 6332. Fix search event message integration test

### DIFF
--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -367,7 +367,7 @@ class SelectEventsFilterTest(SelectEventsBaseTest):
         self.assertListEqual(event_ids, expected_event_ids)
 
     def test_filter_by_message(self):
-        """Filter events by message.text."""
+        """Filter events by message."""
         self.filter_by_message_helper('message')
 
     def test_filter_by_message_text(self):

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -13,8 +13,6 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-import re
-
 from integration_tests import AgentlessTestCase
 from integration_tests.tests.utils import get_resource as resource
 
@@ -81,24 +79,6 @@ class EventsTest(AgentlessTestCase):
         message = '+ - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /'
         self._events_list(message=message,
                           skip_assertion=True)
-
-    def test_search_event_message_with_reserved_characters(self):
-        from manager_rest.storage.manager_elasticsearch import \
-            RESERVED_CHARS_REGEX
-
-        # expecting to find a message containing 'dummy workflow'
-        message = 'dum-my *low: ++**'
-        searched_events = self._events_list(message=message,
-                                            include_logs=True)
-        message_without_reserved_chars = \
-            re.sub(RESERVED_CHARS_REGEX, '', message)
-
-        keywords = message_without_reserved_chars.lower().split()
-
-        # assert some search results contain requested message
-        for event in searched_events:
-            text = event['message']['text'].lower()
-            self.assertTrue(all([keyword in text for keyword in keywords]))
 
     def test_search_event_message(self):
         all_events = self._events_list()

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -103,13 +103,16 @@ class EventsTest(AgentlessTestCase):
     def test_search_event_message(self):
         all_events = self._events_list()
         # checking partial word and case insensitivity ('sending')
-        message = 'SeNdIN'
+        raw_message = 'SeNdIN'
+        message = '%{}%'.format(raw_message)
         searched_events = self._events_list(message=message)
         # assert the search actually returned a partial result
         self.assertLess(len(searched_events), len(all_events))
         # assert all search results are relevant
         for event in searched_events:
-            self.assertIn(message.lower(), event['message']['text'].lower())
+            self.assertIn(
+                raw_message.lower(),
+                event['message']['text'].lower())
 
     def test_list_with_include_option(self):
         _include = ['@timestamp', 'type']


### PR DESCRIPTION
In this PR the problem with integration tests using the `message` parameter have been fixed by:
- Updating the query syntax to the one using the `LIKE` operator
- Removing the test case that was testing Elasticsearch query details that no longer apply