### PR TITLE
CFY-7005. Default timestamp values as UTC

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/3496c876cd1a_drop_server_side_event_timestamp_.py
+++ b/resources/rest-service/cloudify/migrations/versions/3496c876cd1a_drop_server_side_event_timestamp_.py
@@ -1,0 +1,36 @@
+"""Drop server-side event timestamp defaults
+
+Revision ID: 3496c876cd1a
+Revises: 730403566523
+Create Date: 2017-06-20 10:58:39.408846
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3496c876cd1a'
+down_revision = '730403566523'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    for table_name in ['events', 'logs']:
+        op.alter_column(
+            table_name,
+            'timestamp',
+            server_default=None,
+            nullable=False,
+        ),
+
+
+def downgrade():
+    for table_name in ['events', 'logs']:
+        op.alter_column(
+            table_name,
+            'timestamp',
+            server_default=sa.func.current_timestamp(),
+            nullable=False,
+        )

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -13,8 +13,9 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
+from datetime import datetime
+
 from flask_restful import fields as flask_fields
-from sqlalchemy import func
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -195,7 +196,7 @@ class Event(SQLResourceBase):
 
     timestamp = db.Column(
         UTCDateTime,
-        server_default=func.current_timestamp(),
+        default=datetime.utcnow,
         nullable=False,
         index=True,
     )
@@ -228,7 +229,7 @@ class Log(SQLResourceBase):
 
     timestamp = db.Column(
         UTCDateTime,
-        server_default=func.current_timestamp(),
+        default=datetime.utcnow,
         nullable=False,
         index=True,
     )


### PR DESCRIPTION
In this PR, the schema for the events and logs tables is updated to drop the server side default that was inserting `timestamp` values automatically. This is because the timestamp value was in localtime, not UTC, in PostgreSQL and there's no common syntax supported by both PostgreSQL and SQLite to add that default (SQLAlchemy should handle that, but it doesn't yet).

Hence, the timestamp value is either generated by SQLAlchemy using `datetime.utcnow` or passed explicitly (as logstash does).  