### PR TITLE
CFY-7258. Set 'user' role by default in migration scripts

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
+++ b/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
@@ -33,23 +33,24 @@ def upgrade():
         ['user_id', 'tenant_id'],
     )
 
-    # Define with just the columns needed
+    # Define tables with just the columns needed
     # to generate the UPDATE sql expression below
     users_tenants = sa.table(
         'users_tenants',
         sa.column('user_id', sa.Integer),
         sa.column('role_id', sa.Integer),
     )
-    users_roles = sa.table(
-        'users_roles',
-        sa.column('user_id', sa.Integer),
-        sa.column('role_id', sa.Integer),
+    roles = sa.table(
+        'roles',
+        sa.column('id', sa.Integer),
+        sa.column('name', sa.Text),
     )
+    # Set 'user' role as the default for every user in a tenant
     op.execute(
         users_tenants.update()
         .values(role_id=(
-            sa.select([users_roles.c.role_id])
-            .where(users_tenants.c.user_id == users_roles.c.user_id)
+            sa.select([roles.c.id])
+            .where(roles.c.name == 'user')
         ))
     )
     op.alter_column('users_tenants', 'role_id', nullable=False)

--- a/resources/rest-service/cloudify/migrations/versions/7aae863786af_add_role_column_groups_tenants_table.py
+++ b/resources/rest-service/cloudify/migrations/versions/7aae863786af_add_role_column_groups_tenants_table.py
@@ -54,8 +54,7 @@ def upgrade():
             .where(roles.c.name == 'user')
         ))
     )
-    # TBD: Uncomment when default value is set when a group is added to tenant
-    # op.alter_column('groups_tenants', 'role_id', nullable=False)
+    op.alter_column('groups_tenants', 'role_id', nullable=False)
 
 
 def downgrade():

--- a/resources/rest-service/cloudify/migrations/versions/7aae863786af_add_role_column_groups_tenants_table.py
+++ b/resources/rest-service/cloudify/migrations/versions/7aae863786af_add_role_column_groups_tenants_table.py
@@ -34,6 +34,28 @@ def upgrade():
         'groups_tenants',
         ['group_id', 'tenant_id'],
     )
+    # Define tables with just the columns needed
+    # to generate the UPDATE sql expression below
+    groups_tenants = sa.table(
+        'groups_tenants',
+        sa.column('group_id', sa.Integer),
+        sa.column('role_id', sa.Integer),
+    )
+    roles = sa.table(
+        'roles',
+        sa.column('id', sa.Integer),
+        sa.column('name', sa.Text),
+    )
+    # Set 'user' role as the default for every group in a tenant
+    op.execute(
+        groups_tenants.update()
+        .values(role_id=(
+            sa.select([roles.c.id])
+            .where(roles.c.name == 'user')
+        ))
+    )
+    # TBD: Uncomment when default value is set when a group is added to tenant
+    # op.alter_column('groups_tenants', 'role_id', nullable=False)
 
 
 def downgrade():


### PR DESCRIPTION
In this PR, the `user` role is set by default to every user and group that is part of a tenant

Requires: cloudify-cosmo/cloudify-premium#280