### PR TITLE
CFY-7257 Use association object instead of secondary table

### DIFF
--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -249,6 +249,13 @@ class User(SQLModelBase, UserMixin):
 
 
 class UserTenantAssoc(SQLModelBase):
+    """Association between users and tenants.
+
+    This is used to create a many-to-many relationship between users and
+    tenants with the ability to set the role as an additional attribute to the
+    relationship.
+
+    """
     __tablename__ = 'users_tenants'
     user_id = db.Column(
         db.Integer,

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -61,7 +61,7 @@ class Tenant(SQLModelBase):
     rabbitmq_password = db.Column(db.Text)
 
     user_associations = db.relationship(
-        'UserTenant',
+        'UserTenantAssoc',
         back_populates='tenant',
         cascade='all, delete-orphan',
     )
@@ -184,7 +184,7 @@ class User(SQLModelBase, UserMixin):
     api_token_key = db.Column(db.String(100))
 
     tenant_associations = db.relationship(
-        'UserTenant',
+        'UserTenantAssoc',
         back_populates='user',
         cascade='all, delete-orphan',
     )
@@ -248,7 +248,7 @@ class User(SQLModelBase, UserMixin):
         return self.id == BOOTSTRAP_ADMIN_ID
 
 
-class UserTenant(SQLModelBase):
+class UserTenantAssoc(SQLModelBase):
     __tablename__ = 'users_tenants'
     user_id = db.Column(
         db.Integer,

--- a/rest-service/manager_rest/storage/models.py
+++ b/rest-service/manager_rest/storage/models.py
@@ -18,6 +18,7 @@
 from .management_models import (User,
                                 Role,
                                 Group,
+                                GroupTenantAssoc,
                                 Tenant,
                                 UserTenantAssoc,
                                 user_datastore,

--- a/rest-service/manager_rest/storage/models.py
+++ b/rest-service/manager_rest/storage/models.py
@@ -19,7 +19,7 @@ from .management_models import (User,
                                 Role,
                                 Group,
                                 Tenant,
-                                UserTenant,
+                                UserTenantAssoc,
                                 user_datastore,
                                 ProviderContext)
 

--- a/rest-service/manager_rest/storage/models.py
+++ b/rest-service/manager_rest/storage/models.py
@@ -19,6 +19,7 @@ from .management_models import (User,
                                 Role,
                                 Group,
                                 Tenant,
+                                UserTenant,
                                 user_datastore,
                                 ProviderContext)
 

--- a/rest-service/manager_rest/storage/storage_utils.py
+++ b/rest-service/manager_rest/storage/storage_utils.py
@@ -18,7 +18,7 @@ from flask_security.utils import encrypt_password
 
 from manager_rest import constants
 from manager_rest.storage.models import Node
-from manager_rest.storage.management_models import Tenant
+from manager_rest.storage.management_models import Tenant, UserTenant
 from manager_rest.manager_exceptions import NotFoundError
 from manager_rest.storage import user_datastore, db, get_storage_manager
 
@@ -58,7 +58,12 @@ def create_default_user_tenant_and_roles(admin_username,
         password=encrypt_password(admin_password),
         roles=[admin_role]
     )
-    admin_user.tenants.append(default_tenant)
+    user_tenant = UserTenant(
+        user=admin_user,
+        tenant=default_tenant,
+        role_id=admin_role.id,
+    )
+    admin_user.tenant_associations.append(user_tenant)
     user_datastore.commit()
     return default_tenant
 

--- a/rest-service/manager_rest/storage/storage_utils.py
+++ b/rest-service/manager_rest/storage/storage_utils.py
@@ -18,7 +18,7 @@ from flask_security.utils import encrypt_password
 
 from manager_rest import constants
 from manager_rest.storage.models import Node
-from manager_rest.storage.management_models import Tenant, UserTenant
+from manager_rest.storage.management_models import Tenant, UserTenantAssoc
 from manager_rest.manager_exceptions import NotFoundError
 from manager_rest.storage import user_datastore, db, get_storage_manager
 
@@ -58,12 +58,12 @@ def create_default_user_tenant_and_roles(admin_username,
         password=encrypt_password(admin_password),
         roles=[admin_role]
     )
-    user_tenant = UserTenant(
+    user_tenant_association = UserTenantAssoc(
         user=admin_user,
         tenant=default_tenant,
         role_id=admin_role.id,
     )
-    admin_user.tenant_associations.append(user_tenant)
+    admin_user.tenant_associations.append(user_tenant_association)
     user_datastore.commit()
     return default_tenant
 

--- a/rest-service/manager_rest/storage/storage_utils.py
+++ b/rest-service/manager_rest/storage/storage_utils.py
@@ -59,7 +59,6 @@ def create_default_user_tenant_and_roles(admin_username,
         roles=[admin_role]
     )
     user_tenant_association = UserTenantAssoc(
-        user=admin_user,
         tenant=default_tenant,
         role_id=admin_role.id,
     )

--- a/rest-service/manager_rest/test/security_utils.py
+++ b/rest-service/manager_rest/test/security_utils.py
@@ -15,7 +15,7 @@
 
 from flask_security.utils import encrypt_password
 
-from manager_rest.storage.models import Tenant
+from manager_rest.storage.models import Tenant, UserTenant
 from manager_rest.storage import user_datastore
 from manager_rest.constants import (ADMIN_ROLE,
                                     USER_ROLE,
@@ -67,5 +67,10 @@ def add_users_to_db(user_list):
             roles=[role]
         )
         user_obj.active = user.get('active', True)
-        user_obj.tenants.append(default_tenant)
+        user_tenant = UserTenant(
+            user=user_obj,
+            tenant=default_tenant,
+            role_id=role.id,
+        )
+        user_obj.tenant_associations.append(user_tenant)
     user_datastore.commit()

--- a/rest-service/manager_rest/test/security_utils.py
+++ b/rest-service/manager_rest/test/security_utils.py
@@ -68,7 +68,6 @@ def add_users_to_db(user_list):
         )
         user_obj.active = user.get('active', True)
         user_tenant_association = UserTenantAssoc(
-            user=user_obj,
             tenant=default_tenant,
             role_id=role.id,
         )

--- a/rest-service/manager_rest/test/security_utils.py
+++ b/rest-service/manager_rest/test/security_utils.py
@@ -15,7 +15,7 @@
 
 from flask_security.utils import encrypt_password
 
-from manager_rest.storage.models import Tenant, UserTenant
+from manager_rest.storage.models import Tenant, UserTenantAssoc
 from manager_rest.storage import user_datastore
 from manager_rest.constants import (ADMIN_ROLE,
                                     USER_ROLE,
@@ -67,10 +67,10 @@ def add_users_to_db(user_list):
             roles=[role]
         )
         user_obj.active = user.get('active', True)
-        user_tenant = UserTenant(
+        user_tenant_association = UserTenantAssoc(
             user=user_obj,
             tenant=default_tenant,
             role_id=role.id,
         )
-        user_obj.tenant_associations.append(user_tenant)
+        user_obj.tenant_associations.append(user_tenant_association)
     user_datastore.commit()


### PR DESCRIPTION
In this PR, the original secondary table design is replaced with an association object.

This is because the secondary table doesn't provide a way to access the `role_id` column
at the ORM level and that is something that will be needed to add/remove tenants to a user. 

Note that back references are set to new attributes (`user_associations` and `tenant_associations`)
while association proxies are used to keep the old attributes (`users` and `tenants`).
This way, old code that uses those attributes don't need to be updated.

Also, there's a cascade parameter in the relationships that will be used in a separate PR
when removing users from a tenant.