### PR TITLE
CFY-7357 Deployments shouldn't inherit the blueprint's tenant/creator

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -692,10 +692,7 @@ class ResourceManager(object):
             deployment_id,
             deployment_plan
         )
-        new_deployment.set_blueprint(blueprint)
-        # The creator of the deployment is the current user (can be someone
-        # other than the creator of the blueprint)
-        new_deployment.creator = current_user
+        new_deployment.blueprint = blueprint
         # The deployment is private if either the blueprint was
         # private, or the user passed the `private_resource` flag
         private_blueprint = blueprint.resource_availability == \

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -152,10 +152,6 @@ class Deployment(SQLResourceBase):
                          parameters=wf.get('parameters', dict()))
                 for wf_name, wf in deployment_workflows.iteritems()]
 
-    def set_blueprint(self, blueprint):
-        self._set_parent(blueprint)
-        self.blueprint = blueprint
-
 
 class Execution(SQLResourceBase):
     __tablename__ = 'executions'


### PR DESCRIPTION
The creator is set explicitly anyway, as is the resource availability
field, and the tenant shouldn't be inherited as well, because the
blueprint can be global anyway, in which case there's no point in
inheriting the tenant from it.