### PR TITLE
CFY 6718. Timestamp index and default

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/9aa6f74c9653_4_0_1.py
+++ b/resources/rest-service/cloudify/migrations/versions/9aa6f74c9653_4_0_1.py
@@ -195,7 +195,7 @@ def upgrade():
     op.alter_column(
         'events',
         'timestamp',
-        server_default=sa.text(u'CURRENT_TIMESTAMP'),
+        server_default=sa.func.current_timestamp(),
         nullable=False,
     )
     op.add_column(
@@ -266,7 +266,7 @@ def upgrade():
     op.alter_column(
         'logs',
         'timestamp',
-        server_default=sa.text(u'CURRENT_TIMESTAMP'),
+        server_default=sa.func.current_timestamp(),
         nullable=False,
     )
     op.add_column(

--- a/resources/rest-service/cloudify/migrations/versions/9aa6f74c9653_4_0_1.py
+++ b/resources/rest-service/cloudify/migrations/versions/9aa6f74c9653_4_0_1.py
@@ -192,7 +192,12 @@ def upgrade():
     op.alter_column('events', '_creator_id', nullable=False)
     op.alter_column('events', '_tenant_id', nullable=False)
     op.alter_column('events', 'reported_timestamp', nullable=False)
-    op.alter_column('events', 'timestamp', server_default=sa.text(u'CURRENT_TIMESTAMP'), nullable=False)
+    op.alter_column(
+        'events',
+        'timestamp',
+        server_default=sa.text(u'CURRENT_TIMESTAMP'),
+        nullable=False,
+    )
     op.add_column(
         'events',
         sa.Column(
@@ -258,7 +263,12 @@ def upgrade():
     op.alter_column('logs', '_creator_id', nullable=False)
     op.alter_column('logs', '_tenant_id', nullable=False)
     op.alter_column('logs', 'reported_timestamp', nullable=False)
-    op.alter_column('logs', 'timestamp', server_default=sa.text(u'CURRENT_TIMESTAMP'), nullable=False)
+    op.alter_column(
+        'logs',
+        'timestamp',
+        server_default=sa.text(u'CURRENT_TIMESTAMP'),
+        nullable=False,
+    )
     op.add_column(
         'logs',
         sa.Column('private_resource', sa.Boolean(), nullable=True),
@@ -471,6 +481,7 @@ def downgrade():
         type_='foreignkey',
     )
     op.create_index('ix_logs_id', 'logs', ['id'], unique=False)
+    op.alter_column('logs', 'timestamp', server_default=None, nullable=False)
     op.drop_column('logs', 'reported_timestamp')
     op.drop_column('logs', 'private_resource')
     op.drop_column('logs', '_tenant_id')
@@ -496,6 +507,7 @@ def downgrade():
         type_='foreignkey',
     )
     op.create_index('ix_events_id', 'events', ['id'], unique=False)
+    op.alter_column('events', 'timestamp', server_default=None, nullable=False)
     op.drop_column('events', 'reported_timestamp')
     op.drop_column('events', 'private_resource')
     op.drop_column('events', 'error_causes')

--- a/resources/rest-service/cloudify/migrations/versions/9aa6f74c9653_4_0_1.py
+++ b/resources/rest-service/cloudify/migrations/versions/9aa6f74c9653_4_0_1.py
@@ -206,7 +206,6 @@ def upgrade():
         sa.Column('private_resource', sa.Boolean(), nullable=True),
     )
     op.drop_index('ix_events_id', table_name='events')
-    op.drop_index('ix_events_timestamp', table_name='events')
     op.create_foreign_key(
         op.f('events__tenant_id_fkey'),
         'events',
@@ -265,7 +264,6 @@ def upgrade():
         sa.Column('private_resource', sa.Boolean(), nullable=True),
     )
     op.drop_index('ix_logs_id', table_name='logs')
-    op.drop_index('ix_logs_timestamp', table_name='logs')
     op.create_foreign_key(
         op.f('logs__tenant_id_fkey'),
         'logs',
@@ -472,7 +470,6 @@ def downgrade():
         'logs',
         type_='foreignkey',
     )
-    op.create_index('ix_logs_timestamp', 'logs', ['timestamp'], unique=False)
     op.create_index('ix_logs_id', 'logs', ['id'], unique=False)
     op.drop_column('logs', 'reported_timestamp')
     op.drop_column('logs', 'private_resource')
@@ -497,12 +494,6 @@ def downgrade():
         op.f('events__tenant_id_fkey'),
         'events',
         type_='foreignkey',
-    )
-    op.create_index(
-        'ix_events_timestamp',
-        'events',
-        ['timestamp'],
-        unique=False,
     )
     op.create_index('ix_events_id', 'events', ['id'], unique=False)
     op.drop_column('events', 'reported_timestamp')


### PR DESCRIPTION
In this PR:
- the timestamp index for events/logs is no longer dropped in the migration upgrade from 4.0 to 4.0.1
- the timestamp default is unset in the migration downgrade from 4.0.1 to 4.0