### PR TITLE
CFY-6648. Make sorting order by event type explicit

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_task_retries.py
+++ b/tests/integration_tests/tests/agentless_tests/test_task_retries.py
@@ -132,11 +132,20 @@ class TaskRetriesTest(AgentlessTestCase):
             ]
 
             # Note: sorting by timestamp and event_type to guarantee
-            # that # sending_task will come before task_started
+            # that tasks will be correctly ordered
             # even if they have the same timestamp
+            event_type_sort_order = {
+                'sending_task': 0,
+                'task_started': 1,
+                'task_rescheduled': 2,
+                'task_succeeded': 3
+            }
             retry_events = sorted(
                 retry_events,
-                key=lambda e: (e['timestamp'], e['event_type']),
+                key=lambda e: (
+                    e['timestamp'],
+                    event_type_sort_order[e['event_type']],
+                ),
             )
             self.assertTrue(len(retry_events), 12)
 


### PR DESCRIPTION
This is a followup of #802 in which `test_operation_retry` is made more stable by making sure that the event data is correctly ordered to avoid assertion failures when events have exactly the same timestamp.