### PR TITLE
CFY-7259. Return tenants dictionary in API response

### DIFF
--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -242,7 +242,10 @@ class User(SQLModelBase, UserMixin):
 
     def to_response(self, get_data=False):
         user_dict = super(User, self).to_response()
-        user_dict['tenants'] = _get_response_data(self.all_tenants, get_data)
+        user_dict['tenants'] = {
+            tenant.name: [role.name for role in roles]
+            for tenant, roles in self.all_tenants.iteritems()
+        }
         user_dict['groups'] = _get_response_data(self.groups, get_data)
         user_dict['role'] = self.role
         return user_dict

--- a/rest-service/manager_rest/test/endpoints/test_user.py
+++ b/rest-service/manager_rest/test/endpoints/test_user.py
@@ -29,5 +29,5 @@ class UserTestCase(base_test.BaseServerTestCase):
         self.assertEqual('admin', result['username'])
         self.assertEqual('sys_admin', result['role'])
         self.assertEqual(0, result['groups'])
-        self.assertEqual(1, result['tenants'])
+        self.assertDictEqual({'default_tenant': ['user']}, result['tenants'])
         self.assertEqual(True, result['active'])


### PR DESCRIPTION
In this PR, the `User.all_tenants` dictionary is returned in the API response.