### PR TITLE
CFY 6652. Serialize timestamps using manager timezone

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -14,8 +14,6 @@
 #  * limitations under the License.
 #
 
-from datetime import datetime
-
 from flask_restful_swagger import swagger
 from sqlalchemy import (
     asc,
@@ -465,10 +463,6 @@ class Events(SecuredResource):
             del event['level']
         elif event['type'] == 'cloudify_log':
             del event['event_type']
-
-        for key, value in event.items():
-            if isinstance(value, datetime):
-                event[key] = '{}Z'.format(value.isoformat()[:-3])
 
         # Keep only keys passed in the _include request argument
         # TBD: Do the projection at the database level

--- a/rest-service/manager_rest/rest/resources_v3.py
+++ b/rest-service/manager_rest/rest/resources_v3.py
@@ -14,8 +14,6 @@
 #  * limitations under the License.
 #
 
-from datetime import datetime
-
 from flask_security import current_user
 from flask import current_app, request
 from toolz import dicttoolz
@@ -693,10 +691,6 @@ class Events(v2_Events):
             del event['level']
         elif event['type'] == 'cloudify_log':
             del event['event_type']
-
-        for key, value in event.items():
-            if isinstance(value, datetime):
-                event[key] = '{}Z'.format(value.isoformat()[:-3])
 
         # Keep only keys passed in the _include request argument
         # TBD: Do the projection at the database level

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -22,7 +22,11 @@ from manager_rest.utils import classproperty
 from manager_rest.rest.responses import Workflow
 from manager_rest.deployment_update.constants import ACTION_TYPES, ENTITY_TYPES
 
-from .models_base import db, UTCDateTime
+from .models_base import (
+    db,
+    LocalDateTime,
+    UTCDateTime,
+)
 from .relationships import foreign_key, one_to_many_relationship
 from .resource_models_base import (TopLevelResource,
                                    DerivedResource,
@@ -202,7 +206,7 @@ class Event(DerivedResource):
 
     __tablename__ = 'events'
 
-    timestamp = db.Column(UTCDateTime, nullable=False, index=True)
+    timestamp = db.Column(LocalDateTime, nullable=False, index=True)
     message = db.Column(db.Text)
     message_code = db.Column(db.Text)
     event_type = db.Column(db.Text)
@@ -233,7 +237,7 @@ class Log(DerivedResource):
 
     __tablename__ = 'logs'
 
-    timestamp = db.Column(UTCDateTime, nullable=False, index=True)
+    timestamp = db.Column(LocalDateTime, nullable=False, index=True)
     message = db.Column(db.Text)
     message_code = db.Column(db.Text)
     logger = db.Column(db.Text)

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -14,7 +14,6 @@
 
 from collections import namedtuple
 from copy import deepcopy
-from datetime import datetime
 from random import choice
 from unittest import TestCase
 
@@ -730,7 +729,7 @@ class MapEventToDictTestV1(TestCase):
     def test_map_event(self):
         """Map event as returned by SQL query to elasticsearch style output."""
         sql_event = EventResult(
-            timestamp=datetime(2016, 12, 9),
+            timestamp='2016-12-09T00:00Z',
             deployment_id='<deployment_id>',
             execution_id='<execution_id>',
             workflow_id='<workflow_id>',
@@ -771,7 +770,7 @@ class MapEventToDictTestV1(TestCase):
     def test_map_log(self):
         """Map log as returned by SQL query to elasticsearch style output."""
         sql_log = EventResult(
-            timestamp=datetime(2016, 12, 9),
+            timestamp='2016-12-09T00:00Z',
             deployment_id='<deployment_id>',
             execution_id='<execution_id>',
             workflow_id='<workflow_id>',

--- a/rest-service/manager_rest/test/endpoints/test_events_v3.py
+++ b/rest-service/manager_rest/test/endpoints/test_events_v3.py
@@ -12,7 +12,6 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from datetime import datetime
 from unittest import TestCase
 
 from nose.plugins.attrib import attr
@@ -30,7 +29,7 @@ class MapEventToDictTestV3(TestCase):
     def test_map_event(self):
         """Map event as returned by SQL query to elasticsearch style output."""
         sql_event = EventResult(
-            timestamp=datetime(2016, 12, 9),
+            timestamp='2016-12-09T00:00Z',
             deployment_id='<deployment_id>',
             execution_id='<execution_id>',
             workflow_id='<workflow_id>',
@@ -65,7 +64,7 @@ class MapEventToDictTestV3(TestCase):
     def test_map_log(self):
         """Map log as returned by SQL query to elasticsearch style output."""
         sql_log = EventResult(
-            timestamp=datetime(2016, 12, 9),
+            timestamp='2016-12-09T00:00Z',
             deployment_id='<deployment_id>',
             execution_id='<execution_id>',
             workflow_id='<workflow_id>',

--- a/rest-service/manager_rest/test/endpoints/test_models_base.py
+++ b/rest-service/manager_rest/test/endpoints/test_models_base.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+
+from datetime import datetime
+from unittest import TestCase
+
+from dateutil import tz
+from mock import patch
+from nose.plugins.attrib import attr
+
+from manager_rest.storage.models_base import LocalDateTime
+
+
+@attr(client_min_version=1, client_max_version=1)
+class LocalDateTimeTest(TestCase):
+
+    """Verify local datetime serialization."""
+
+    def _test_datetime(self, timezone, db_value, expected_value):
+        """Test datetime serialization helper."""
+        local_date_time = LocalDateTime()
+
+        with patch('manager_rest.storage.models_base.tz.tzlocal') as tz_local:
+            tz_local.return_value = timezone
+            value = local_date_time.process_result_value(db_value, None)
+        self.assertEqual(value, expected_value)
+
+    def test_utc(self):
+        """UTC datetime is serialized using Z for the timezone."""
+        self._test_datetime(
+            tz.gettz('UTC'),
+            datetime(2016, 12, 9, 8, 12, 34, 567890),
+            '2016-12-09T08:12:34.567Z',
+        )
+
+    def test_utc_zero_milliseconds(self):
+        """UTC datetime with zero milliseconds is serialized."""
+        self._test_datetime(
+            tz.gettz('UTC'),
+            datetime(2016, 12, 9, 8, 12, 34, 0),
+            '2016-12-09T08:12:34.000Z',
+        )
+
+    def test_asia_jerusalem(self):
+        """Jerusalem datetime is serialized using time zone offset."""
+        self._test_datetime(
+            tz.gettz('Asia/Jerusalem'),
+            datetime(2016, 12, 9, 8, 12, 34, 567890),
+            '2016-12-09T10:12:34.567+02:00',
+        )
+
+    def test_asia_jerusalem_zero_milliseconds(self):
+        """Jerusalem datetime with zero milliseconds is serialized."""
+        self._test_datetime(
+            tz.gettz('Asia/Jerusalem'),
+            datetime(2016, 12, 9, 8, 12, 34, 0),
+            '2016-12-09T10:12:34.000+02:00',
+        )


### PR DESCRIPTION
In this PR, timestamps for events and logs are updated, so that when they are serialized the timezone in which the manager machine is configured is taken into account.

For example, if the manager is in UTC:
`2017-03-22 11:42:30.032  CFY <linuxdp1> 'install' workflow execution succeeded`

if the manager is in `Asia/Jerusalem`:
`2017-03-22 13:42:30.032+02:00  CFY <linuxdp1> 'install' workflow execution succeeded`

and if the manager is in `America/New_York`:
`2017-03-22 07:42:30.032000-04:00  CFY <linuxdp1> 'install' workflow execution succeeded`