### PR TITLE
Add index=True to the Tenant FK

### DIFF
--- a/rest-service/manager_rest/storage/relationships.py
+++ b/rest-service/manager_rest/storage/relationships.py
@@ -16,15 +16,17 @@
 from .models_base import db
 
 
-def foreign_key(foreign_key_column, nullable=False):
+def foreign_key(foreign_key_column, nullable=False, index=False):
     """Return a ForeignKey object with the relevant
 
     :param foreign_key_column: Unique id column in the parent table
     :param nullable: Should the column be allowed to remain empty
+    :param index: Should the column be indexed
     """
     return db.Column(
         db.ForeignKey(foreign_key_column, ondelete='CASCADE'),
-        nullable=nullable
+        nullable=nullable,
+        index=index
     )
 
 

--- a/rest-service/manager_rest/storage/resource_models_base.py
+++ b/rest-service/manager_rest/storage/resource_models_base.py
@@ -59,7 +59,7 @@ class SQLResourceBase(SQLModelBase):
 
     @declared_attr
     def _tenant_id(cls):
-        return foreign_key(Tenant.id)
+        return foreign_key(Tenant.id, index=True)
 
     @declared_attr
     def _creator_id(cls):


### PR DESCRIPTION
Pretty much all of our resources are queried with a WHERE on tenants,
so let's make that indexable by default.

This is mostly required for the events and logs tables, which can grow 
very large, so we really don't want seq scans on those tables.