### PR TITLE
CFY-7258. Set system roles to new default values

### DIFF
--- a/rest-service/manager_rest/security/authorization.py
+++ b/rest-service/manager_rest/security/authorization.py
@@ -32,6 +32,7 @@ def authorize(action, request_tenant=None):
                         'Provided tenant name unknown: {0}'.format(tenant_name)
                     )
 
+            # when running unittests, there is no authorization
             if config.instance.test_mode:
                 return func(*args, **kwargs)
             user_roles = current_user.all_tenants.get(tenant_name, []) \


### PR DESCRIPTION
In this PR, system roles are updated to their new default values:

Before | After
-------|------
user | default
admin | sys_admin

Requires: a separate PR where the new `default` and `sys_admin` roles are inserted into the database