### PR TITLE
CFY 6648. Fix events integration tests

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -32,14 +32,18 @@ class EventsTest(AgentlessTestCase):
     def test_timestamp_range(self):
         """Filter events by timestamp range."""
         all_events = self._events_list(_sort='@timestamp')
-        first_event = all_events[0]
-        median_event = all_events[len(all_events) / 2 - 1]
-        min_time = first_event['timestamp']
-        max_time = median_event['timestamp']
+        min_time = all_events[0]['timestamp']
+
+        expected_event_count, max_time = next(
+            (index, event['timestamp'])
+            for index, event in enumerate(all_events)
+            if event['timestamp'] > min_time
+        )
+
         # get only half of the events by timestamp
-        ranged_events = self._events_list(from_datetime=min_time,
-                                          to_datetime=max_time)
-        self.assertEquals(len(ranged_events), len(all_events) / 2)
+        ranged_events = self._events_list(
+            from_datetime=min_time, to_datetime=max_time)
+        self.assertEquals(len(ranged_events), expected_event_count)
 
     def test_sorted_events(self):
         events = self._events_list(_sort='-@timestamp')

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -47,24 +47,23 @@ class EventsTest(AgentlessTestCase):
         self.assertListEqual(events.items, sorted_events)
 
     def test_filtered_events(self):
+        """Filter events by deployment."""
         # create multiple deployments
-        deployment_ids = []
-        for i in range(3):
-            deployment_ids.append(self._create_deployment())
+        deployment_ids = [self._create_deployment() for _ in range(3)]
 
         # filter a subset of the deployments
         expected_deployment_ids = deployment_ids[:2]
         filters = {'deployment_id': expected_deployment_ids}
         events = self._events_list(**filters)
 
-        deployments_with_events = \
-            {event['deployment_id'] for event in events}
-        self.assertEquals(sorted(deployments_with_events),
-                          sorted(expected_deployment_ids),
-                          'Expected events of deployment ids {0} exactly, '
-                          'received deployment ids {1} instead'
-                          .format(expected_deployment_ids,
-                                  deployments_with_events))
+        deployments_with_events = {event['deployment_id'] for event in events}
+        self.assertListEqual(
+            sorted(deployments_with_events),
+            sorted(expected_deployment_ids),
+            'Expected events of deployment ids {0} exactly, '
+            'received deployment ids {1} instead'
+            .format(expected_deployment_ids,
+                    deployments_with_events))
 
     def test_paginated_events(self):
         size = 5

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -58,7 +58,7 @@ class EventsTest(AgentlessTestCase):
         events = self._events_list(**filters)
 
         deployments_with_events = \
-            {event['context']['deployment_id'] for event in events}
+            {event['deployment_id'] for event in events}
         self.assertEquals(sorted(deployments_with_events),
                           sorted(expected_deployment_ids),
                           'Expected events of deployment ids {0} exactly, '

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -80,6 +80,7 @@ class EventsTest(AgentlessTestCase):
                           skip_assertion=True)
 
     def test_search_event_message(self):
+        """Filter events by message pattern."""
         all_events = self._events_list()
         # checking partial word and case insensitivity ('sending')
         raw_message = 'SeNdIN'
@@ -89,9 +90,7 @@ class EventsTest(AgentlessTestCase):
         self.assertLess(len(searched_events), len(all_events))
         # assert all search results are relevant
         for event in searched_events:
-            self.assertIn(
-                raw_message.lower(),
-                event['message']['text'].lower())
+            self.assertIn(raw_message.lower(), event['message'].lower())
 
     def test_list_with_include_option(self):
         _include = ['@timestamp', 'type']

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -98,7 +98,8 @@ class EventsTest(AgentlessTestCase):
             self.assertIn(raw_message.lower(), event['message'].lower())
 
     def test_list_with_include_option(self):
-        _include = ['@timestamp', 'type']
+        """Include only desired fields."""
+        _include = ['timestamp', 'type']
         events = self._events_list(_include=_include)
         for event in events:
             self.assertListEqual(_include, event.keys(),

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -30,11 +30,12 @@ class EventsTest(AgentlessTestCase):
                              'Expected events only')
 
     def test_timestamp_range(self):
+        """Filter events by timestamp range."""
         all_events = self._events_list(_sort='@timestamp')
         first_event = all_events[0]
         median_event = all_events[len(all_events) / 2 - 1]
-        min_time = first_event['@timestamp']
-        max_time = median_event['@timestamp']
+        min_time = first_event['timestamp']
+        max_time = median_event['timestamp']
         # get only half of the events by timestamp
         ranged_events = self._events_list(from_datetime=min_time,
                                           to_datetime=max_time)


### PR DESCRIPTION
In this PR, the events integration tests that broke after applying the change to use a flat structure have been fixed.