### PR TITLE
CFY-6660. Remove deployment permission assertion

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -236,7 +236,6 @@ class TestSnapshot(AgentlessTestCase):
         self.assertEqual(deployment.id, deployment_id)
         self.assertEqual(len(deployment.workflows), num_of_workflows)
         self.assertEqual(deployment.blueprint_id, blueprint_id)
-        self.assertEqual(deployment['permission'], 'creator')
         self.assertEqual(deployment['tenant_name'], tenant_name)
         self.assertEqual(len(deployment.inputs), num_of_inputs)
         self.assertEqual(len(deployment.outputs), num_of_outputs)

--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -236,6 +236,7 @@ class TestSnapshot(AgentlessTestCase):
         self.assertEqual(deployment.id, deployment_id)
         self.assertEqual(len(deployment.workflows), num_of_workflows)
         self.assertEqual(deployment.blueprint_id, blueprint_id)
+        self.assertEqual(deployment.created_by, 'admin')
         self.assertEqual(deployment['tenant_name'], tenant_name)
         self.assertEqual(len(deployment.inputs), num_of_inputs)
         self.assertEqual(len(deployment.outputs), num_of_outputs)


### PR DESCRIPTION
In this PR, an assertion that was causing problems in snapshot integration test cases has been removed because it's not longer needed.