### PR TITLE
CFY-6647 Add reported_timestamp field and set default to timestamp

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -14,6 +14,7 @@
 #  * limitations under the License.
 
 from flask_restful import fields as flask_fields
+from sqlalchemy import func
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -192,7 +193,13 @@ class Event(SQLResourceBase):
 
     __tablename__ = 'events'
 
-    timestamp = db.Column(LocalDateTime, nullable=False, index=True)
+    timestamp = db.Column(
+        LocalDateTime,
+        server_default=func.current_timestamp(),
+        nullable=False,
+        index=True,
+    )
+    reported_timestamp = db.Column(LocalDateTime, nullable=False)
     message = db.Column(db.Text)
     message_code = db.Column(db.Text)
     event_type = db.Column(db.Text)
@@ -218,7 +225,13 @@ class Log(SQLResourceBase):
 
     __tablename__ = 'logs'
 
-    timestamp = db.Column(LocalDateTime, nullable=False, index=True)
+    timestamp = db.Column(
+        LocalDateTime,
+        server_default=func.current_timestamp(),
+        nullable=False,
+        index=True,
+    )
+    reported_timestamp = db.Column(LocalDateTime, nullable=False)
     message = db.Column(db.Text)
     message_code = db.Column(db.Text)
     logger = db.Column(db.Text)

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -199,6 +199,7 @@ class SelectEventsBaseTest(TestCase):
             return Event(
                 id='event_{}'.format(fake.uuid4()),
                 timestamp=fake.date_time(),
+                reported_timestamp=fake.date_time(),
                 _execution_fk=choice(executions)._storage_id,
                 _tenant_id=choice(executions)._tenant_id,
                 _creator_id=choice(executions)._creator_id,
@@ -214,6 +215,7 @@ class SelectEventsBaseTest(TestCase):
             return Log(
                 id='log_{}'.format(fake.uuid4()),
                 timestamp=fake.date_time(),
+                reported_timestamp=fake.date_time(),
                 _execution_fk=choice(executions)._storage_id,
                 _tenant_id=choice(executions)._tenant_id,
                 _creator_id=choice(executions)._creator_id,


### PR DESCRIPTION
In this PR, the schema for `Event` and `Log` is updated to add the `reported_timestamp` field and a default value is set to `timestamp` to set it to `current_timestamp` when a new record is inserted.

Related: cloudify-cosmo/cloudify-manager-blueprints#528