### PR TITLE
CFY-7257. Add roles column to secondary table

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
+++ b/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
@@ -19,7 +19,13 @@ def upgrade():
     op.add_column(
         'users_tenants',
         sa.Column('role_id', sa.Integer()),
-        sa.ForeignKeyConstraint(['role_id'], ['roles.id'], ),
+    )
+    op.create_foreign_key(
+        'users_tenants_role_id_fkey',
+        'users_tenants',
+        'roles',
+        ['role_id'],
+        ['id'],
     )
     op.create_primary_key(
         'users_tenants_pkey',
@@ -31,6 +37,10 @@ def upgrade():
 def downgrade():
     op.drop_constraint(
         'users_tenants_pkey',
+        'users_tenants',
+    )
+    op.drop_constraint(
+        'users_tenants_role_id_fkey',
         'users_tenants',
     )
     op.drop_column('users_tenants', 'role_id')

--- a/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
+++ b/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
@@ -1,0 +1,27 @@
+"""Add role column to users_tenants table
+Revision ID: 406821843b55
+Revises: 3496c876cd1a
+Create Date: 2017-10-01 19:37:31.484983
+"""
+from alembic import op
+import sqlalchemy as sa
+import manager_rest     # Adding this manually
+
+
+# revision identifiers, used by Alembic.
+revision = '406821843b55'
+down_revision = '3496c876cd1a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'users_tenants',
+        sa.Column('role_id', sa.Integer()),
+        sa.ForeignKeyConstraint(['role_id'], ['roles.id'], ),
+    )
+
+
+def downgrade():
+    op.drop_column('users_tenants', 'role_id')

--- a/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
+++ b/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
@@ -10,7 +10,7 @@ import manager_rest     # Adding this manually
 
 # revision identifiers, used by Alembic.
 revision = '406821843b55'
-down_revision = '3496c876cd1a'
+down_revision = '4dfd8797fdfa'
 branch_labels = None
 depends_on = None
 

--- a/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
+++ b/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
@@ -21,7 +21,16 @@ def upgrade():
         sa.Column('role_id', sa.Integer()),
         sa.ForeignKeyConstraint(['role_id'], ['roles.id'], ),
     )
+    op.create_primary_key(
+        'users_tenants_pkey',
+        'users_tenants',
+        ['user_id', 'tenant_id'],
+    )
 
 
 def downgrade():
+    op.drop_constraint(
+        'users_tenants_pkey',
+        'users_tenants',
+    )
     op.drop_column('users_tenants', 'role_id')

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -163,24 +163,16 @@ class User(SQLModelBase, UserMixin):
 
     @declared_attr
     def tenants(cls):
-        secondary_table = db.Table(
-            'users_tenants',
+        table_names = ['users', 'tenants', 'roles']
+        columns = [
             db.Column(
-                'user_id',
+                '{0}_id'.format(table_name[:-1]),
                 db.Integer,
-                db.ForeignKey('users.id')
-            ),
-            db.Column(
-                'tenant_id',
-                db.Integer,
-                db.ForeignKey('tenants.id')
-            ),
-            db.Column(
-                'role_id',
-                db.Integer,
-                db.ForeignKey('roles.id')
-            ),
-        )
+                db.ForeignKey('{0}.id'.format(table_name))
+            )
+            for table_name in table_names
+        ]
+        secondary_table = db.Table('users_tenants', *columns)
         return db.relationship(
             Tenant,
             secondary=secondary_table,

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -174,12 +174,8 @@ class User(SQLModelBase, UserMixin):
         ]
         constraint = db.PrimaryKeyConstraint(
             'user_id', 'tenant_id', name='users_tenants_pkey')
-        secondary_table = db.Table(
-            'users_tenants',
-            constraint,
-            *columns
-
-        )
+        args = columns + [constraint]
+        secondary_table = db.Table('users_tenants', *args)
         return db.relationship(
             Tenant,
             secondary=secondary_table,

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -172,10 +172,10 @@ class User(SQLModelBase, UserMixin):
             )
             for table_name in table_names
         ]
+        secondary_table = db.Table('users_tenants', *columns)
         constraint = db.PrimaryKeyConstraint(
             'user_id', 'tenant_id', name='users_tenants_pkey')
-        args = columns + [constraint]
-        secondary_table = db.Table('users_tenants', *args)
+        secondary_table.append_constraint(constraint)
         return db.relationship(
             Tenant,
             secondary=secondary_table,

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -172,7 +172,14 @@ class User(SQLModelBase, UserMixin):
             )
             for table_name in table_names
         ]
-        secondary_table = db.Table('users_tenants', *columns)
+        constraint = db.PrimaryKeyConstraint(
+            'user_id', 'tenant_id', name='users_tenants_pkey')
+        secondary_table = db.Table(
+            'users_tenants',
+            constraint,
+            *columns
+
+        )
         return db.relationship(
             Tenant,
             secondary=secondary_table,

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -163,7 +163,29 @@ class User(SQLModelBase, UserMixin):
 
     @declared_attr
     def tenants(cls):
-        return many_to_many_relationship(cls, Tenant)
+        secondary_table = db.Table(
+            'users_tenants',
+            db.Column(
+                'user_id',
+                db.Integer,
+                db.ForeignKey('users.id')
+            ),
+            db.Column(
+                'tenant_id',
+                db.Integer,
+                db.ForeignKey('tenants.id')
+            ),
+            db.Column(
+                'role_id',
+                db.Integer,
+                db.ForeignKey('roles.id')
+            ),
+        )
+        return db.relationship(
+            Tenant,
+            secondary=secondary_table,
+            backref=db.backref('users'),
+        )
 
     @property
     def all_tenants(self):


### PR DESCRIPTION
In this PR, a custom secondary table is created to add the new `role_id` column to the `users_tenants` table.

Related #973  