### PR TITLE
CFY-6728. Retry if file already exists

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_deployment_creation.py
+++ b/tests/integration_tests/tests/agentless_tests/test_deployment_creation.py
@@ -1,0 +1,45 @@
+########
+# Copyright (c) 2017 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+
+import uuid
+
+from integration_tests import AgentlessTestCase
+from integration_tests.tests import utils
+
+
+class TestDeploymentCreation(AgentlessTestCase):
+
+    """Create multiple deployments."""
+
+    DEPLOYMENTS_COUNT = 10
+
+    def test_deployment_with_the_same_id(self):
+        """Create multiple deployments with the same ID.
+
+        The goal of this test is run multiple create/delete deployment cycles
+        to find out if there's any race condition that prevents the creation of
+        a deployment of the same ID just after it's been deleted.
+
+        """
+        dsl_path = utils.get_resource('dsl/basic.yaml')
+        blueprint_id = deployment_id = str(uuid.uuid4())
+        self.client.blueprints.upload(dsl_path, blueprint_id)
+
+        for _ in range(self.DEPLOYMENTS_COUNT):
+            self.client.deployments.create(
+                blueprint_id, deployment_id, skip_plugins_validation=True)
+            utils.wait_for_deployment_creation_to_complete(deployment_id)
+            self.client.deployments.delete(deployment_id)

--- a/workflows/cloudify_system_workflows/deployment_environment.py
+++ b/workflows/cloudify_system_workflows/deployment_environment.py
@@ -183,7 +183,7 @@ def _retry_if_file_already_exists(exception):
 
 
 @workflow_context.task_config(send_task_events=False)
-@retry(retry_on_exception=_retry_if_file_already_exists)
+@retry(retry_on_exception=_retry_if_file_already_exists, stop_max_delay=60000)
 def _create_deployment_workdir(deployment_id, logger, tenant):
     deployment_workdir = _workdir(deployment_id, tenant)
     try:

--- a/workflows/cloudify_system_workflows/deployment_environment.py
+++ b/workflows/cloudify_system_workflows/deployment_environment.py
@@ -18,6 +18,8 @@ import os
 import shutil
 import errno
 
+from retrying import retry
+
 from cloudify.decorators import workflow
 from cloudify.workflows import tasks as workflow_tasks
 from cloudify.workflows import workflow_context
@@ -172,12 +174,21 @@ def _ignore_task_on_fail_and_send_event(task, ctx):
     task.on_failure = failure_handler
 
 
+def _retry_if_file_already_exists(exception):
+    """Retry if file already exist exception raised."""
+    return (
+        isinstance(exception, OSError) and
+        exception.errno == errno.EEXIST
+    )
+
+
 @workflow_context.task_config(send_task_events=False)
+@retry(retry_on_exception=_retry_if_file_already_exists)
 def _create_deployment_workdir(deployment_id, logger, tenant):
     deployment_workdir = _workdir(deployment_id, tenant)
     try:
         os.makedirs(deployment_workdir)
-    except os.error as e:
+    except OSError as e:
         if e.errno == errno.EEXIST:
             logger.error('Failed creating directory {0}. '
                          'Current directory content: {1}'.format(

--- a/workflows/setup.py
+++ b/workflows/setup.py
@@ -30,5 +30,6 @@ setup(
     install_requires=[
         'cloudify-plugins-common==4.1',
         'elasticsearch==1.6.0'
+        'retrying==1.3.3',
     ]
 )


### PR DESCRIPTION
In this PR, a `retry` decorator has been added to the function in which the `OSError` exception was being raised. After this change, the test case in which the problem is reproduced passes successfully.