### PR TITLE
CFY-7005. Add exception message to `test_timestamp_in_utc`

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -194,11 +194,8 @@ class EventsAlternativeTimezoneTest(EventsTest):
                 for timestamp in timestamps
                 if not self.start_timestamp < timestamp < self.stop_timestamp
         ]
-        self.assertTrue(
-            all(
-                self.start_timestamp < timestamp < self.stop_timestamp
-                for timestamp in timestamps
-            ),
+        self.assertFalse(
+            out_of_range_timestamps,
             'Timestamp values out of range [{} - {}]: {}'
             .format(
                 self.start_timestamp,

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -189,10 +189,23 @@ class EventsAlternativeTimezoneTest(EventsTest):
         """Make sure events timestamp field is in UTC."""
         events = self._events_list()
         timestamps = [event['timestamp'] for event in events]
-        self.assertTrue(all(
-            self.start_timestamp < timestamp < self.stop_timestamp
-            for timestamp in timestamps
-        ))
+        out_of_range_timestamps = [
+                timestamp
+                for timestamp in timestamps
+                if not self.start_timestamp < timestamp < self.stop_timestamp
+        ]
+        self.assertTrue(
+            all(
+                self.start_timestamp < timestamp < self.stop_timestamp
+                for timestamp in timestamps
+            ),
+            'Timestamp values out of range [{} - {}]: {}'
+            .format(
+                self.start_timestamp,
+                self.stop_timestamp,
+                out_of_range_timestamps,
+            )
+        )
 
     def test_reported_timestamp_in_utc(self):
         """Make sure events reported_timestamp field is in UTC."""


### PR DESCRIPTION
In this PR, a message is included in the assertion that verifies that all timestamps are in UTC. This way, if the test case fails in the future, the message will include the timestamps that are out of the expected range.