### PR TITLE
CFY 6647. Return reported timestamp in events API

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -457,6 +457,7 @@ class Events(SecuredResource):
             for attr in sql_event.keys()
         }
         event['@timestamp'] = event['timestamp']
+        del event['reported_timestamp']
 
         event['message'] = {
             'text': event['message']

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -312,6 +312,7 @@ class Events(SecuredResource):
             db.session.query(
                 select_column('id'),
                 select_column('timestamp'),
+                select_column('reported_timestamp'),
                 Blueprint.id.label('blueprint_id'),
                 Deployment.id.label('deployment_id'),
                 Execution.id.label('execution_id'),

--- a/rest-service/manager_rest/rest/resources_v3.py
+++ b/rest-service/manager_rest/rest/resources_v3.py
@@ -668,7 +668,6 @@ class Events(v2_Events):
             attr: getattr(sql_event, attr)
             for attr in sql_event.keys()
         }
-        event['reported_timestamp'] = event['timestamp']
 
         for unused_field in Events.UNUSED_FIELDS:
             if unused_field in event:

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -41,6 +41,7 @@ EventResultTuple = namedtuple(
     'EventResult',
     [
         'timestamp',
+        'reported_timestamp',
         'deployment_id',
         'execution_id',
         'workflow_id',
@@ -936,7 +937,8 @@ class MapEventToDictTestV1(TestCase):
     def test_map_event(self):
         """Map event as returned by SQL query to elasticsearch style output."""
         sql_event = EventResult(
-            timestamp='2016-12-09T00:00Z',
+            timestamp='2017-05-22T00:00Z',
+            reported_timestamp='2016-12-09T00:00Z',
             deployment_id='<deployment_id>',
             execution_id='<execution_id>',
             workflow_id='<workflow_id>',
@@ -961,8 +963,8 @@ class MapEventToDictTestV1(TestCase):
                 'node_name': '<node_name>',
             },
             'event_type': '<event_type>',
-            'timestamp': '2016-12-09T00:00Z',
-            '@timestamp': '2016-12-09T00:00Z',
+            'timestamp': '2017-05-22T00:00Z',
+            '@timestamp': '2017-05-22T00:00Z',
             'message': {
                 'arguments': None,
                 'text': '<message>',
@@ -977,7 +979,8 @@ class MapEventToDictTestV1(TestCase):
     def test_map_log(self):
         """Map log as returned by SQL query to elasticsearch style output."""
         sql_log = EventResult(
-            timestamp='2016-12-09T00:00Z',
+            timestamp='2017-05-22T00:00Z',
+            reported_timestamp='2016-12-09T00:00Z',
             deployment_id='<deployment_id>',
             execution_id='<execution_id>',
             workflow_id='<workflow_id>',
@@ -1002,8 +1005,8 @@ class MapEventToDictTestV1(TestCase):
                 'node_name': '<node_name>',
             },
             'level': '<level>',
-            'timestamp': '2016-12-09T00:00Z',
-            '@timestamp': '2016-12-09T00:00Z',
+            'timestamp': '2017-05-22T00:00Z',
+            '@timestamp': '2017-05-22T00:00Z',
             'message': {'text': '<message>'},
             'message_code': None,
             'type': 'cloudify_log',

--- a/rest-service/manager_rest/test/endpoints/test_events_v3.py
+++ b/rest-service/manager_rest/test/endpoints/test_events_v3.py
@@ -30,6 +30,7 @@ class MapEventToDictTestV3(TestCase):
         """Map event as returned by SQL query to elasticsearch style output."""
         sql_event = EventResult(
             timestamp='2016-12-09T00:00Z',
+            reported_timestamp='2017-05-22T00:00Z',
             deployment_id='<deployment_id>',
             execution_id='<execution_id>',
             workflow_id='<workflow_id>',
@@ -53,7 +54,7 @@ class MapEventToDictTestV3(TestCase):
             'node_name': '<node_name>',
             'event_type': '<event_type>',
             'timestamp': '2016-12-09T00:00Z',
-            'reported_timestamp': '2016-12-09T00:00Z',
+            'reported_timestamp': '2017-05-22T00:00Z',
             'message': '<message>',
             'type': 'cloudify_event',
         }
@@ -65,6 +66,7 @@ class MapEventToDictTestV3(TestCase):
         """Map log as returned by SQL query to elasticsearch style output."""
         sql_log = EventResult(
             timestamp='2016-12-09T00:00Z',
+            reported_timestamp='2017-05-22T00:00Z',
             deployment_id='<deployment_id>',
             execution_id='<execution_id>',
             workflow_id='<workflow_id>',
@@ -88,7 +90,7 @@ class MapEventToDictTestV3(TestCase):
             'node_name': '<node_name>',
             'level': '<level>',
             'timestamp': '2016-12-09T00:00Z',
-            'reported_timestamp': '2016-12-09T00:00Z',
+            'reported_timestamp': '2017-05-22T00:00Z',
             'message': '<message>',
             'type': 'cloudify_log',
             'logger': '<logger>',


### PR DESCRIPTION
In this PR, the `reported_timestamp` value stored in the database is returned in API calls.

Before this PR, the `reported_timestamp` field was just a copy of `timesamp` because there was no `reported_timestamp` field in the database yet.

Thanks @dmitryAII  for reporting the problem.