### PR TITLE
CFY-7417. Get tenant with data

### DIFF
--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -48,7 +48,7 @@ def _get_response_data(resources, get_data=False, name_attr='name'):
                 """Get data for the values in a dictionary.
 
                 Values might be a set (User.tenants case) or a single value
-                (Group.tenans case).
+                (Group.tenants case).
 
                 """
                 if isinstance(values, set):

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -37,13 +37,29 @@ def _get_response_data(resources, get_data=False, name_attr='name'):
     """Either return the sorted list of resource names or their total count
 
     :param resources: A list/dict of users/tenants/user-groups
-    :param name_attr: The name attribute (name/username)
+    :param name_attr:
+        The name attribute (name/username) or a dictionary where 'key' is the
+        attribute name for the keys and 'value' is the attribute name for the
+        values.
     :param get_data: If True: return the names, o/w return the count
     """
     if get_data:
         if isinstance(resources, list):
             return sorted(getattr(res, name_attr) for res in resources)
         elif isinstance(resources, dict):
+            if isinstance(name_attr, str):
+                name_attrs = {
+                    'key': name_attr,
+                    'value': name_attr,
+                }
+            elif isinstance(name_attr, dict):
+                name_attrs = name_attr
+            else:
+                raise ValueError(
+                    'Unexpected name_attr type: {0}'
+                    .format(type(name_attr))
+                )
+
             def get_value_data(values):
                 """Get data for the values in a dictionary.
 
@@ -51,14 +67,17 @@ def _get_response_data(resources, get_data=False, name_attr='name'):
                 (Group.tenants case).
 
                 """
+
                 if isinstance(values, set):
                     return sorted([
-                        getattr(value, name_attr) for value in values])
+                        getattr(value, name_attrs['value'])
+                        for value in values
+                    ])
                 else:
-                    return getattr(values, name_attr)
+                    return getattr(values, name_attrs['value'])
 
             return {
-                getattr(key, name_attr): get_value_data(value)
+                getattr(key, name_attrs['key']): get_value_data(value)
                 for key, value in resources.iteritems()
             }
         else:

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -134,18 +134,21 @@ class Tenant(SQLModelBase):
         tenant_dict['users'] = _get_response_data(
             self.all_users,
             get_data=get_data,
-            name_attr='username'
+            name_attr={'key': 'username', 'value': 'name'},
         )
         return tenant_dict
 
     @property
     def all_users(self):
-        all_users = set()
-        all_users.update(self.users)
-        for group in self.groups:
-            all_users.update(group.users)
+        all_users = defaultdict(set)
+        for user_association in self.user_associations:
+            all_users[user_association.user].add(user_association.role)
 
-        return list(all_users)
+        for group_association in self.group_associations:
+            for user in group_association.group.users:
+                all_users[user].add(group_association.role)
+
+        return all_users
 
     @property
     def is_default_tenant(self):

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -130,7 +130,13 @@ class Tenant(SQLModelBase):
 
     def to_response(self, get_data=False):
         tenant_dict = super(Tenant, self).to_response()
-        tenant_dict['groups'] = _get_response_data(list(self.groups), get_data)
+        tenant_dict['groups'] = _get_response_data(
+            {
+                group_association.group: group_association.role
+                for group_association in self.group_associations
+            },
+            get_data,
+        )
         tenant_dict['users'] = _get_response_data(
             self.all_users,
             get_data=get_data,


### PR DESCRIPTION
In this PR, the data returned by the tenant model is updated to display the roles associated with users and groups when the `--get-data` flag is used.

Before:
```
$ cfy tenant get my-tenant --get-data
Getting info for tenant `my-tenant`...

Requested tenant info:
+-----------+---------------------+---------+
|    name   |        groups       |  users  |
+-----------+---------------------+---------+
| my-tenant | my-group,my-group-2 | my-user |
+-----------+---------------------+---------+
```

After:
```
$ cfy tenant get my-tenant --get-data
Getting info for tenant `my-tenant`...

Requested tenant info:
+-----------+-----------------------------------------------------+------------------------------------------------+
|    name   |                        groups                       |                     users                      |
+-----------+-----------------------------------------------------+------------------------------------------------+
| my-tenant | {u'my-group-2': u'manager', u'my-group': u'viewer'} | {u'my-user': [u'manager', u'user', u'viewer']} |
+-----------+-----------------------------------------------------+------------------------------------------------+
```