### PR TITLE
storage_manager: check .is_resource before checking for admin

### DIFF
--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -178,11 +178,14 @@ class SQLStorageManager(object):
         if not has_request_context():
             return query
 
-        # For users that are allowed to see all resources, regardless of tenant
         # Queries of elements that aren't resources (tenants, users, etc.),
-        # shouldn't be filtered as well
+        # shouldn't be filtered
+        if not model_class.is_resource:
+            return query
+
+        # For users that are allowed to see all resources, regardless of tenant
         is_admin = is_administrator(self.current_tenant)
-        if not model_class.is_resource or is_admin:
+        if is_admin:
             return query
 
         # Only get resources that are public - not private (note that ~ stands


### PR DESCRIPTION
Authorization queries for a tenant, so we need to be able to look up
tenants BEFORE current_tenant is set.

It used to be that _add_permissions_filter checked for is_resource
before ever checking for administrator, so we should go back to that
behaviour, because now checking for administrator needs a tenant.

So this change simply moves the .is_resource check to BEFORE
touching current_tenant at all.
This also makes _add_permissions_filter be more similar to
_add_tenant_filter.