### PR TITLE
CFY-7005. Add event test cases with different database timezone

### DIFF
--- a/tests/integration_tests/resources/dsl/dockercompute_timezone.yaml
+++ b/tests/integration_tests/resources/dsl/dockercompute_timezone.yaml
@@ -1,0 +1,28 @@
+# In this blueprint:
+# - a docker container is created
+# - the agents is installed in the docker container
+# - timezone configuration is updated in the container
+# - a log is generated after timezone configuration updated
+#
+# The goal is to verify if the timestamp in the logs change after the timezone
+# in the container is updated
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+    - cloudify/types/types.yaml
+    - plugins/dockercompute.yaml
+
+node_templates:
+  agent_host:
+    type: cloudify.nodes.docker.Compute
+    properties:
+      install_agent: true
+
+  timezone_configurator:
+    type: cloudify.nodes.SoftwareComponent
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: agent_host
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        configure: scripts/operations/timezone_configure.sh

--- a/tests/integration_tests/resources/dsl/scripts/operations/timezone_configure.sh
+++ b/tests/integration_tests/resources/dsl/scripts/operations/timezone_configure.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+TIMEZONE="Asia/Jerusalem"
+
+ctx logger info "Date before timezone configuration: $(date)"
+ctx logger info "Setting timezone for $(hostname) to $TIMEZONE"
+rm -f /etc/localtime
+ln -s /usr/share/zoneinfo/$TIMEZONE /etc/localtime
+ctx logger info "Date after timezone configuration: $(date)"

--- a/tests/integration_tests/tests/agent_tests/test_events.py
+++ b/tests/integration_tests/tests/agent_tests/test_events.py
@@ -75,8 +75,10 @@ class TimezoneTest(AgentTestWithPlugins):
         stop_timestamp = datetime.utcnow().isoformat()
 
         all_events = list(deploy_events) + list(undeploy_events)
-        timestamps = [event['timestamp'] for event in all_events]
-        self.assertTrue(all(
-            start_timestamp < timestamp < stop_timestamp
-            for timestamp in timestamps
-        ))
+
+        for field_name in ['timestamp', 'reported_timestamp']:
+            timestamps = [event[field_name] for event in all_events]
+            self.assertTrue(all(
+                start_timestamp < timestamp < stop_timestamp
+                for timestamp in timestamps
+            ))

--- a/tests/integration_tests/tests/agent_tests/test_events.py
+++ b/tests/integration_tests/tests/agent_tests/test_events.py
@@ -17,10 +17,6 @@ import uuid
 
 from datetime import datetime
 
-import pytz
-
-from dateutil.parser import parse as parse_datetime
-
 from integration_tests import AgentTestWithPlugins
 from integration_tests.framework.postgresql import run_query
 from integration_tests.tests.utils import get_resource as resource

--- a/tests/integration_tests/tests/agent_tests/test_events.py
+++ b/tests/integration_tests/tests/agent_tests/test_events.py
@@ -1,0 +1,82 @@
+########
+# Copyright (c) 2017 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+import uuid
+
+from datetime import datetime
+
+from integration_tests import AgentTestWithPlugins
+from integration_tests.framework.postgresql import run_query
+from integration_tests.tests.utils import get_resource as resource
+
+from manager_rest.flask_utils import get_postgres_conf
+
+
+class TimezoneTest(AgentTestWithPlugins):
+
+    """Events test cases using an alternative timezone (Asia/Jerusalem)."""
+
+    TIMEZONE = 'Asia/Jerusalem'
+
+    @classmethod
+    def setUpClass(cls):
+        """Configure database timezone."""
+        super(TimezoneTest, cls).setUpClass()
+
+        # Container is launched once per unittest.TestCase class.
+        # Timezone configuration just needs to updated at the class level.
+        # Between tests cases tables are re-created,
+        # but timezone configuration is preserved.
+        postgres_conf = get_postgres_conf()
+        run_query(
+            "ALTER USER {} SET TIME ZONE '{}'"
+            .format(postgres_conf.username, cls.TIMEZONE)
+        )
+
+    def setUp(self):
+        """Update postgres timezone and create a deployment."""
+        # Make sure that database timezone is correctly set
+        query_result = run_query('SHOW TIME ZONE')
+        self.assertEqual(query_result['all'][0][0], self.TIMEZONE)
+
+        super(TimezoneTest, self).setUp()
+
+    def test_event_timezone(self):
+        """Create deployment with agent and delete it afterwards."""
+        deployment_id = str(uuid.uuid4())
+        blueprint = 'dsl/with_agent.yaml'
+        dsl_path = resource(blueprint)
+
+        start_timestamp = datetime.utcnow().isoformat()
+        _, execution_id = self.deploy_application(
+            dsl_path, deployment_id=deployment_id)
+        deploy_events = self.client.events.list(
+            execution_id=execution_id, include_logs=True)
+
+        # TBD: Update timezone in agent container
+        # rm -f /etc/localtime
+        # ln -s /usr/share/zoneinfo/Asia/Jerusalem /etc/localtime
+
+        execution_id = self.undeploy_application(deployment_id)
+        undeploy_events = self.client.events.list(
+            execution_id=execution_id, include_logs=True)
+        stop_timestamp = datetime.utcnow().isoformat()
+
+        all_events = list(deploy_events) + list(undeploy_events)
+        timestamps = [event['timestamp'] for event in all_events]
+        self.assertTrue(all(
+            start_timestamp < timestamp < stop_timestamp
+            for timestamp in timestamps
+        ))

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -13,11 +13,18 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
+from datetime import datetime
+
 from integration_tests import AgentlessTestCase
