### PR TITLE
CFY-7257. Set user tenant role in migration

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
+++ b/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
@@ -32,6 +32,17 @@ def upgrade():
         'users_tenants',
         ['user_id', 'tenant_id'],
     )
+    op.execute(sa.text(
+        '''
+        UPDATE users_tenants
+        SET role_id =
+            (
+                SELECT role_id
+                FROM users_roles
+                WHERE user_id = users_tenants.user_id
+            )
+        '''
+    ))
 
 
 def downgrade():

--- a/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
+++ b/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
@@ -52,6 +52,7 @@ def upgrade():
             .where(users_tenants.c.user_id == users_roles.c.user_id)
         ))
     )
+    op.alter_column('users_tenants', 'role_id', nullable=False)
 
 
 def downgrade():

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -291,7 +291,11 @@ class UserTenantAssoc(SQLModelBase):
         db.ForeignKey('tenants.id'),
         primary_key=True,
     )
-    role_id = db.Column(db.Integer, db.ForeignKey('roles.id'))
+    role_id = db.Column(
+        db.Integer,
+        db.ForeignKey('roles.id'),
+        nullable=False,
+    )
 
     user = db.relationship('User', back_populates='tenant_associations')
     tenant = db.relationship('Tenant', back_populates='user_associations')


### PR DESCRIPTION
In this PR, the migration script that adds the `role_id` column to the `users_tenants` table is updated to set the system-wide user role as the default value for the association. In addition to this, once the column has been filled in with values, a `NOT NULL` constraint is added to make sure that the column always contains a value.