### PR TITLE
CFY-7350. Only tenant roles in error message

### DIFF
--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -189,6 +189,11 @@ def verify_role(role, is_system_role=False):
                 'Role `{0}` is a {1} and cannot be assigned as a {2}'.format(
                     role, r['name'], role_type)
             )
-    valid_roles = [r['name'] for r in config.instance.authorization_roles]
+
+    valid_roles = [
+        r['name']
+        for r in config.instance.authorization_roles
+        if r['type'] in (role_type, 'any')
+    ]
     raise manager_exceptions.BadParametersError(
         'Invalid role: `{0}`. Valid roles are: {1}'.format(role, valid_roles))

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -187,7 +187,7 @@ def verify_role(role, is_system_role=False):
                 return
             raise manager_exceptions.BadParametersError(
                 'Role `{0}` is a {1} and cannot be assigned as a {2}'.format(
-                    role, r['name'], role_type)
+                    role, r['type'], role_type)
             )
 
     valid_roles = [

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -171,10 +171,10 @@ def is_clustered():
     return node_status.get('initialized')
 
 
-def verify_role(role, is_system_role=False):
+def verify_role(role_name, is_system_role=False):
     """Make sure that role name is present in the system.
 
-    :param role: Role name to validate against database content.
+    :param role_name: Role name to validate against database content.
     :param is_system_role: True if system_role, False if tenant_role
     :raises: BadParametersError when role is not found in the system or is
     not from the right type
@@ -182,12 +182,12 @@ def verify_role(role, is_system_role=False):
     """
     role_type = 'system_role' if is_system_role else 'tenant_role'
     for r in config.instance.authorization_roles:
-        if r['name'] == role:
+        if r['name'] == role_name:
             if r['type'] in (role_type, 'any'):
                 return
             raise manager_exceptions.BadParametersError(
                 'Role `{0}` is a {1} and cannot be assigned as a {2}'.format(
-                    role, r['type'], role_type)
+                    role_name, r['type'], role_type)
             )
 
     valid_roles = [
@@ -196,4 +196,6 @@ def verify_role(role, is_system_role=False):
         if r['type'] in (role_type, 'any')
     ]
     raise manager_exceptions.BadParametersError(
-        'Invalid role: `{0}`. Valid roles are: {1}'.format(role, valid_roles))
+        'Invalid role: `{0}`. Valid roles are: {1}'
+        .format(role_name, valid_roles)
+    )

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -183,7 +183,7 @@ def verify_role(role, is_system_role=False):
     role_type = 'system_role' if is_system_role else 'tenant_role'
     for r in config.instance.authorization_roles:
         if r['name'] == role:
-            if r['type'] == role_type or r['type'] == 'any':
+            if r['type'] in (role_type, 'any'):
                 return
             raise manager_exceptions.BadParametersError(
                 'Role `{0}` is a {1} and cannot be assigned as a {2}'.format(

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -200,8 +200,8 @@ def verify_role(role_name, is_system_role=False):
             if r['type'] in (expected_role_type, 'any')
         ]
         raise manager_exceptions.BadParametersError(
-            'Invalid role: `{0}`. Valid roles are: {1}'
-            .format(role_name, valid_roles)
+            'Invalid role: `{0}`. Valid {1} roles are: {2}'
+            .format(role_name, expected_role_type, valid_roles)
         )
 
     # Role type doesn't match


### PR DESCRIPTION
In this PR, the error message returned when a role is not found is improved. Instead of returning all roles, it just returns the roles of the expected type.

Before:
```
$ cfy tenants add-user -t my-tenant -r unknown my-user
An error occurred on the server: 400: Invalid role: `unknown`. Valid roles are: ['sys_admin', 'manager', 'user', 'viewer', 'default']
```

After:
```
$ cfy tenants add-user -t my-tenant -r unknown my-user
An error occurred on the server: 400: Invalid role: `unknown`. Valid tenant_role roles are: ['manager', 'user', 'viewer']
```