### PR TITLE
CFY 6479. Fix test execution logging

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -317,6 +317,7 @@ class Events(SecuredResource):
                 Execution.workflow_id.label('workflow_id'),
                 select_column('message'),
                 select_column('message_code'),
+                select_column('error_causes'),
                 select_column('event_type'),
                 select_column('operation'),
                 select_column('node_id'),

--- a/rest-service/manager_rest/storage/models_base.py
+++ b/rest-service/manager_rest/storage/models_base.py
@@ -13,6 +13,7 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
+import json
 import re
 
 from collections import OrderedDict
@@ -86,6 +87,30 @@ class LocalDateTime(UTCDateTime):
             serialized_datetime = transformation(serialized_datetime)
 
         return serialized_datetime
+
+
+class JSONString(db.TypeDecorator):
+
+    """A json object stored as a string.
+
+    json encoding/decoding is handled by SQLAlchemy, so this type is database
+    agnostic and is not affected by differences in underlying JSON types
+    implementations.
+
+    """
+
+    impl = db.Text
+
+    def process_bind_param(self, value, dialect):
+        """Encode object to a string before inserting into database."""
+        return json.dumps(value)
+
+    def process_result_value(self, value, engine):
+        """Decode string to an object after selecting from database."""
+        if value is None:
+            return
+
+        return json.loads(value)
 
 
 class CIColumn(db.Column):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -25,6 +25,7 @@ from manager_rest.deployment_update.constants import ACTION_TYPES, ENTITY_TYPES
 
 from .models_base import (
     db,
+    JSONString,
     LocalDateTime,
     UTCDateTime,
 )
@@ -205,7 +206,7 @@ class Event(SQLResourceBase):
     event_type = db.Column(db.Text)
     operation = db.Column(db.Text)
     node_id = db.Column(db.Text)
-    error_causes = db.Column(db.Text)
+    error_causes = db.Column(JSONString)
 
     _execution_fk = foreign_key(Execution._storage_id)
 

--- a/tests/integration_tests/tests/agentless_tests/test_execution_logging.py
+++ b/tests/integration_tests/tests/agentless_tests/test_execution_logging.py
@@ -80,26 +80,20 @@ class ExecutionLoggingTest(AgentlessTestCase):
             causes_assert('Causes', user_cause_events)
             causes_assert('RuntimeError: ERROR_MESSAGE', user_cause_events)
 
-        # In the following asserts, that uses the `expect_traceback_wip`,
-        # the `expect_traceback` parameter should be True.
-        # But, since moving events logs to pg is a WIP, the test fails.
-        # Need to return it to True once the events to pg task is completed.
-        expect_traceback_wip = False
-
         assert_output(verbosity=[],  # sh handles '' as an argument, but not []
                       expect_traceback=False,
                       expect_debug=False,
                       expect_rest_logs=False)
         assert_output(verbosity='-v',
-                      expect_traceback=expect_traceback_wip,
+                      expect_traceback=True,
                       expect_debug=False,
                       expect_rest_logs=False)
         assert_output(verbosity='-vv',
-                      expect_traceback=expect_traceback_wip,
+                      expect_traceback=True,
                       expect_debug=True,
                       expect_rest_logs=False)
         assert_output(verbosity='-vvv',
-                      expect_traceback=expect_traceback_wip,
+                      expect_traceback=True,
                       expect_debug=True,
                       expect_rest_logs=True)
 


### PR DESCRIPTION
In this PR, the execution logging test is fixed thanks to the fact that the task error causes are now included in the API response from the events endpoint.

Depends on:  cloudify-cosmo/cloudify-manager-blueprints#540, cloudify-cosmo/cloudify-cli#576