### PR TITLE
CFY-7373. Add endpoint to update group-tenant association

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3/tenants.py
+++ b/rest-service/manager_rest/rest/resources_v3/tenants.py
@@ -177,6 +177,34 @@ class TenantGroups(SecuredMultiTenancyResource):
         )
 
     @rest_decorators.exceptions_handled
+    @authorize('tenant_update_group', get_tenant_from='data')
+    @rest_decorators.marshal_with(TenantResponse)
+    @rest_decorators.no_external_authenticator('update group in tenant')
+    def patch(self, multi_tenancy):
+        """Update role in group tenant association."""
+        request_dict = rest_utils.get_json_and_verify_params(
+            {
+                'tenant_name': {
+                    'type': unicode,
+                },
+                'group_name': {
+                    'type': unicode,
+                },
+                'role': {
+                    'type': unicode,
+                },
+            },
+        )
+        rest_utils.validate_inputs(request_dict)
+        role_name = request_dict['role']
+        rest_utils.validate_role_name(role_name)
+        return multi_tenancy.update_group_in_tenant(
+            request_dict['group_name'],
+            request_dict['tenant_name'],
+            role_name,
+        )
+
+    @rest_decorators.exceptions_handled
     @authorize('tenant_remove_group', get_tenant_from='data')
     @rest_decorators.marshal_with(TenantResponse)
     def delete(self, multi_tenancy):

--- a/rest-service/manager_rest/rest/resources_v3/tenants.py
+++ b/rest-service/manager_rest/rest/resources_v3/tenants.py
@@ -197,7 +197,7 @@ class TenantGroups(SecuredMultiTenancyResource):
         )
         rest_utils.validate_inputs(request_dict)
         role_name = request_dict['role']
-        rest_utils.validate_role_name(role_name)
+        rest_utils.verify_role(role_name)
         return multi_tenancy.update_group_in_tenant(
             request_dict['group_name'],
             request_dict['tenant_name'],


### PR DESCRIPTION
In this PR, the endpoint to update the group-tenant association is added.

Requires:
- cloudify-cosmo/cloudify-manager-blueprints#699
- cloudify-cosmo/cloudify-premium#294