### PR TITLE
CFY-7331. Set role description in database

### DIFF
--- a/rest-service/manager_rest/storage/storage_utils.py
+++ b/rest-service/manager_rest/storage/storage_utils.py
@@ -73,7 +73,7 @@ def _create_roles(authorization_file_path):
     for role in roles:
         user_datastore.find_or_create_role(
             name=role['name'],
-            description=role['description'],
+            description=role.get('description'),
         )
     # return the first role, which is the strongest
     return user_datastore.find_role(roles[0]['name'])

--- a/rest-service/manager_rest/storage/storage_utils.py
+++ b/rest-service/manager_rest/storage/storage_utils.py
@@ -71,7 +71,10 @@ def _create_roles(authorization_file_path):
     with open(authorization_file_path) as f:
         roles = load(f)['roles']
     for role in roles:
-        user_datastore.find_or_create_role(name=role['name'])
+        user_datastore.find_or_create_role(
+            name=role['name'],
+            description=role['description'],
+        )
     # return the first role, which is the strongest
     return user_datastore.find_role(roles[0]['name'])
 


### PR DESCRIPTION
In this PR, the role description is inserted into the database, if available, when roles are created from the  `authorization.conf` file.