### PR TITLE
CFY 6648. Remove unused fields from events

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3.py
+++ b/rest-service/manager_rest/rest/resources_v3.py
@@ -658,6 +658,9 @@ class Events(v2_Events):
     stored in the SQL database.
 
     """
+
+    UNUSED_FIELDS = ['id', 'node_id', 'message_code']
+
     @staticmethod
     def _map_event_to_dict(_include, sql_event):
         """Map event to a dictionary to be sent as an API response.
@@ -681,8 +684,9 @@ class Events(v2_Events):
         }
         event['reported_timestamp'] = event['timestamp']
 
-        if 'node_id' in event:
-            del event['node_id']
+        for unused_field in Events.UNUSED_FIELDS:
+            if unused_field in event:
+                del event[unused_field]
 
         if event['type'] == 'cloudify_event':
             del event['logger']

--- a/rest-service/manager_rest/test/endpoints/test_events_v3.py
+++ b/rest-service/manager_rest/test/endpoints/test_events_v3.py
@@ -56,7 +56,6 @@ class MapEventToDictTestV3(TestCase):
             'timestamp': '2016-12-09T00:00Z',
             'reported_timestamp': '2016-12-09T00:00Z',
             'message': '<message>',
-            'message_code': None,
             'type': 'cloudify_event',
         }
 
@@ -92,7 +91,6 @@ class MapEventToDictTestV3(TestCase):
             'timestamp': '2016-12-09T00:00Z',
             'reported_timestamp': '2016-12-09T00:00Z',
             'message': '<message>',
-            'message_code': None,
             'type': 'cloudify_log',
             'logger': '<logger>',
         }


### PR DESCRIPTION
In this PR, unused fields (`id` and `message_code`) are removed from events endpoint in API v3.