### PR TITLE
CFY 6648. Fix task_operation_retry

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_task_retries.py
+++ b/tests/integration_tests/tests/agentless_tests/test_task_retries.py
@@ -140,29 +140,36 @@ class TaskRetriesTest(AgentlessTestCase):
             )
             self.assertTrue(len(retry_events), 12)
 
-            retries = 0
             # We should have 4 groups of 3 events - sending_task, task_started
             # and task rescheduled (in the last case it will be
             # task_succeeded). Thus setting the range's step to 3
-            for i in range(0, 10, 3):
-                send_task = retry_events[i]
-                start_task = retry_events[i + 1]
-                reschedule_task = retry_events[i + 2]
-                self.assertEqual('sending_task', send_task['event_type'])
-                self.assertEqual('task_started', start_task['event_type'])
+            sending_task_events = retry_events[::3]
+            self.assertTrue(all(
+                event['event_type'] == 'sending_task'
+                for event in sending_task_events))
 
-                if retries < 3:  # The final retry should succeed
-                    self.assertEqual('task_rescheduled',
-                                     reschedule_task['event_type'])
-                else:
-                    self.assertEqual('task_succeeded',
-                                     reschedule_task['event_type'])
-                if retries:
-                    retry_msg = '[retry {0}/5]'.format(retries)
-                    for task in (send_task, start_task, reschedule_task):
-                        msg = task['message']
-                        self.assertTrue(msg.endswith(retry_msg))
-                retries += 1
+            task_started_events = retry_events[1::3]
+            self.assertTrue(all(
+                event['event_type'] == 'task_started'
+                for event in task_started_events))
+
+            task_rescheduled_events = retry_events[2:-1:3]
+            self.assertTrue(all(
+                event['event_type'] == 'task_rescheduled'
+                for event in task_rescheduled_events))
+
+            task_succeeded_event = retry_events[-1]
+            self.assertEqual(
+                task_succeeded_event['event_type'], 'task_succeeded')
+
+            for retry_attempt in xrange(1, 3):
+                retry_attempt_events = (
+                    retry_events[retry_attempt * 3:(retry_attempt + 1) * 3])
+                retry_msg = '[retry {0}/5]'.format(retry_attempt)
+                self.assertTrue(all(
+                    retry_task_event['message'].endswith(retry_msg)
+                    for retry_task_event in retry_attempt_events
+                ))
 
         # events are async so we may have to wait some
         self.do_assertions(assertion, timeout=120)

--- a/tests/integration_tests/tests/agentless_tests/test_task_retries.py
+++ b/tests/integration_tests/tests/agentless_tests/test_task_retries.py
@@ -117,16 +117,12 @@ class TaskRetriesTest(AgentlessTestCase):
             events = self.client.events.list(deployment_id=deployment_id,
                                              include_logs=True)
             self.assertGreater(len(events), 0)
-            for event in events:
-                if 'Task rescheduled' in event['message']:
-                    break
-            else:
-                self.fail('could not find expected message')
-            for event in events:
-                if 'Retrying operation' in event['message']:
-                    break
-            else:
-                self.fail('could not find expected message')
+            self.assertTrue(any(
+                'Task rescheduled' in event['message']
+                for event in events))
+            self.assertTrue(any(
+                'Retrying operation' in event['message']
+                for event in events))
 
             # We're looking only at the events from the create operation
             retry_events = [

--- a/tests/integration_tests/tests/agentless_tests/test_task_retries.py
+++ b/tests/integration_tests/tests/agentless_tests/test_task_retries.py
@@ -118,12 +118,12 @@ class TaskRetriesTest(AgentlessTestCase):
                                              include_logs=True)
             self.assertGreater(len(events), 0)
             for event in events:
-                if 'Task rescheduled' in event['message']['text']:
+                if 'Task rescheduled' in event['message']:
                     break
             else:
                 self.fail('could not find expected message')
             for event in events:
