### PR TITLE
CFY-7259. Take_get data flag into account

### DIFF
--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -99,7 +99,7 @@ class Tenant(SQLModelBase):
 
     def to_response(self, get_data=False):
         tenant_dict = super(Tenant, self).to_response()
-        tenant_dict['groups'] = _get_response_data(self.groups, get_data)
+        tenant_dict['groups'] = _get_response_data(list(self.groups), get_data)
         tenant_dict['users'] = _get_response_data(
             self.all_users,
             get_data=get_data,
@@ -143,7 +143,10 @@ class Group(SQLModelBase):
 
     def to_response(self, get_data=False):
         group_dict = super(Group, self).to_response()
-        group_dict['tenants'] = _get_response_data(self.tenants, get_data)
+        group_dict['tenants'] = _get_response_data(
+            list(self.tenants),
+            get_data,
+        )
         group_dict['users'] = _get_response_data(
             self.users,
             get_data=get_data,

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -50,7 +50,8 @@ def _get_response_data(resources, get_data=False, name_attr='name'):
                 for key, values in resources.iteritems()
             }
         else:
-            raise ValueError('Unexpected resources: {0}'.format(resources))
+            raise ValueError(
+                'Unexpected resources type: {0}'.format(type(resources)))
     else:
         return len(resources)
 

--- a/rest-service/manager_rest/test/endpoints/test_user.py
+++ b/rest-service/manager_rest/test/endpoints/test_user.py
@@ -29,5 +29,5 @@ class UserTestCase(base_test.BaseServerTestCase):
         self.assertEqual('admin', result['username'])
         self.assertEqual('sys_admin', result['role'])
         self.assertEqual(0, result['groups'])
-        self.assertDictEqual({'default_tenant': ['user']}, result['tenants'])
+        self.assertEqual(1, result['tenants'])
         self.assertEqual(True, result['active'])


### PR DESCRIPTION
In this PR, the `get_data` flag is taken into account to make sure that `User.tenants` is either a count of tenants or a dictionary of tenants with the associated roles.