### PR TITLE
CFY-7259. Remove unneeded conditional

### DIFF
--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -239,10 +239,8 @@ class User(SQLModelBase, UserMixin):
 
         for group in self.groups:
             for tenant_association in group.tenant_associations:
-                # TBD: Remove this when groups have a role set by default
-                if tenant_association.role:
-                    all_tenants[tenant_association.tenant].add(
-                        tenant_association.role)
+                all_tenants[tenant_association.tenant].add(
+                    tenant_association.role)
         return all_tenants
 
     def to_response(self, get_data=False):

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -168,6 +168,7 @@ class GroupTenantAssoc(SQLModelBase):
         return OrderedDict([
             ('group', self.group.name),
             ('tenant', self.tenant.name),
+            ('role', self.role.name),
         ])
 
 


### PR DESCRIPTION
In this PR, a couple of minor changes are applied now that a `role_id` column is always set in the group tenants association.