-                if 'Retrying operation' in event['message']['text']:
+                if 'Retrying operation' in event['message']:
                     break
             else:
                 self.fail('could not find expected message')
@@ -154,7 +154,7 @@ class TaskRetriesTest(AgentlessTestCase):
                 if retries:
                     retry_msg = '[retry {0}/5]'.format(retries)
                     for task in (send_task, start_task, reschedule_task):
-                        msg = task['message']['text']
+                        msg = task['message']
                         self.assertTrue(msg.endswith(retry_msg))
                 retries += 1
 

--- a/tests/integration_tests/tests/agentless_tests/test_task_retries.py
+++ b/tests/integration_tests/tests/agentless_tests/test_task_retries.py
@@ -130,7 +130,14 @@ class TaskRetriesTest(AgentlessTestCase):
                 for event in events
                 if event['operation'] == 'cloudify.interfaces.lifecycle.create'
             ]
-            retry_events = sorted(retry_events, key=lambda e: e['timestamp'])
+
+            # Note: sorting by timestamp and event_type to guarantee
+            # that # sending_task will come before task_started
+            # even if they have the same timestamp
+            retry_events = sorted(
+                retry_events,
+                key=lambda e: (e['timestamp'], e['event_type']),
+            )
             self.assertTrue(len(retry_events), 12)
 
             retries = 0

--- a/tests/integration_tests/tests/agentless_tests/test_task_retries.py
+++ b/tests/integration_tests/tests/agentless_tests/test_task_retries.py
@@ -129,8 +129,11 @@ class TaskRetriesTest(AgentlessTestCase):
                 self.fail('could not find expected message')
 
             # We're looking only at the events from the create operation
-            retry_events = [e for e in events if e['context']['operation'] ==
-                            'cloudify.interfaces.lifecycle.create']
+            retry_events = [
+                event
+                for event in events
+                if event['operation'] == 'cloudify.interfaces.lifecycle.create'
+            ]
             retry_events = sorted(retry_events, key=lambda e: e['timestamp'])
             self.assertTrue(len(retry_events), 12)
 

--- a/tests/integration_tests/tests/agentless_tests/test_task_retries.py
+++ b/tests/integration_tests/tests/agentless_tests/test_task_retries.py
@@ -143,24 +143,13 @@ class TaskRetriesTest(AgentlessTestCase):
             # We should have 4 groups of 3 events - sending_task, task_started
             # and task rescheduled (in the last case it will be
             # task_succeeded). Thus setting the range's step to 3
-            sending_task_events = retry_events[::3]
-            self.assertTrue(all(
-                event['event_type'] == 'sending_task'
-                for event in sending_task_events))
-
-            task_started_events = retry_events[1::3]
-            self.assertTrue(all(
-                event['event_type'] == 'task_started'
-                for event in task_started_events))
-
-            task_rescheduled_events = retry_events[2:-1:3]
-            self.assertTrue(all(
-                event['event_type'] == 'task_rescheduled'
-                for event in task_rescheduled_events))
-
-            task_succeeded_event = retry_events[-1]
-            self.assertEqual(
-                task_succeeded_event['event_type'], 'task_succeeded')
+            event_types = ['sending_task', 'task_started', 'task_rescheduled']
+            for start_index, event_type in enumerate(event_types):
+                events_by_event_type = retry_events[start_index:-1:3]
+                self.assertTrue(all(
+                    event['event_type'] == event_type
+                    for event in events_by_event_type))
+            self.assertEqual(retry_events[-1]['event_type'], 'task_succeeded')
 
             for retry_attempt in xrange(1, 3):
                 retry_attempt_events = (


### PR DESCRIPTION
In this PR, the following test case:
`integration_tests.tests.agentless_tests.test_task_retries.TaskRetriesTest.test_operation_retry`
is fixed and refactored.

The fix is basically using the properties of the new flat event structure instead of the old nested one with context. 