### PR TITLE
CFY-7258 Add creator function to association proxies

### DIFF
--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -225,12 +225,12 @@ class User(SQLModelBase, UserMixin):
 
         Note: recursive membership in groups is currently not supported
         """
-        tenant_list = self.tenants
+        all_tenants = set()
+        all_tenants.update(self.tenants)
         for group in self.groups:
-            for tenant in group.tenants:
-                tenant_list.append(tenant)
+            all_tenants.update(group.tenants)
 
-        return list(set(tenant_list))
+        return list(all_tenants)
 
     def to_response(self, get_data=False):
         user_dict = super(User, self).to_response()

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -65,13 +65,21 @@ class Tenant(SQLModelBase):
         back_populates='tenant',
         cascade='all, delete-orphan',
     )
-    users = association_proxy('user_associations', 'user')
+    users = association_proxy(
+        'user_associations',
+        'user',
+        creator=lambda user: UserTenantAssoc(user=user),
+    )
     group_associations = db.relationship(
         'GroupTenantAssoc',
         back_populates='tenant',
         cascade='all, delete-orphan',
     )
-    groups = association_proxy('group_associations', 'group')
+    groups = association_proxy(
+        'group_associations',
+        'group',
+        creator=lambda group: GroupTenantAssoc(group=group),
+    )
 
     def _get_identifier_dict(self):
         return OrderedDict({'name': self.name})


### PR DESCRIPTION
In this PR, a creator function is added to the association proxies, so that an association can be created easily when there's no need to set the role in that association. 

In addition to this, the `User.all_tenants` property problems have been fixed. The issue was related to lists returned by association proxies not having a `.append` method.