### PR TITLE
CFY-6864 schema.py: use the same postgresql_host as restservice

### DIFF
--- a/resources/rest-service/cloudify/migrations/schema.py
+++ b/resources/rest-service/cloudify/migrations/schema.py
@@ -34,7 +34,7 @@ def main():
     args = parse_arguments(sys.argv[1:])
     configure_logging(args['log_level'])
 
-    setup_flask_app()
+    setup_flask_app(manager_ip=args['postgresql_host'])
 
     func = args['func']
     func(args)
@@ -65,6 +65,9 @@ def parse_arguments(argv):
 
     """
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--postgresql-host',
+                        dest='postgresql_host',
+                        help='Address the database is listening on')
     subparsers = parser.add_subparsers(help='Migration subcommands')
 
     downgrade_parser = subparsers.add_parser(

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -162,7 +162,7 @@ class SnapshotRestore(object):
         """
         ctx.logger.info('Restoring database')
         if self._snapshot_version >= V_4_0_0:
-            with utils.db_schema(schema_revision):
+            with utils.db_schema(schema_revision, config=self._config):
                 postgres.restore(self._tempdir)
 
             if self._snapshot_version > V_4_0_0 and self._premium_enabled:


### PR DESCRIPTION
Postgresql port isn't always 5432 - when running a cluster, it's by default 15432.

This change makes the port parametrized, by passing the whole `postgresql_host` from restservice - which contains both the host and the port, eg. "localhost:15432"

The `self._config` for the snapshot restore contains that value (it is created here https://github.com/cloudify-cosmo/cloudify-manager/blob/master/rest-service/manager_rest/resource_manager.py#L97 ), so we use that - pass the whole config to the utils `db_schema` function, which passes it to the `schema.py` script via a cmdline arg, where it is used for creating a flask app that is used by flask_migrate