### PR TITLE
CFY 6647. Fix restore snapshot timestamp

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -196,15 +196,16 @@ class TestSnapshot(AgentlessTestCase):
             tenant_name=tenant_name
         )
 
-        # temp comment, until restore events into pg will be handled
-        # execution_id = self._assert_execution_restored(
-        #     deployment_id,
-        #     num_of_executions,
-        #     tenant_name
-        # )
-        # self._assert_events_restored(execution_id,
-        # num_of_events,
-        # tenant_name)
+        execution_id = self._assert_execution_restored(
+            deployment_id,
+            num_of_executions,
+            tenant_name,
+        )
+        self._assert_events_restored(
+            execution_id,
+            num_of_events,
+            tenant_name,
+        )
 
         with self.client_using_tenant(self.client, tenant_name):
             for node_id in node_ids:

--- a/workflows/cloudify_system_workflows/snapshots/estopg.py
+++ b/workflows/cloudify_system_workflows/snapshots/estopg.py
@@ -196,7 +196,7 @@ class EsToPg(object):
 
             pg_event = {
                 'id': es_document['_id'],
-                'timestamp': es_event['timestamp'],
+                'reported_timestamp': es_event['timestamp'],
                 'message': es_event['message']['text'],
                 'message_code': es_event['message_code'],
                 'event_type': es_event['event_type'],
@@ -230,7 +230,7 @@ class EsToPg(object):
 
             pg_log = {
                 'id': es_document['_id'],
-                'timestamp': es_log['timestamp'],
+                'reported_timestamp': es_log['timestamp'],
                 'message': es_log['message']['text'],
                 'message_code': es_log['message_code'],
                 'logger': es_log['logger'],

--- a/workflows/cloudify_system_workflows/snapshots/estopg.py
+++ b/workflows/cloudify_system_workflows/snapshots/estopg.py
@@ -196,6 +196,7 @@ class EsToPg(object):
 
             pg_event = {
                 'id': es_document['_id'],
+                'timestamp': es_event['@timestamp'],
                 'reported_timestamp': es_event['timestamp'],
                 'message': es_event['message']['text'],
                 'message_code': es_event['message_code'],
@@ -230,6 +231,7 @@ class EsToPg(object):
 
             pg_log = {
                 'id': es_document['_id'],
+                'timestamp': es_log['@timestamp'],
                 'reported_timestamp': es_log['timestamp'],
                 'message': es_log['message']['text'],
                 'message_code': es_log['message_code'],


### PR DESCRIPTION
In this PR, the problems with timestamps in snapsthot are fixed by restoring the following fields:

Elasticsearch | PostgreSQL
------------- | ----------
`@timestamp`  | `timestamp`
`timestamp`   | `restored_timestamp`

Note: this doesn't fix the test cases yet, but fixes the problem related to snapshot timestamps