### PR TITLE
CFY 6718. Store schema revision in snapshot metadata

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/constants.py
+++ b/workflows/cloudify_system_workflows/snapshots/constants.py
@@ -15,5 +15,6 @@
 
 METADATA_FILENAME = 'metadata.json'
 M_VERSION = 'snapshot_version'
+M_SCHEMA_REVISION = 'schema_revision'
 M_HAS_CLOUDIFY_EVENTS = 'has_cloudify_events'
 ARCHIVE_CERT_DIR = 'ssl'

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_create.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_create.py
@@ -49,12 +49,13 @@ class SnapshotCreate(object):
         metadata = dict()
         try:
             manager_version = utils.get_manager_version(self._client)
+            schema_revision = utils.db_schema_get_current_revision()
 
             self._dump_files()
             self._dump_postgres()
             self._dump_influxdb()
             self._dump_credentials()
-            self._dump_metadata(metadata, manager_version)
+            self._dump_metadata(metadata, manager_version, schema_revision)
             self._dump_agents(manager_version)
 
             self._create_archive()
@@ -98,9 +99,10 @@ class SnapshotCreate(object):
         if self._include_credentials:
             Credentials().dump(self._tempdir)
 
-    def _dump_metadata(self, metadata, manager_version):
+    def _dump_metadata(self, metadata, manager_version, schema_revision):
         ctx.logger.info('Dumping metadata')
         metadata[constants.M_VERSION] = str(manager_version)
+        metadata[constants.M_SCHEMA_REVISION] = schema_revision
         metadata_filename = os.path.join(
             self._tempdir,
             constants.METADATA_FILENAME

--- a/workflows/cloudify_system_workflows/snapshots/utils.py
+++ b/workflows/cloudify_system_workflows/snapshots/utils.py
@@ -276,3 +276,19 @@ def db_schema_upgrade(revision='head'):
         'upgrade',
         revision,
     ])
+
+
+def db_schema_get_current_revision():
+    """Get database schema revision.
+
+    :returns: Current revision
+    :rtype: str
+
+    """
+    output = subprocess.check_output([
+        PYTHON_MANAGER_ENV,
+        SCHEMA_SCRIPT,
+        'current',
+    ])
+    revision = output.split(' ', 1)[0]
+    return revision


### PR DESCRIPTION
In this PR, the current schema revision is added to the snapshot metadata.

This will make easier in the future to restore snapshots from different versions without having a explicit mapping from cloudify version to database schema revision.