### PR TITLE
CFY-6652 Fix datetime type in migration scripts

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/333998bc1627_4_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/333998bc1627_4_0.py
@@ -627,7 +627,7 @@ def upgrade():
         sa.Column('id', sa.Text(), nullable=True),
         sa.Column(
             'timestamp',
-            manager_rest.storage.models_base.LocalDateTime(),
+            manager_rest.storage.models_base.UTCDateTime(),
             nullable=False,
         ),
         sa.Column('message', sa.Text(), nullable=True),
@@ -656,7 +656,7 @@ def upgrade():
         sa.Column('id', sa.Text(), nullable=True),
         sa.Column(
             'timestamp',
-            manager_rest.storage.models_base.LocalDateTime(),
+            manager_rest.storage.models_base.UTCDateTime(),
             nullable=False,
         ),
         sa.Column('message', sa.Text(), nullable=True),

--- a/resources/rest-service/cloudify/migrations/versions/9aa6f74c9653_4_0_1.py
+++ b/resources/rest-service/cloudify/migrations/versions/9aa6f74c9653_4_0_1.py
@@ -154,7 +154,7 @@ def upgrade():
         'events',
         sa.Column(
             'reported_timestamp',
-            manager_rest.storage.models_base.LocalDateTime(),
+            manager_rest.storage.models_base.UTCDateTime(),
             nullable=True,
         ),
     )
@@ -220,7 +220,7 @@ def upgrade():
         'logs',
         sa.Column(
             'reported_timestamp',
-            manager_rest.storage.models_base.LocalDateTime(),
+            manager_rest.storage.models_base.UTCDateTime(),
             nullable=True,
         ),
     )


### PR DESCRIPTION
As reported by @mcouthon, the migration scripts where broken when #855 was merged because they still use the old `LodalDateTime` type.

In this PR, that is replaced by `UTCDatetime` which was used in the past. Note that that is SQLAlchemy type that changes serialization, but uses the same underlying database type. Hence, there's no need to create a new migration script.