+from integration_tests.framework.postgresql import run_query
 from integration_tests.tests.utils import get_resource as resource
+
+from manager_rest.flask_utils import get_postgres_conf
 
 
 class EventsTest(AgentlessTestCase):
+
+    """Events test cases using the default database timezone (UTC)."""
 
     def setUp(self):
         super(EventsTest, self).setUp()
@@ -132,3 +139,53 @@ class EventsTest(AgentlessTestCase):
         dsl_path = resource('dsl/basic_event_and_log.yaml')
         test_deployment, _ = self.deploy_application(dsl_path)
         return test_deployment.id
+
+
+class EventsAlternativeTimezoneTest(EventsTest):
+
+    """Events test cases using an alternative timezone (Asia/Jerusalem)."""
+
+    TIMEZONE = 'Asia/Jerusalem'
+
+    @classmethod
+    def setUpClass(cls):
+        """Configure database timezone."""
+        super(EventsAlternativeTimezoneTest, cls).setUpClass()
+
+        # Container is launched once per unittest.TestCase class.
+        # Timezone configuration just needs to updated at the class level.
+        # Between tests cases tables are re-created,
+        # but timezone configuration is preserved.
+        postgres_conf = get_postgres_conf()
+        run_query(
+            "ALTER USER {} SET TIME ZONE '{}'"
+            .format(postgres_conf.username, cls.TIMEZONE)
+        )
+
+    def setUp(self):
+        """Update postgres timezone and create a deployment."""
+        # Make sure that database timezone is correctly set
+        query_result = run_query('SHOW TIME ZONE')
+        self.assertEqual(query_result['all'][0][0], self.TIMEZONE)
+
+        self.start_timestamp = datetime.utcnow().isoformat()
+        super(EventsAlternativeTimezoneTest, self).setUp()
+        self.stop_timestamp = datetime.utcnow().isoformat()
+
+    def test_timestamp_in_utc(self):
+        """Make sure events timestamp field is in UTC."""
+        events = self._events_list()
+        timestamps = [event['timestamp'] for event in events]
+        self.assertTrue(all(
+            self.start_timestamp < timestamp < self.stop_timestamp
+            for timestamp in timestamps
+        ))
+
+    def test_reported_timestamp_in_utc(self):
+        """Make sure events reported_timestamp field is in UTC."""
+        events = self._events_list()
+        reported_timestamps = [event['reported_timestamp'] for event in events]
+        self.assertTrue(all(
+            self.start_timestamp < reported_timestamp < self.stop_timestamp
+            for reported_timestamp in reported_timestamps
+        ))

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -38,18 +38,31 @@ class EventsTest(AgentlessTestCase):
 
     def test_timestamp_range(self):
         """Filter events by timestamp range."""
-        all_events = self._events_list(_sort='@timestamp')
-        min_time = all_events[0]['timestamp']
+        all_events = self._events_list(
+            _sort='@timestamp',
+            include_logs=True,
+        )
+        all_timestamps = [event['timestamp'] for event in all_events]
 
-        expected_event_count, max_time = next(
-            (index, event['timestamp'])
-            for index, event in enumerate(all_events)
-            if event['timestamp'] > min_time
+        min_time = all_timestamps[0]
+        max_time = next(
+            timestamp
+            for timestamp in all_timestamps
+            if timestamp > min_time
+        )
+        expected_event_count = sum([
+            min_time <= timestamp < max_time
+            for timestamp in all_timestamps
+        ])
+
+        ranged_events = self._events_list(
+            _sort='@timestamp',
+            include_logs=True,
+            from_datetime=min_time,
+            to_datetime=max_time,
+            skip_assertion=True,
         )
 
-        # get only half of the events by timestamp
-        ranged_events = self._events_list(
-            from_datetime=min_time, to_datetime=max_time)
         self.assertEquals(len(ranged_events), expected_event_count)
 
     def test_sorted_events(self):


### PR DESCRIPTION
In this PR, a new events test class is added to the integration tests. This new class inherits from the old one meaning that all test cases are repeated using a different timezone configuration with the addition of a couple ones that verify that the timestamp values are within the expected range in UTC.