### PR TITLE
REST service config: change default db port from 9200 to 5432

### DIFF
--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -21,7 +21,7 @@ class Config(object):
 
     def __init__(self):
         self.db_address = 'localhost'
-        self.db_port = 9200
+        self.db_port = 5432
         self.postgresql_db_name = None
         self.postgresql_host = None
         self.postgresql_username = None


### PR DESCRIPTION
We're now using postgresql instead of elasticsearch, so we can
default the db port to postgresql's default, instead of
elasticsearch's default