### PR TITLE
CFY 6645. Use outer joins to allow for empty node values

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -326,9 +326,9 @@ class Events(SecuredResource):
                 model._execution_fk == Execution._storage_id,
                 Execution._deployment_fk == Deployment._storage_id,
                 Deployment._blueprint_fk == Blueprint._storage_id,
-                model.node_id == NodeInstance.id,
-                NodeInstance._node_fk == Node._storage_id,
             )
+            .outerjoin(NodeInstance, NodeInstance.id == model.node_id)
+            .outerjoin(Node, Node._storage_id == NodeInstance._node_fk)
         )
 
         query = Events._apply_filters(query, model, filters)

--- a/rest-service/manager_rest/rest/resources_v2/events.py
+++ b/rest-service/manager_rest/rest/resources_v2/events.py
@@ -91,9 +91,11 @@ class Events(resources_v1.Events):
         :rtype: :class:`manager_rest.storage.storage_manager.ListResult`
 
         """
+        size = pagination.get('size', self.DEFAULT_SEARCH_SIZE)
+        offset = pagination.get('offset', 0)
         params = {
-            'limit': pagination.get('size', self.DEFAULT_SEARCH_SIZE),
-            'offset': pagination.get('offset', 0),
+            'limit': size,
+            'offset': offset,
         }
 
         count_query = self._build_count_query(filters, range_filters)
@@ -107,7 +109,11 @@ class Events(resources_v1.Events):
         ]
 
         metadata = {
-            'pagination': dict(pagination, total=total)
+            'pagination': {
+                'size': size,
+                'offset': offset,
+                'total': total,
+            }
         }
         return ListResult(results, metadata)
 

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -676,42 +676,6 @@ class BuildSelectQueryTest(TestCase):
         'range_filters': {},
     }
 
-    def setUp(self):
-        """Patch flask application.
-
-        The application is only used to write to logs, so it can be patched for
-        unit testing.
-
-        """
-        db_patcher = patch('manager_rest.rest.resources_v1.events.db')
-        self.db = db_patcher.start()
-
-        # Set column descriptions (used by sorting functionality)
-        column_descriptions = [
-                {'name': 'timestamp'},
-        ]
-        select_query = (
-            self.db.session.query().filter().outerjoin().outerjoin())
-        select_query.column_descriptions = column_descriptions
-        select_query.union().column_descriptions = column_descriptions
-        self.addCleanup(db_patcher.stop)
-
-    def test_from_events(self):
-        """Query against events table."""
-        Events._build_select_query(**self.DEFAULT_PARAMS)
-        select_query = (
-            self.db.session.query().filter().outerjoin().outerjoin().union)
-        self.assertLessEqual(select_query.call_count, 1)
-
-    def test_from_logs(self):
-        """Query against both events and logs tables."""
-        params = deepcopy(self.DEFAULT_PARAMS)
-        params['filters']['type'].append('cloudify_log')
-        Events._build_select_query(**params)
-        select_query = (
-            self.db.session.query().filter().outerjoin().outerjoin().union)
-        self.assertGreater(select_query.call_count, 1)
-
     def test_filter_required(self):
         """Filter parameter is expected to be dictionary."""
         params = deepcopy(self.DEFAULT_PARAMS)

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -690,29 +690,27 @@ class BuildSelectQueryTest(TestCase):
         column_descriptions = [
                 {'name': 'timestamp'},
         ]
-        self.db.session.query().filter().column_descriptions = (
-            column_descriptions)
-        self.db.session.query().filter().union().column_descriptions = (
-            column_descriptions)
+        select_query = (
+            self.db.session.query().filter().outerjoin().outerjoin())
+        select_query.column_descriptions = column_descriptions
+        select_query.union().column_descriptions = column_descriptions
         self.addCleanup(db_patcher.stop)
 
     def test_from_events(self):
         """Query against events table."""
         Events._build_select_query(**self.DEFAULT_PARAMS)
-        self.assertLessEqual(
-            self.db.session.query().filter().union.call_count,
-            1,
-        )
+        select_query = (
+            self.db.session.query().filter().outerjoin().outerjoin().union)
+        self.assertLessEqual(select_query.call_count, 1)
 
     def test_from_logs(self):
         """Query against both events and logs tables."""
         params = deepcopy(self.DEFAULT_PARAMS)
         params['filters']['type'].append('cloudify_log')
         Events._build_select_query(**params)
-        self.assertGreater(
-            self.db.session.query().filter().union.call_count,
-            1,
-        )
+        select_query = (
+            self.db.session.query().filter().outerjoin().outerjoin().union)
+        self.assertGreater(select_query.call_count, 1)
 
     def test_filter_required(self):
         """Filter parameter is expected to be dictionary."""


### PR DESCRIPTION
In #785 a problem was introduced because `Node` and `NodeInstance` model were added to the events query. What happens is that the event count doesn't match the event list actually returned because the query discards events for which no `Node` or `NodeInstance` is set.

In this PR, that problem is solved using outer joins.