### PR TITLE
Celery: don't send users/groups related to a tenant

### DIFF
--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -85,7 +85,8 @@ def execute_system_workflow(wf_id,
 def _get_tenant_dict():
     current_tenant = current_app.config[CURRENT_TENANT_CONFIG]
     tenant_dict = current_tenant.to_dict()
-    tenant_dict.pop('id')
+    for to_remove in ['id', 'users', 'groups']:
+        tenant_dict.pop(to_remove)
     return tenant_dict
 
 


### PR DESCRIPTION
Celery tasks don't require the users/groups related to a tenant, so
we don't need to send them.

If we did want to send them, we'd have to serialize them. Currently
the users and groups end up as sqlalchemy association proxy lists
of models, which can't be json-encoded directly.

Future work might involve whitelisting the attributes instead of
blacklisting, ie. creating a new dict there with just the few
attributes that are required, instead of serializing the whole
tenant object and removing the few attributes we don't want.