### PR TITLE
CFY 6718. Restore 4.0 snapshot

### DIFF
--- a/resources/rest-service/cloudify/migrations/schema.py
+++ b/resources/rest-service/cloudify/migrations/schema.py
@@ -1,0 +1,96 @@
+########
+# Copyright (c) 2017 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+"""Downgrade/upgrade database schema to target revision."""
+
+import argparse
+import logging
+import os
+import sys
+
+import flask_migrate
+
+from manager_rest.flask_utils import setup_flask_app
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def main():
+    """Run migration command."""
+    args = parse_arguments(sys.argv[1:])
+    configure_logging(args['log_level'])
+
+    setup_flask_app()
+    directory = os.path.dirname(__file__)
+
+    command = getattr(flask_migrate, args['command'])
+    command(directory, args['revision'])
+
+
+def parse_arguments(argv):
+    """Parse command line arguments.
+
+    :param argv: Command line arguments
+    :type argv: list(str)
+    :returns: Parsed arguments
+    :rtype: argparse.Namespace
+
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        'command',
+        choices=['downgrade', 'upgrade'],
+        help='Migration command',
+    )
+    parser.add_argument('revision', help='Target schema revision')
+
+    log_levels = ['debug', 'info', 'warning', 'error', 'critical']
+    parser.add_argument(
+        '-l', '--log-level',
+        dest='log_level',
+        choices=log_levels,
+        default='debug',
+        help=('Log level. One of {0} or {1} '
+              '(%(default)s by default)'
+              .format(', '.join(log_levels[:-1]), log_levels[-1])))
+
+    args = vars(parser.parse_args(argv))
+    args['log_level'] = getattr(logging, args['log_level'].upper())
+    return args
+
+
+def configure_logging(log_level):
+    """Configure logging based on command line argument.
+
+    :param log_level: Log level passed form the command line
+    :type log_level: int
+
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.DEBUG)
+
+    # Log to sys.stderr using log level
+    # passed through command line
+    log_handler = logging.StreamHandler()
+    formatter = logging.Formatter(
+        '%(asctime)s %(threadName)s %(levelname)s: %(message)s')
+    log_handler.setFormatter(formatter)
+    log_handler.setLevel(log_level)
+    root_logger.addHandler(log_handler)
+
+
+if __name__ == '__main__':
+    main()

--- a/rest-service/manager_rest/storage/storage_utils.py
+++ b/rest-service/manager_rest/storage/storage_utils.py
@@ -58,7 +58,7 @@ def create_default_user_tenant_and_roles(admin_username, admin_password):
 
 def _create_roles():
     for role in constants.ALL_ROLES:
-        user_datastore.create_role(name=role)
+        user_datastore.find_or_create_role(name=role)
     return user_datastore.find_role(constants.ADMIN_ROLE)
 
 

--- a/tests/integration_tests/framework/flask_utils.py
+++ b/tests/integration_tests/framework/flask_utils.py
@@ -62,7 +62,7 @@ def reset_storage():
     app = setup_flask_app()
 
     # Rebuild the DB
-    safe_drop_all()
+    safe_drop_all(keep_tables=['roles'])
     upgrade(directory=migrations_dir)
 
     # Add default tenant, admin user and provider context

--- a/tests/integration_tests/framework/postgresql.py
+++ b/tests/integration_tests/framework/postgresql.py
@@ -48,11 +48,13 @@ def run_query(query, db_name=None):
             return {'status': status_message, 'all': fetchall}
 
 
-def safe_drop_all():
+def safe_drop_all(keep_tables):
     """Creates a single transaction that *always* drops all tables, regardless
     of relationships and foreign key constraints (as opposed to `db.drop_all`)
     """
     meta = db.metadata
     for table in reversed(meta.sorted_tables):
+        if table.name in keep_tables:
+            continue
         db.session.execute(table.delete())
     db.session.commit()

--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -97,7 +97,8 @@ class TestSnapshot(AgentlessTestCase):
             num_of_workflows=7,
             num_of_inputs=4,
             num_of_outputs=1,
-            num_of_executions=1
+            num_of_executions=1,
+            num_of_events=12,
         )
 
     def test_3_4_0_snapshot_with_deployment(self):

--- a/workflows/cloudify_system_workflows/snapshots/postgres.py
+++ b/workflows/cloudify_system_workflows/snapshots/postgres.py
@@ -35,7 +35,7 @@ class Postgres(object):
     _POSTGRES_DUMP_FILENAME = 'pg_data'
     _STAGE_DUMP_FILENAME = 'stage_data'
     _STAGE_DB_NAME = 'stage'
-    _TABLES_TO_KEEP = ['provider_context', 'roles']
+    _TABLES_TO_KEEP = ['alembic_version', 'provider_context', 'roles']
     _TABLES_TO_RESTORE = ['users', 'tenants']
 
     def __init__(self, config):

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -141,7 +141,6 @@ class SnapshotRestore(object):
         elif self._snapshot_version == V_4_0_0:
             with utils.db_schema('333998bc1627'):
                 postgres.restore(self._tempdir)
-            postgres.restore_stage(self._tempdir)
         else:
             if self._should_clean_old_db_for_3_x_snapshot():
                 postgres.clean_db()

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -139,26 +139,9 @@ class SnapshotRestore(object):
             postgres.restore(self._tempdir)
             postgres.restore_stage(self._tempdir)
         elif self._snapshot_version == V_4_0_0:
