### PR TITLE
Make snapshot agent key converter apply db changes

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/fix_snapshot_ssh_db.py
+++ b/workflows/cloudify_system_workflows/snapshots/fix_snapshot_ssh_db.py
@@ -16,10 +16,14 @@
 
 import os
 import argparse
-from copy import deepcopy
 
 from manager_rest import flask_utils
-from manager_rest.storage.models import Deployment
+import manager_rest.storage.storage_manager as stor
+from manager_rest.storage.resource_models import (
+    Deployment,
+    Node,
+    NodeInstance,
+)
 from manager_rest.storage import get_storage_manager
 
 # These vars need to be loaded before the rest server is imported
@@ -31,6 +35,18 @@ os.environ["MANAGER_REST_CONFIG_PATH"] = (
 os.environ["MANAGER_REST_SECURITY_CONFIG_PATH"] = (
     "/opt/manager/rest-security.conf"
 )
+
+
+def commit_changes(storage_manager, item_class, item, update):
+    """
+        Commit changes to the DB for a given entity.
+    """
+    # Using the storage manager's update and refresh resulted in no updates
+    storage_manager.db.session.query(item_class).filter_by(
+        id=item.id,
+    ).update(update)
+    storage_manager.db.session.commit()
+    storage_manager.db.session.refresh(item)
 
 
 def replace_ssh_keys(input_dict, original_string, secret_name):
@@ -103,10 +119,12 @@ def main(original_string, secret_name):
                     print('Changing runtime properties for `{0}`'.format(
                         node_instance.id
                     ))
-                    node_instance.runtime_properties = deepcopy(
-                        runtime_properties
+                    commit_changes(
+                        stor,
+                        NodeInstance,
+                        node_instance,
+                        {'runtime_properties': runtime_properties},
                     )
-                    sm.update(node_instance)
                     print('Updated')
                 else:
                     print('No changes')
@@ -134,9 +152,12 @@ def main(original_string, secret_name):
             if changed:
                 print('Changing operations/properties for node '
                       '`{0}` on dep `{1}`'.format(node.id, deployment.id))
-                node.operations = deepcopy(ops)
-                node.properties = deepcopy(props)
-                sm.update(node)
+                commit_changes(
+                    stor,
+                    Node,
+                    node,
+                    {'operations': ops, 'properties': props},
+                )
                 print('Updated')
             else:
                 print('No changes')


### PR DESCRIPTION
Without this, the update runs, but the changes seem to be lost (presumably something to do with the way the storage manager is being used here causing it not to commit correctly?).