### PR TITLE
CFY-6966- Snapshot restore improvements (this does not solve all of the jira issue)

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/estopg.py
+++ b/workflows/cloudify_system_workflows/snapshots/estopg.py
@@ -49,7 +49,7 @@ class EsToPg(object):
         app = setup_flask_app()
         admin = self._set_current_user(app)
         storage_manager = get_storage_manager()
-        tenant = self._get_or_create_tenant(tenant_name)
+        tenant = self._get_tenant(tenant_name)
         self._set_tenant_in_app(tenant, app, storage_manager, admin)
         return storage_manager
 
@@ -63,16 +63,15 @@ class EsToPg(object):
         app.config[CURRENT_TENANT_CONFIG] = tenant
 
     @staticmethod
-    def _get_or_create_tenant(tenant_name):
-        """Get the default tenant if using community edition, or
+    def _get_tenant(tenant_name):
+        """Get the tenant name, or fail noisily.
         """
         tenant = models.Tenant.query.filter_by(name=tenant_name).first()
-        if tenant_name != DEFAULT_TENANT_NAME:
-            assert not tenant, 'Attempted to restore into an ' \
-                               'existing {0}:'.format(tenant)
-            tenant = models.Tenant(name=tenant_name)
-        else:
-            assert tenant.name == DEFAULT_TENANT_NAME
+        if not tenant:
+            raise Exception(
+                'Could not restore into tenant "{name}" as this tenant does '
+                'not exist.'.format(name=tenant_name)
+            )
         return tenant
 
     @staticmethod

--- a/workflows/cloudify_system_workflows/snapshots/estopg.py
+++ b/workflows/cloudify_system_workflows/snapshots/estopg.py
@@ -21,6 +21,7 @@ import argparse
 
 from manager_rest import manager_exceptions
 from manager_rest.flask_utils import setup_flask_app
+from manager_rest.constants import CURRENT_TENANT_CONFIG
 from manager_rest.storage import models, get_storage_manager
 
 format_str = '%(asctime)s [%(name)s] %(levelname)s: %(message)s'

--- a/workflows/cloudify_system_workflows/snapshots/estopg.py
+++ b/workflows/cloudify_system_workflows/snapshots/estopg.py
@@ -21,7 +21,6 @@ import argparse
 
 from manager_rest import manager_exceptions
 from manager_rest.flask_utils import setup_flask_app
-from manager_rest.constants import CURRENT_TENANT_CONFIG, DEFAULT_TENANT_NAME
 from manager_rest.storage import models, get_storage_manager
 
 format_str = '%(asctime)s [%(name)s] %(levelname)s: %(message)s'

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -65,7 +65,8 @@ class SnapshotRestore(object):
                  premium_enabled,
                  user_is_bootstrap_admin,
                  restore_certificates,
-                 no_reboot):
+                 no_reboot,
+                 recreate_deployment_envs_for):
         self._npm = Npm()
         self._config = utils.DictToAttributes(config)
         self._snapshot_id = snapshot_id
@@ -81,9 +82,15 @@ class SnapshotRestore(object):
         self._tempdir = None
         self._snapshot_version = None
         self._client = get_rest_client()
-        self._tenant_client = self._get_tenant_client()
+        self._recreate_deployment_envs_for = recreate_deployment_envs_for
 
     def restore(self):
+        if self._recreate_deployment_envs_for:
+            # To avoid having to try to modify the ctx in interesting ways,
+            # the deployment envs are restored with a call per tenant
+            self._recreate_deployment_envs()
+            return
+
         self._tempdir = tempfile.mkdtemp('-snapshot-data')
         snapshot_path = self._get_snapshot_path()
         ctx.logger.debug('Going to restore snapshot, '
@@ -342,12 +349,7 @@ class SnapshotRestore(object):
         """
         if not self._recreate_deployments_envs:
             return
-        for tenant in ('restoretenant', 'restoretenant2'):
-            client = get_rest_client(tenant=tenant)
-            client.snapshots.restore(snapshot_id='snapshot41fake',
-                                     recreate_deployment_envs_for=tenant)
 
-    def recreate_deployment_envs_for(self):
         ctx.logger.info('Restoring deployment environments')
         deployments_contexts = ctx.deployments_contexts
 

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -34,8 +34,6 @@ from cloudify_system_workflows import plugins
 from cloudify_system_workflows.deployment_environment import \
     generate_create_dep_tasks_graph
 