-            base_script = (
-                'import flask_migrate;'
-                'from manager_rest.flask_utils import setup_flask_app;'
-                'setup_flask_app();'
-                "directory = '/opt/manager/resources/cloudify/migrations';"
-            )
-            downgrade_script = (
-                base_script +
-                "flask_migrate.downgrade(directory, '333998bc1627')"
-            )
-            upgrade_script = (
-                base_script +
-                "flask_migrate.upgrade(directory)"
-            )
-            subprocess.check_call(
-                ['/opt/manager/env/bin/python', '-c', downgrade_script])
-            postgres.restore(self._tempdir)
+            with utils.db_schema('333998bc1627'):
+                postgres.restore(self._tempdir)
             postgres.restore_stage(self._tempdir)
-            subprocess.check_call(
-                ['/opt/manager/env/bin/python', '-c', upgrade_script])
         else:
             if self._should_clean_old_db_for_3_x_snapshot():
                 postgres.clean_db()

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -135,9 +135,30 @@ class SnapshotRestore(object):
 
     def _restore_db(self, postgres):
         ctx.logger.info('Restoring database')
-        if self._snapshot_version >= V_4_0_0:
+        if self._snapshot_version > V_4_0_0:
             postgres.restore(self._tempdir)
             postgres.restore_stage(self._tempdir)
+        elif self._snapshot_version == V_4_0_0:
+            base_script = (
+                'import flask_migrate;'
+                'from manager_rest.flask_utils import setup_flask_app;'
+                'setup_flask_app();'
+                "directory = '/opt/manager/resources/cloudify/migrations';"
+            )
+            downgrade_script = (
+                base_script +
+                "flask_migrate.downgrade(directory, '333998bc1627')"
+            )
+            upgrade_script = (
+                base_script +
+                "flask_migrate.upgrade(directory)"
+            )
+            subprocess.check_call(
+                ['/opt/manager/env/bin/python', '-c', downgrade_script])
+            postgres.restore(self._tempdir)
+            postgres.restore_stage(self._tempdir)
+            subprocess.check_call(
+                ['/opt/manager/env/bin/python', '-c', upgrade_script])
         else:
             if self._should_clean_old_db_for_3_x_snapshot():
                 postgres.clean_db()

--- a/workflows/cloudify_system_workflows/snapshots/utils.py
+++ b/workflows/cloudify_system_workflows/snapshots/utils.py
@@ -26,6 +26,11 @@ from cloudify.workflows import ctx
 from .constants import ARCHIVE_CERT_DIR
 from cloudify.utils import ManagerVersion, get_local_rest_certificate
 
+# Path to python binary in the manager environment
+PYTHON_MANAGER_ENV = '/opt/manager/env/bin/python'
+# Path to database migration script
+SCHEMA_SCRIPT = '/opt/manager/resources/cloudify/migrations/schema.py'
+
 
 class DictToAttributes(object):
     def __init__(self, dic):
@@ -249,8 +254,8 @@ def db_schema_downgrade(revision='-1'):
 
     """
     subprocess.check_call([
-        '/opt/manager/env/bin/python',
-        '/opt/manager/resources/cloudify/migrations/schema.py',
+        PYTHON_MANAGER_ENV,
+        SCHEMA_SCRIPT,
         'downgrade',
         revision,
     ])
@@ -266,8 +271,8 @@ def db_schema_upgrade(revision='head'):
 
     """
     subprocess.check_call([
-        '/opt/manager/env/bin/python',
-        '/opt/manager/resources/cloudify/migrations/schema.py',
+        PYTHON_MANAGER_ENV,
+        SCHEMA_SCRIPT,
         'upgrade',
         revision,
     ])

--- a/workflows/cloudify_system_workflows/snapshots/utils.py
+++ b/workflows/cloudify_system_workflows/snapshots/utils.py
@@ -221,14 +221,6 @@ def compare_cert_metadata(path1, path2):
     return content1 == content2
 
 
-BASE_MIGRATION_SCRIPT = (
-    'import flask_migrate;'
-    'from manager_rest.flask_utils import setup_flask_app;'
-    'setup_flask_app();'
-    "directory = '/opt/manager/resources/cloudify/migrations';"
-)
-
-
 @contextlib.contextmanager
 def db_schema(revision):
     """Downgrade schema to desired revision to perform operation and upgrade.
@@ -256,12 +248,12 @@ def db_schema_downgrade(revision='-1'):
     :type revision: str
 
     """
-    downgrade_script = (
-        BASE_MIGRATION_SCRIPT +
-        "flask_migrate.downgrade(directory, '{}')".format(revision)
-    )
-    subprocess.check_call(
-        ['/opt/manager/env/bin/python', '-c', downgrade_script])
+    subprocess.check_call([
+        '/opt/manager/env/bin/python',
+        '/opt/manager/resources/cloudify/migrations/schema.py',
+        'downgrade',
+        revision,
+    ])
 
 
 def db_schema_upgrade(revision='head'):
@@ -273,9 +265,9 @@ def db_schema_upgrade(revision='head'):
     :type revision: str
 
     """
-    upgrade_script = (
-        BASE_MIGRATION_SCRIPT +
-        "flask_migrate.upgrade(directory, '{}')".format(revision)
-    )
-    subprocess.check_call(
-        ['/opt/manager/env/bin/python', '-c', upgrade_script])
+    subprocess.check_call([
+        '/opt/manager/env/bin/python',
+        '/opt/manager/resources/cloudify/migrations/schema.py',
+        'upgrade',
+        revision,
+    ])


### PR DESCRIPTION
In this PR, the ability to restore 4.0 snapshots by running database schema migrations has been implemented.

Note that the migration scripts need to run in the manager virtualenv while the postgres restore itself runs in the management worker virtualenv. When a better design for restoring snapshots is in place, this should be refactored.