### PR TITLE
CFY-6479 Add error_causes column to event model

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -198,6 +198,7 @@ class Event(SQLResourceBase):
     event_type = db.Column(db.Text)
     operation = db.Column(db.Text)
     node_id = db.Column(db.Text)
+    error_causes = db.Column(db.Text)
 
     _execution_fk = foreign_key(Execution._storage_id)
 


### PR DESCRIPTION
In this PR, the `error_causes` column is added to the event model.

The column type is set to text for now even though the content will be JSON data. The deserialization code will be submitted in a separate PR.