### PR TITLE
CFY 6408. Fix filter by type

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -377,12 +377,14 @@ class Events(SecuredResource):
             'Filters is expected to be a dictionary'
 
         subqueries = []
-        if 'type' not in filters or 'cloudify_event' in filters['type']:
+        if (('type' not in filters or 'cloudify_event' in filters['type']) and
+                ('level' not in filters)):
             events_query = Events._build_count_subquery(
                 Event, filters, range_filters)
             subqueries.append(events_query)
 
-        if 'type' not in filters or 'cloudify_log' in filters['type']:
+        if (('type' not in filters or 'cloudify_log' in filters['type']) and
+                ('event_type' not in filters)):
             logs_query = Events._build_count_subquery(
                 Log, filters, range_filters)
             subqueries.append(logs_query)
@@ -418,6 +420,7 @@ class Events(SecuredResource):
             .filter(
                 model._execution_fk == Execution._storage_id,
                 Execution._deployment_fk == Deployment._storage_id,
+                Deployment._blueprint_fk == Blueprint._storage_id,
             )
         )
 

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -387,7 +387,14 @@ class Events(SecuredResource):
                 Log, filters, range_filters)
             subqueries.append(logs_query)
 
-        query = db.session.query(sum(subqueries))
+        if subqueries:
+            query = db.session.query(sum(subqueries))
+        else:
+            query = (
+                db.session.query(func.count('*').label('count'))
+                .filter(Event.timestamp is None)
+            )
+
         return query
 
     @staticmethod

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -257,13 +257,21 @@ class Events(SecuredResource):
                 Log, filters, range_filters)
             subqueries.append(logs_query)
 
-        query = reduce(lambda left, right: left.union(right), subqueries)
-        query = Events._apply_sort(query, sort)
-        query = (
-            query
-            .limit(bindparam('limit'))
-            .offset(bindparam('offset'))
-        )
+        if subqueries:
+            query = reduce(lambda left, right: left.union(right), subqueries)
+            query = Events._apply_sort(query, sort)
+            query = (
+                query
+                .limit(bindparam('limit'))
+                .offset(bindparam('offset'))
+            )
+        else:
+            # Simple query that returns no results
+            # Used when filtering by a field that doesn't exist for a type
+            query = (
+                db.session.query(Event.timestamp)
+                .filter(Event.timestamp is None)
+            )
 
         return query
 

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -358,15 +358,24 @@ class SelectEventsFilterTest(SelectEventsBaseTest):
             'event_type': [event_type],
             'type': ['cloudify_log']
         }
+
         query = EventsV1._build_select_query(
             filters,
             self.DEFAULT_SORT,
             self.DEFAULT_RANGE_FILTERS,
         )
         events = query.params(**self.DEFAULT_PAGINATION).all()
+
+        count_query = EventsV1._build_count_query(
+            filters,
+            self.DEFAULT_RANGE_FILTERS,
+        )
+        event_count = count_query.params(**self.DEFAULT_RANGE_FILTERS).scalar()
+
         # logs don't have event_type, so query should return no results
         expected_events = []
         self.assertListEqual(events, expected_events)
+        self.assertEqual(event_count, len(expected_events))
 
     def test_filter_by_level(self):
         """Filter events by level."""
@@ -397,15 +406,24 @@ class SelectEventsFilterTest(SelectEventsBaseTest):
             'level': [level],
             'type': ['cloudify_event']
         }
+
         query = EventsV1._build_select_query(
             filters,
             self.DEFAULT_SORT,
             self.DEFAULT_RANGE_FILTERS,
         )
         events = query.params(**self.DEFAULT_PAGINATION).all()
+
+        count_query = EventsV1._build_count_query(
+            filters,
+            self.DEFAULT_RANGE_FILTERS,
+        )
+        event_count = count_query.params(**self.DEFAULT_RANGE_FILTERS).scalar()
+
         # events don't have level, so query should return no results
         expected_events = []
         self.assertListEqual(events, expected_events)
+        self.assertEqual(event_count, len(expected_events))
 
     def filter_by_message_helper(self, message_field):
         """Filter events by message field."""

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -351,6 +351,23 @@ class SelectEventsFilterTest(SelectEventsBaseTest):
         expected_event_ids = [event.id for event in expected_events]
         self.assertListEqual(event_ids, expected_event_ids)
 
+    def test_filter_by_event_type_and_type_cloudify_log(self):
+        """Filter events by even_type and type cloudify_log."""
+        event_type = choice(self.EVENT_TYPES)
+        filters = {
+            'event_type': [event_type],
+            'type': ['cloudify_log']
+        }
+        query = EventsV1._build_select_query(
+            filters,
+            self.DEFAULT_SORT,
+            self.DEFAULT_RANGE_FILTERS,
+        )
+        events = query.params(**self.DEFAULT_PAGINATION).all()
+        # logs don't have event_type, so query should return no results
+        expected_events = []
+        self.assertListEqual(events, expected_events)
+
     def test_filter_by_level(self):
         """Filter events by level."""
         level = choice(self.LOG_LEVELS)
@@ -372,6 +389,23 @@ class SelectEventsFilterTest(SelectEventsBaseTest):
         ]
         expected_event_ids = [event.id for event in expected_events]
         self.assertListEqual(event_ids, expected_event_ids)
+
+    def test_filter_by_level_and_type_cloudify_event(self):
+        """Filter events by level and type cloudify_event."""
+        level = choice(self.LOG_LEVELS)
+        filters = {
+            'level': [level],
+            'type': ['cloudify_event']
+        }
+        query = EventsV1._build_select_query(
+            filters,
+            self.DEFAULT_SORT,
+            self.DEFAULT_RANGE_FILTERS,
+        )
+        events = query.params(**self.DEFAULT_PAGINATION).all()
+        # events don't have level, so query should return no results
+        expected_events = []
+        self.assertListEqual(events, expected_events)
 
     def filter_by_message_helper(self, message_field):
         """Filter events by message field."""


### PR DESCRIPTION
When an impossible filter condition was passed (such as `event_type` and `cloudify_log` or `level` and `cloudify_event`), the rest server crashed because no query was generated.

In this PR, this is fix by returning a simple query that always returns an empty result set.