### PR TITLE
CFY-7257. Add roles column

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
+++ b/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
@@ -23,7 +23,16 @@ def upgrade():
         sa.Column('role_id', sa.Integer()),
         sa.ForeignKeyConstraint(['role_id'], ['roles.id'], ),
     )
+    op.create_primary_key(
+        'users_tenants_pkey',
+        'users_tenants',
+        ['user_id', 'tenant_id'],
+    )
 
 
 def downgrade():
+    op.drop_constraint(
+        'users_tenants_pkey',
+        'users_tenants',
+    )
     op.drop_column('users_tenants', 'role_id')

--- a/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
+++ b/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
@@ -1,0 +1,29 @@
+"""Add role column to users_tenants table
+
+Revision ID: 406821843b55
+Revises: 3496c876cd1a
+Create Date: 2017-10-01 19:37:31.484983
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import manager_rest     # Adding this manually
+
+
+# revision identifiers, used by Alembic.
+revision = '406821843b55'
+down_revision = '3496c876cd1a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'users_tenants',
+        sa.Column('role_id', sa.Integer()),
+        sa.ForeignKeyConstraint(['role_id'], ['roles.id'], ),
+    )
+
+
+def downgrade():
+    op.drop_column('users_tenants', 'role_id')

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -161,9 +161,7 @@ class User(SQLModelBase, UserMixin):
     def groups(cls):
         return many_to_many_relationship(cls, Group)
 
-    @declared_attr
-    def tenants(cls):
-        return many_to_many_relationship(cls, Tenant)
+    tenants = db.relationship('UserTenant', backpopulates='user')
 
     @property
     def all_tenants(self):

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -203,4 +203,21 @@ class User(SQLModelBase, UserMixin):
         return self.id == BOOTSTRAP_ADMIN_ID
 
 
+class UserTenant(SQLModelBase):
+    """Association class between users and tenants."""
+    __tablename__ = 'users_tenants'
+    user_id = db.Column(
+        db.Integer, db.ForeignKey(User.id), primary_key=True)
+    tenant_id = db.Column(
+        db.Integer, db.ForeignKey(Tenant.id), primary_key=True)
+
+    # Role is not part of the primary key
+    # because only one role for each user and tenant is allowed for now
+    role_id = db.Column(db.Integer, db.ForeignKey(Role.id))
+
+    user = db.relationship(User, backpopulates='tenants')
+    tenant = db.relationship(Tenant)
+    role = db.relationship(Role)
+
+
 user_datastore = SQLAlchemyUserDatastore(db, User, Role)


### PR DESCRIPTION
Note: this is a work in progress

In this PR, the `users_tenant` secondary table is replaced with an association object that generates the same table with the following details:
- a new column `role_id` is added to the table
- a primary key constraint is generated to include `user_id` and `tenant_id`. Note that `role_id` is not part of the primary key because for now only one role is allowed per user and tenant.