### PR TITLE
CFY-7188 Use a script to set manager SSL state

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/status.py
+++ b/rest-service/manager_rest/rest/resources_v1/status.py
@@ -18,16 +18,12 @@ import os
 
 from flask_restful_swagger import swagger
 
-from manager_rest.rest import responses
+from manager_rest.rest import responses, rest_utils
 from manager_rest.rest.rest_decorators import (
     exceptions_handled,
     marshal_with,
 )
 from manager_rest.security import SecuredResource
-try:
-    from cloudify_premium.ha import node_status
-except ImportError:
-    node_status = {'initialized': False}
 
 
 class Status(SecuredResource):
@@ -73,7 +69,7 @@ class Status(SecuredResource):
                             'postgresql-9.5.service': 'PostgreSQL'
                             }
 
-                if self._is_clustered():
+                if rest_utils.is_clustered():
                     # clustered postgresql service is named differently -
                     # the old service is not used in a clustered manager,
                     # so we can ignore its status
@@ -95,7 +91,3 @@ class Status(SecuredResource):
     @staticmethod
     def _is_docker_env():
         return os.getenv('DOCKER_ENV') is not None
-
-    @staticmethod
-    def _is_clustered():
-        return node_status.get('initialized')

--- a/rest-service/manager_rest/rest/resources_v3_1/manager.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/manager.py
@@ -13,7 +13,7 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from subprocess import check_call, Popen
+from subprocess import check_call
 
 from flask_login import current_user
 
@@ -44,12 +44,8 @@ class SSLConfig(SecuredResource):
         status = 'enabled' if state else 'disabled'
         if state == SSLConfig._is_enabled():
             return 'SSL is already {0} on the manager'.format(status)
-        source = HTTP_PATH if state else HTTPS_PATH
-        target = HTTPS_PATH if state else HTTP_PATH
-        cmd = 'sudo sed -i "s~{0}~{1}~g" {2}'.format(
-            source, target, DEFAULT_CONF_PATH)
-        check_call(cmd, shell=True)
-        Popen('sleep 1; sudo systemctl restart nginx', shell=True)
+        flag = '--ssl-enabled' if state else '--ssl-disabled'
+        check_call(['/opt/cloudify/restservice/set-manager-ssl.py', flag])
         return 'SSL is now {0} on the manager'.format(status)
 
     @exceptions_handled

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -24,6 +24,10 @@ from contextlib import contextmanager
 
 from manager_rest import manager_exceptions
 from manager_rest.constants import REST_SERVICE_NAME
+try:
+    from cloudify_premium.ha import node_status
+except ImportError:
+    node_status = {'initialized': False}
 
 
 @contextmanager
@@ -159,3 +163,7 @@ def validate_and_decode_password(password):
         )
 
     return password
+
+
+def is_clustered():
+    return node_status.get('initialized')

--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -31,6 +31,7 @@ from flask_restful import abort
 
 from manager_rest import constants, config
 
+
 CLOUDIFY_AUTH_HEADER = 'Authorization'
 CLOUDIFY_AUTH_TOKEN_HEADER = 'Authentication-Token'
 CLOUDIFY_API_AUTH_TOKEN_HEADER = 'API-Authentication-Token'
@@ -113,7 +114,7 @@ def get_plugin_archive_path(plugin_id, archive_name):
 
 def plugin_installable_on_current_platform(plugin):
     dist, _, release = platform.linux_distribution(
-            full_distribution_name=False)
+        full_distribution_name=False)
     dist, release = dist.lower(), release.lower()
 
     # Mac OSX is a special case, in which plugin.distribution and
@@ -134,7 +135,7 @@ def get_formatted_timestamp():
     return '{0}Z'.format(datetime.now().isoformat()[:-3])
 
 
-class classproperty(object):
+class classproperty(object):  # NOQA  # class CapWords
     """A class that acts a a decorator for class-level properties
 
     class A(object):


### PR DESCRIPTION
Instead of calling `sed` from the restservice code, let's add
a script that will do the necessary config changes.
This way, we can also run that script from within cluster code,
and also we won't need to enable `sudo` for `sed`, only for this
specific script.