-from cloudify_rest_client.exceptions import CloudifyClientError
-
 from . import utils
 from .npm import Npm
 from .agents import Agents
@@ -150,8 +148,10 @@ class SnapshotRestore(object):
         validator.validate()
 
     def _restore_files_to_manager(self):
-        new_tenant = self._tenant_name \
-            if self._snapshot_version < V_4_0_0 else ''
+        if self._snapshot_version < V_4_0_0:
+            new_tenant = self._tenant_name or ''
+        else:
+            new_tenant = ''
         ctx.logger.info('Restoring files from the archive to the manager')
         utils.copy_files_between_manager_and_snapshot(
             self._tempdir,
@@ -184,7 +184,7 @@ class SnapshotRestore(object):
             # If no tenant name was passed, we can assume that we're working
             # with the community edition (due to the validations we've made)
             tenant_name = self._tenant_name or \
-                self._config['default_tenant_name']
+                self._config.default_tenant_name
             ElasticSearch.restore_db_from_pre_4_version(
                 self._tempdir,
                 tenant_name
@@ -429,37 +429,14 @@ class SnapshotRestoreValidator(object):
 
     def _validate_v_3_snapshot(self):
         if self._tenant_name:
-            if self._is_premium_enabled:
-                self._assert_tenant_does_not_exist()
-            else:
+            if not self._is_premium_enabled:
                 raise NonRecoverableError(
                     'Passing a tenant name when restoring a snapshot is a '
                     'feature that exists only in the premium edition of '
                     'Cloudify. \nPlease contact sales for additional info.'
                 )
         else:
-            if self._is_premium_enabled:
-                raise NonRecoverableError(
-                    'Tenant name was not provided when restoring a snapshot '
-                    'of version {0}. Tenant name must be provided when '
-                    'restoring versions prior to {1}'.format(
-                        self._snapshot_version,
-                        V_4_0_0
-                    ))
-            else:
-                self._assert_clean_db()
-
-    def _assert_tenant_does_not_exist(self):
-        try:
-            self._client.tenants.get(self._tenant_name)
-            raise NonRecoverableError(
-                'Tenant `{0}` already exists on the manager. A *new* tenant '
-                'name must be provided when restoring a snapshot of version '
-                'prior to {1}'.format(self._tenant_name, V_4_0_0)
-            )
-        except CloudifyClientError:
-            # We're expecting a client error here if the tenant does not exist
-            pass
+            self._assert_clean_db()
 
     def _assert_clean_db(self):
         if self._client.blueprints.list(_all_tenants=True).items:

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -272,10 +272,7 @@ class SnapshotRestore(object):
         for plugin in installable_plugins:
             if should_install(plugin):
                 tenant = plugin['tenant']
-                if tenant in plugins_to_install.keys():
-                    plugins_to_install[tenant].append(plugin)
-                else:
-                    plugins_to_install[tenant] = [plugin]
+                plugins_to_install.setdefault(tenant, []).append(plugin)
         ctx.logger.debug('Found plugins to install by tenant: {p}'
                          .format(p=plugins_to_install))
         return plugins_to_install

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -20,7 +20,6 @@ import zipfile
 import platform
 import tempfile
 import subprocess
-from contextlib import contextmanager
 
 from wagon import wagon
 
@@ -30,7 +29,6 @@ from cloudify.manager import get_rest_client
 from cloudify.exceptions import NonRecoverableError
 from cloudify.constants import FILE_SERVER_SNAPSHOTS_FOLDER
 
-from cloudify_system_workflows import plugins
 from cloudify_system_workflows.deployment_environment import \
     generate_create_dep_tasks_graph
 
@@ -148,16 +146,11 @@ class SnapshotRestore(object):
         validator.validate()
 
     def _restore_files_to_manager(self):
-        if self._snapshot_version < V_4_0_0:
-            new_tenant = self._tenant_name or ''
-        else:
-            new_tenant = ''
         ctx.logger.info('Restoring files from the archive to the manager')
         utils.copy_files_between_manager_and_snapshot(
             self._tempdir,
             self._config,
             to_archive=False,
-            new_tenant=new_tenant
         )
         utils.restore_stage_files(self._tempdir)
         ctx.logger.info('Successfully restored archive files')
@@ -181,13 +174,9 @@ class SnapshotRestore(object):
             if self._should_clean_old_db_for_3_x_snapshot():
                 postgres.clean_db()
 
-            # If no tenant name was passed, we can assume that we're working
-            # with the community edition (due to the validations we've made)
-            tenant_name = self._tenant_name or \
-                self._config.default_tenant_name
             ElasticSearch.restore_db_from_pre_4_version(
                 self._tempdir,
-                tenant_name
+                ctx.tenant_name,
             )
         ctx.logger.info('Successfully restored database')
 
@@ -242,8 +231,19 @@ class SnapshotRestore(object):
     def _get_existing_plugin_names(self):
         ctx.logger.debug('Collecting existing plugins')
         existing_plugins = self._client.plugins.list(_all_tenants=True)
-        return set((p.archive_name, p['tenant_name'])
+        return set(self._get_plugin_archive_path_id_and_tenant(p)
                    for p in existing_plugins)
+
+    def _get_plugin_archive_path_id_and_tenant(self, plugin):
+        return {
+            'path': os.path.join(
+                '/opt/manager/resources/plugins',
+                plugin['id'],
+                plugin.archive_name
+            ),
+            'id': plugin['id'],
+            'tenant': plugin['tenant_name'],
+        }
 
     def _get_existing_dep_envs(self):
         return [dep.id for dep in self._client.deployments.list()]
@@ -256,17 +256,29 @@ class SnapshotRestore(object):
         :param existing_plugins: Names of already installed plugins
         """
         def should_install(plugin):
-            return (plugin.archive_name, plugin['tenant_name']) \
-                   not in existing_plugins \
-                   and self._plugin_installable_on_current_platform(plugin)
+            # Can't just do 'not in' as plugin is a dict
+            hashable_existing = (frozenset(p) for p in existing_plugins)
+            return frozenset(plugin.items()) not in hashable_existing
 
         ctx.logger.debug('Looking for plugins to install')
         all_plugins = self._client.plugins.list(_all_tenants=True)
+        installable_plugins = [
+            self._get_plugin_archive_path_id_and_tenant(plugin)
+            for plugin in all_plugins
+            if self._plugin_installable_on_current_platform(plugin)
+        ]
         ctx.logger.debug('Found {0} plugins in total'
                          .format(len(all_plugins)))
-        plugins_to_install = [p for p in all_plugins if should_install(p)]
-        ctx.logger.debug('Found {0} plugins to install'
-                         .format(len(plugins_to_install)))
+        plugins_to_install = {}
+        for plugin in installable_plugins:
+            if should_install(plugin):
+                tenant = plugin['tenant']
+                if tenant in plugins_to_install.keys():
+                    plugins_to_install[tenant].append(plugin)
+                else:
+                    plugins_to_install[tenant] = [plugin]
+        ctx.logger.debug('Found plugins to install by tenant: {p}'
+                         .format(p=plugins_to_install))
         return plugins_to_install
 
     def _restore_plugins(self, existing_plugins):
@@ -276,14 +288,23 @@ class SnapshotRestore(object):
         """
         ctx.logger.info('Restoring plugins')
         plugins_to_install = self._get_plugins_to_install(existing_plugins)
-        for plugin in plugins_to_install:
-            self._tenant_name = plugin['tenant_name']
-            with self._update_tenant_in_ctx():
-                plugins.install(ctx=ctx, plugin={
-                    'name': plugin['package_name'],
-                    'package_name': plugin['package_name'],
-                    'package_version': plugin['package_version']
-                })
+        for tenant, plugins in plugins_to_install.items():
+            client = get_rest_client(tenant=tenant)
+            plugins_tmp = tempfile.mkdtemp()
+            for plugin in plugins:
+                wagon_name = os.path.basename(plugin['path'])
+                ctx.logger.info(
+                    'Installing plugin {plugin} for {tenant}'.format(
+                        plugin=wagon_name,
+                        tenant=tenant,
+                    )
+                )
+                temp_plugin = os.path.join(plugins_tmp, wagon_name)
+                shutil.copyfile(plugin['path'], temp_plugin)
+                client.plugins.delete(plugin['id'], force=True)
+                client.plugins.upload(temp_plugin)
+                os.remove(temp_plugin)
+            os.rmdir(plugins_tmp)
         ctx.logger.info('Successfully restored plugins')
 
     @staticmethod
@@ -309,25 +330,8 @@ class SnapshotRestore(object):
 
     def _restore_agents(self):
         ctx.logger.info('Restoring cloudify agent data')
-        Agents().restore(self._tempdir, self._tenant_client)
+        Agents().restore(self._tempdir, self._client)
         ctx.logger.info('Successfully restored cloudify agent data')
-
-    def _get_tenant_client(self):
-        with self._update_tenant_in_ctx():
-            return get_rest_client()
-
-    @contextmanager
-    def _update_tenant_in_ctx(self):
-        """Temporarily change the tenant in the current context to be the
-        tenant passed in the restore command
-        """
-        curr_tenant = ctx.tenant_name
-        tenant_name = self._tenant_name if self._tenant_name else curr_tenant
-        try:
-            ctx._context['tenant_name'] = tenant_name
-            yield
-        finally:
-            ctx._context['tenant_name'] = curr_tenant
 
     def _restore_deployment_envs(self, existing_dep_envs):
         """Restore any deployment environments on the manager that didn't
@@ -338,16 +342,21 @@ class SnapshotRestore(object):
         """
         if not self._recreate_deployments_envs:
             return
+        for tenant in ('restoretenant', 'restoretenant2'):
+            client = get_rest_client(tenant=tenant)
+            client.snapshots.restore(snapshot_id='snapshot41fake',
+                                     recreate_deployment_envs_for=tenant)
+
+    def recreate_deployment_envs_for(self):
         ctx.logger.info('Restoring deployment environments')
-        with self._update_tenant_in_ctx():
-            deployments_contexts = ctx.deployments_contexts
+        deployments_contexts = ctx.deployments_contexts
 
         for deployment_id, dep_ctx in deployments_contexts.iteritems():
             if deployment_id in existing_dep_envs:
                 continue
             with dep_ctx:
-                dep = self._tenant_client.deployments.get(deployment_id)
-                blueprint = self._tenant_client.blueprints.get(
+                dep = self._client.deployments.get(deployment_id)
+                blueprint = self._client.blueprints.get(
                     dep_ctx.blueprint.id)
                 tasks_graph = self._get_tasks_graph(dep_ctx, blueprint, dep)
                 tasks_graph.execute()
@@ -410,12 +419,10 @@ class SnapshotRestoreValidator(object):
     def _validate_v_4_snapshot(self):
         if self._tenant_name:
             raise NonRecoverableError(
-                'Tenant name `{0}` passed when restoring snapshot of version '
-                '{1}. Tenant name should only be passed when restoring '
-                'versions prior to {2}'.format(
-                    self._tenant_name,
-                    self._snapshot_version,
-                    V_4_0_0
+                'Tenant name `{tenant}` passed when restoring snapshot of '
+                'version {version}.'.format(
+                    tenant=self._tenant_name,
+                    version=self._snapshot_version,
                 )
             )
 
@@ -429,12 +436,14 @@ class SnapshotRestoreValidator(object):
 
     def _validate_v_3_snapshot(self):
         if self._tenant_name:
-            if not self._is_premium_enabled:
-                raise NonRecoverableError(
-                    'Passing a tenant name when restoring a snapshot is a '
-                    'feature that exists only in the premium edition of '
-                    'Cloudify. \nPlease contact sales for additional info.'
+            raise NonRecoverableError(
+                'Passing a tenant name when restoring a snapshot is no '
+                'longer supported. Please switch to the "{tenant}" tenant '
+                'and re-upload then perform the restore from that '
+                'tenant.'.format(
+                    tenant=self._tenant_name,
                 )
+            )
         else:
             self._assert_clean_db()
 

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -65,8 +65,7 @@ class SnapshotRestore(object):
                  premium_enabled,
                  user_is_bootstrap_admin,
                  restore_certificates,
-                 no_reboot,
-                 recreate_deployment_envs_for):
+                 no_reboot):
         self._npm = Npm()
         self._config = utils.DictToAttributes(config)
         self._snapshot_id = snapshot_id
@@ -82,15 +81,8 @@ class SnapshotRestore(object):
         self._tempdir = None
         self._snapshot_version = None
         self._client = get_rest_client()
-        self._recreate_deployment_envs_for = recreate_deployment_envs_for
 
     def restore(self):
-        if self._recreate_deployment_envs_for:
-            # To avoid having to try to modify the ctx in interesting ways,
-            # the deployment envs are restored with a call per tenant
-            self._recreate_deployment_envs()
-            return
-
         self._tempdir = tempfile.mkdtemp('-snapshot-data')
         snapshot_path = self._get_snapshot_path()
         ctx.logger.debug('Going to restore snapshot, '

--- a/workflows/cloudify_system_workflows/snapshots/utils.py
+++ b/workflows/cloudify_system_workflows/snapshots/utils.py
@@ -50,8 +50,7 @@ class DictToAttributes(object):
 
 def copy_files_between_manager_and_snapshot(archive_root,
                                             config,
-                                            to_archive=True,
-                                            new_tenant=''):
+                                            to_archive=True):
     """
     Copy files/dirs between snapshot/manager and manager/snapshot.
 
@@ -59,9 +58,6 @@ def copy_files_between_manager_and_snapshot(archive_root,
     :param config: Config of manager.
     :param to_archive: If True then copying is from manager to snapshot,
         otherwise from snapshot to manager.
-    :param new_tenant: a tenant to which the snapshot is restored.
-        Relevant only in the case of restoring a snapshot from a manager
-        of a version older than 4.0.0
     """
     ctx.logger.info('Copying files/directories...')
 
@@ -71,25 +67,22 @@ def copy_files_between_manager_and_snapshot(archive_root,
     # in manager) and snapshot archive (path in snapshot). If paths are
     # absolute then should point to proper data in manager/snapshot archive
     data_to_copy = [
-        (os.path.join(
-            constants.FILE_SERVER_BLUEPRINTS_FOLDER, new_tenant),
-         constants.FILE_SERVER_BLUEPRINTS_FOLDER),
-        (os.path.join(
-            constants.FILE_SERVER_DEPLOYMENTS_FOLDER, new_tenant),
-         constants.FILE_SERVER_DEPLOYMENTS_FOLDER),
-        (os.path.join(
-            constants.FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER, new_tenant),
-         constants.FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER),
-        (constants.FILE_SERVER_PLUGINS_FOLDER,
-         constants.FILE_SERVER_PLUGINS_FOLDER)
+        constants.FILE_SERVER_BLUEPRINTS_FOLDER,
+        constants.FILE_SERVER_DEPLOYMENTS_FOLDER,
+        constants.FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER,
+        constants.FILE_SERVER_PLUGINS_FOLDER,
     ]
+
+    # To work with cert dir logic for archiving
+    data_to_copy = [(path, path) for path in data_to_copy]
 
     local_cert_dir = os.path.dirname(get_local_rest_certificate())
     if to_archive:
         data_to_copy.append((local_cert_dir,
                              snapshot_constants.ARCHIVE_CERT_DIR))
 
-    for (p1, p2) in data_to_copy:
+    ctx.logger.info(str(data_to_copy))
+    for p1, p2 in data_to_copy:
         # first expand relative paths
         if p1[0] != '/':
             p1 = os.path.join(config.file_server_root, p1)
@@ -142,18 +135,18 @@ def restore_stage_files(archive_root):
 
 
 def copy_snapshot_path(source, destination):
-        # source doesn't need to exist, then ignore
-        if not os.path.exists(source):
-            return
-        ctx.logger.debug(
-            'Copying from dump: {0} to: {1}..'.format(source, destination))
-        # copy data
-        if os.path.isfile(source):
-            shutil.copy(source, destination)
-        else:
-            if os.path.exists(destination):
-                shutil.rmtree(destination)
-            shutil.copytree(source, destination)
+    # source doesn't need to exist, then ignore
+    if not os.path.exists(source):
+        return
+    ctx.logger.debug(
+        'Copying from dump: {0} to: {1}..'.format(source, destination))
+    # copy data
+    if os.path.isfile(source):
+        shutil.copy(source, destination)
+    else:
+        if os.path.exists(destination):
+            shutil.rmtree(destination)
+        shutil.copytree(source, destination)
 
 
 def copy(source, destination):


### PR DESCRIPTION
Makes 3.x snapshot restores only go to the existing tenant, which works around the issue of plugins not being in the tenant after the restore.

Makes plugin wagons be restored to correct tenants for 4.x snapshots.

Disables restoring 3.x snapshots to the not-current tenant.