### PR TITLE
CFY-7257. Update all_tenants property to return a dictionary

### DIFF
--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -164,6 +164,13 @@ class GroupTenantAssoc(SQLModelBase):
     tenant = db.relationship('Tenant', back_populates='group_associations')
     role = db.relationship('Role')
 
+    def _get_identifier_dict(self):
+        """Return elements to display in object's string representation."""
+        return OrderedDict([
+            ('group', self.group.name),
+            ('tenant', self.tenant.name),
+        ])
+
 
 class Role(SQLModelBase, RoleMixin):
     __tablename__ = 'roles'

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -281,5 +281,13 @@ class UserTenantAssoc(SQLModelBase):
     tenant = db.relationship('Tenant', back_populates='user_associations')
     role = db.relationship('Role')
 
+    def _get_identifier_dict(self):
+        """Return elements to display in object's string representation."""
+        return OrderedDict([
+            ('user', self.user.username),
+            ('tenant', self.tenant.name),
+            ('role', self.role.name),
+        ])
+
 
 user_datastore = SQLAlchemyUserDatastore(db, User, Role)

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -279,6 +279,7 @@ class UserTenantAssoc(SQLModelBase):
 
     user = db.relationship('User', back_populates='tenant_associations')
     tenant = db.relationship('Tenant', back_populates='user_associations')
+    role = db.relationship('Role')
 
 
 user_datastore = SQLAlchemyUserDatastore(db, User, Role)

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -162,6 +162,7 @@ class GroupTenantAssoc(SQLModelBase):
 
     group = db.relationship('Group', back_populates='tenant_associations')
     tenant = db.relationship('Tenant', back_populates='group_associations')
+    role = db.relationship('Role')
 
 
 class Role(SQLModelBase, RoleMixin):

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -96,12 +96,12 @@ class Tenant(SQLModelBase):
 
     @property
     def all_users(self):
-        users_list = self.users
+        all_users = set()
+        all_users.update(self.users)
         for group in self.groups:
-            for user in group.users:
-                users_list.append(user)
+            all_users.update(group.users)
 
-        return list(set(users_list))
+        return list(all_users)
 
     @property
     def is_default_tenant(self):


### PR DESCRIPTION
In this PR, the `User.all_tenants` property is updated to return a dictionary where the keys of the dictionary are the tenants associated with that user and the values are the role associated with that user in the context of the tenant.

Besides this, there are other changes to make it easier to work with the association objects:
- fix string representation
- get role object through relationship

Finally the `Tenant.all_users` method is updated to return a list instead of an association proxy list which has side effects that the code that uses it doesn't take into account and might cause problems like the ones seen in integration tests where a new instance of an ORM object conflicts with another one that is already in persistent state with the same primary key.