### PR TITLE
CFY 6835. Use schema revision on snapshot restore

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -86,19 +86,23 @@ class TestSnapshot(AgentlessTestCase):
 
     def test_4_0_1_snapshot_with_deployment(self):
         """Restore a 4_0_1 snapshot with a deployment."""
-        snapshot_path = self._get_snapshot('snap_4.0.1.zip')
+        snapshot_path = self._get_snapshot('secretshot_4.0.1.zip')
         self._upload_and_restore_snapshot(snapshot_path)
 
         # Now make sure all the resources really exist in the DB
         self._assert_snapshot_restored(
-            blueprint_id='bp',
-            deployment_id='dep',
-            node_ids=['http_web_server', 'vm'],
-            node_instance_ids=['http_web_server_ndps9x', 'vm_qvyj1m'],
+            blueprint_id='t',
+            deployment_id='t',
+            node_ids=['vm1', 'vm2', 'some_sort_of_thing'],
+            node_instance_ids=[
+                'vm1_vj52lv',
+                'vm2_pxra28',
+                'some_sort_of_thing_papsns',
+            ],
             num_of_workflows=7,
-            num_of_inputs=4,
-            num_of_outputs=1,
-            num_of_executions=1,
+            num_of_inputs=3,
+            num_of_outputs=0,
+            num_of_executions=2,
             num_of_events=4,
         )
 

--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -84,6 +84,24 @@ class TestSnapshot(AgentlessTestCase):
         execution = client.executions.get(execution.id)
         self.assertEqual(execution.status, ExecutionState.FAILED)
 
+    def test_4_0_1_snapshot_with_deployment(self):
+        """Restore a 4_0_1 snapshot with a deployment."""
+        snapshot_path = self._get_snapshot('snap_4.0.1.zip')
+        self._upload_and_restore_snapshot(snapshot_path)
+
+        # Now make sure all the resources really exist in the DB
+        self._assert_snapshot_restored(
+            blueprint_id='bp',
+            deployment_id='dep',
+            node_ids=['http_web_server', 'vm'],
+            node_instance_ids=['http_web_server_ndps9x', 'vm_qvyj1m'],
+            num_of_workflows=7,
+            num_of_inputs=4,
+            num_of_outputs=1,
+            num_of_executions=1,
+            num_of_events=4,
+        )
+
     def test_4_0_0_snapshot_with_deployment(self):
         snapshot_path = self._get_snapshot('snap_4.0.0.zip')
         self._upload_and_restore_snapshot(snapshot_path)

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -53,6 +53,9 @@ V_4_0_0 = ManagerVersion('4.0.0')
 
 
 class SnapshotRestore(object):
+
+    SCHEMA_REVISION_4_0 = '333998bc1627'
+
     def __init__(self,
                  config,
                  snapshot_id,
@@ -84,8 +87,10 @@ class SnapshotRestore(object):
         try:
             metadata = self._extract_snapshot_archive(snapshot_path)
             self._snapshot_version = ManagerVersion(metadata[M_VERSION])
-            # Assume 4.0 schema if metadata is missing
-            schema_revision = metadata.get(M_SCHEMA_REVISION, '333998bc1627')
+            schema_revision = metadata.get(
+                M_SCHEMA_REVISION,
+                self.SCHEMA_REVISION_4_0,
+            )
             self._validate_snapshot()
 
             existing_plugins = self._get_existing_plugin_names()

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -41,7 +41,12 @@ from .influxdb import InfluxDB
 from .postgres import Postgres
 from .es_snapshot import ElasticSearch
 from .credentials import restore as restore_credentials
-from .constants import METADATA_FILENAME, M_VERSION, ARCHIVE_CERT_DIR
+from .constants import (
+    ARCHIVE_CERT_DIR,
+    METADATA_FILENAME,
+    M_SCHEMA_REVISION,
+    M_VERSION,
+)
 
 
 V_4_0_0 = ManagerVersion('4.0.0')
@@ -79,6 +84,8 @@ class SnapshotRestore(object):
         try:
             metadata = self._extract_snapshot_archive(snapshot_path)
             self._snapshot_version = ManagerVersion(metadata[M_VERSION])
+            # Assume 4.0 schema if metadata is missing
+            schema_revision = metadata.get(M_SCHEMA_REVISION, '333998bc1627')
             self._validate_snapshot()
 
             existing_plugins = self._get_existing_plugin_names()
@@ -86,7 +93,7 @@ class SnapshotRestore(object):
 
             self._restore_certificate()
             with Postgres(self._config) as postgres:
-                self._restore_db(postgres)
+                self._restore_db(postgres, schema_revision)
                 self._restore_files_to_manager()
                 self._restore_plugins(existing_plugins)
                 self._restore_influxdb()
@@ -129,15 +136,23 @@ class SnapshotRestore(object):
         )
         ctx.logger.info('Successfully restored archive files')
 
-    def _restore_db(self, postgres):
+    def _restore_db(self, postgres, schema_revision):
+        """Restore database from snapshot.
+
+        :param postgres: Database wrapper for snapshots
+        :type: :class:`cloudify_system_workflows.snapshots.postgres.Postgres`
+        :param schema_revision:
+            Schema revision for the dump file in the snapshot
+        :type schema_revision: str
+
+        """
         ctx.logger.info('Restoring database')
-        if self._snapshot_version > V_4_0_0:
-            postgres.restore(self._tempdir)
-            if self._premium_enabled:
-                postgres.restore_stage(self._tempdir)
-        elif self._snapshot_version == V_4_0_0:
-            with utils.db_schema('333998bc1627'):
+        if self._snapshot_version >= V_4_0_0:
+            with utils.db_schema(schema_revision):
                 postgres.restore(self._tempdir)
+
+            if self._snapshot_version > V_4_0_0 and self._premium_enabled:
+                postgres.restore_stage(self._tempdir)
         else:
             if self._should_clean_old_db_for_3_x_snapshot():
                 postgres.clean_db()


### PR DESCRIPTION
In this PR, the code to restore snapshots is updated to take into account the schema revision that is included in the metadata starting from 4.0.1.

Notes:
- this change is expected to be merged in 4.1.
- a local snapshot was used for testing. When 4.0.1 is released, a new snapshot needs to be created and uploaded to the s3 bucket used to store testing snapshots.  