### PR TITLE
CFY-6997. Restrict allowed characters in rabbitmq user password

### DIFF
--- a/rest-service/manager_rest/amqp_manager.py
+++ b/rest-service/manager_rest/amqp_manager.py
@@ -116,7 +116,7 @@ class AMQPManager(object):
         allowed_characters = (
             string.letters +
             string.digits +
-            string.punctuation
+            '-_'
         )
 
         password = ''.join(


### PR DESCRIPTION
This is to prevent escaping problems from happening in scripts that
just quote the password value.