### PR TITLE
CFY-7005 Parse timestamps as UTC values and remove timezone info

### DIFF
--- a/rest-service/manager_rest/rest/rest_decorators.py
+++ b/rest-service/manager_rest/rest/rest_decorators.py
@@ -13,6 +13,8 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
+import pytz
+
 from functools import wraps
 from collections import OrderedDict
 
@@ -253,6 +255,15 @@ def rangeable(func):
             parsed_datetime = parse_datetime(datetime)
         except Exception:
             raise Invalid('Datetime parsing error')
+
+        # Make sure timestamp is in UTC, but doesn't have any timezone info.
+        # Passing timezone aware timestamp to PosgreSQL through SQLAlchemy
+        # doesn't seem to work well in manual tests
+        if parsed_datetime.tzinfo:
+            parsed_datetime = (
+                parsed_datetime.astimezone(pytz.timezone('UTC'))
+                .replace(tzinfo=None)
+            )
 
         return parsed_datetime
 

--- a/rest-service/manager_rest/test/endpoints/test_rest_decorators.py
+++ b/rest-service/manager_rest/test/endpoints/test_rest_decorators.py
@@ -115,7 +115,9 @@ class RangeableTest(TestCase):
         with patch('manager_rest.rest.rest_decorators.request') as request:
             for valid_datetime_str in valid_datetime_strs:
                 valid_value = 'field,{0},{0}'.format(valid_datetime_str)
-                valid_datetime = parse_datetime(valid_datetime_str)
+                valid_datetime = (
+                    parse_datetime(valid_datetime_str).replace(tzinfo=None)
+                )
                 expected_value = {
                     'field': {
                         'from': valid_datetime,
@@ -130,7 +132,9 @@ class RangeableTest(TestCase):
         """From/to are optional and validation passes if one is missing."""
 
         valid_datetime_str = '2016-09-12T00:00:00.0Z'
-        valid_datetime = parse_datetime(valid_datetime_str)
+        valid_datetime = (
+            parse_datetime(valid_datetime_str).replace(tzinfo=None)
+        )
 
         with patch('manager_rest.rest.rest_decorators.request') as request:
             data = [
@@ -156,7 +160,9 @@ class RangeableTest(TestCase):
         """Unicode values pass validation."""
 
         valid_datetime_str = '2016-09-12T00:00:00.0Z'
-        valid_datetime = parse_datetime(valid_datetime_str)
+        valid_datetime = (
+            parse_datetime(valid_datetime_str).replace(tzinfo=None)
+        )
 
         with patch('manager_rest.rest.rest_decorators.request') as request:
             data = [


### PR DESCRIPTION
Passing timezone aware timestamp to PosgreSQL through SQLAlchemy doesn't
seem to work well in manual tests