### PR TITLE
CFY-7258. Use association object

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/7aae863786af_add_role_column_groups_tenants_table.py
+++ b/resources/rest-service/cloudify/migrations/versions/7aae863786af_add_role_column_groups_tenants_table.py
@@ -1,0 +1,48 @@
+"""Add role column to groups_tenants_table
+
+Revision ID: 7aae863786af
+Revises: 406821843b55
+Create Date: 2017-10-04 11:10:48.227654
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import manager_rest     # Adding this manually
+
+
+# revision identifiers, used by Alembic.
+revision = '7aae863786af'
+down_revision = '406821843b55'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'groups_tenants',
+        sa.Column('role_id', sa.Integer()),
+    )
+    op.create_foreign_key(
+        'groups_tenants_role_id_fkey',
+        'groups_tenants',
+        'roles',
+        ['role_id'],
+        ['id'],
+    )
+    op.create_primary_key(
+        'groups_tenants_pkey',
+        'groups_tenants',
+        ['group_id', 'tenant_id'],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        'groups_tenants_pkey',
+        'groups_tenants',
+    )
+    op.drop_constraint(
+        'groups_tenants_role_id_fkey',
+        'groups_tenants',
+    )
+    op.drop_column('groups_tenants', 'role_id')

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -114,6 +114,31 @@ class Group(SQLModelBase):
         return group_dict
 
 
+class GroupTenantAssoc(SQLModelBase):
+    """Association between groups and tenants.
+
+    This is used to create a many-to-many relationship between groups and
+    tenants with the ability to set the role as an additional attribute to the
+    relationship.
+
+    """
+    __tablename__ = 'groups_tenants'
+    group_id = db.Column(
+        db.Integer,
+        db.ForeignKey('groups.id'),
+        primary_key=True,
+    )
+    tenant_id = db.Column(
+        db.Integer,
+        db.ForeignKey('tenants.id'),
+        primary_key=True,
+    )
+    role_id = db.Column(db.Integer, db.ForeignKey('roles.id'))
+
+    group = db.relationship('Group', back_populates='tenant_associations')
+    tenant = db.relationship('Tenant', back_populates='group_associations')
+
+
 class Role(SQLModelBase, RoleMixin):
     __tablename__ = 'roles'
 

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -60,6 +60,13 @@ class Tenant(SQLModelBase):
     rabbitmq_username = db.Column(db.Text)
     rabbitmq_password = db.Column(db.Text)
 
+    group_associations = db.relationship(
+        'GroupTenantAssoc',
+        back_populates='tenant',
+        cascade='all, delete-orphan',
+    )
+    groups = association_proxy('group_associations', 'group')
+
     def _get_identifier_dict(self):
         return OrderedDict({'name': self.name})
 


### PR DESCRIPTION
In this PR, the database schema is updated to add a `role_id` column to the `groups_tenants` table, so that a role can be assigned to a group when added to a tenant.