### PR TITLE
CFY-7373. Return response data directly

### DIFF
--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -93,7 +93,7 @@ def verify_and_convert_bool(attribute_name, str_bool):
 def convert_to_int(value):
     try:
         return int(value)
-    except:
+    except Exception:
         raise manager_exceptions.BadParametersError(
             'invalid parameter, should be int, got: {0}'.format(value))
 

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -33,60 +33,6 @@ from .relationships import (
 from .models_base import db, SQLModelBase, UTCDateTime, CIColumn
 
 
-def _get_response_data(resources, get_data=False, name_attr='name'):
-    """Either return the sorted list of resource names or their total count
-
-    :param resources: A list/dict of users/tenants/user-groups
-    :param name_attr:
-        The name attribute (name/username) or a dictionary where 'key' is the
-        attribute name for the keys and 'value' is the attribute name for the
-        values.
-    :param get_data: If True: return the names, o/w return the count
-    """
-    if get_data:
-        if isinstance(resources, list):
-            return sorted(getattr(res, name_attr) for res in resources)
-        elif isinstance(resources, dict):
-            if isinstance(name_attr, str):
-                name_attrs = {
-                    'key': name_attr,
-                    'value': name_attr,
-                }
-            elif isinstance(name_attr, dict):
-                name_attrs = name_attr
-            else:
-                raise ValueError(
-                    'Unexpected name_attr type: {0}'
-                    .format(type(name_attr))
-                )
-
-            def get_value_data(values):
-                """Get data for the values in a dictionary.
-
-                Values might be a set (User.tenants case) or a single value
-                (Group.tenants case).
-
-                """
-
-                if isinstance(values, set):
-                    return sorted([
-                        getattr(value, name_attrs['value'])
-                        for value in values
-                    ])
-                else:
-                    return getattr(values, name_attrs['value'])
-
-            return {
-                getattr(key, name_attrs['key']): get_value_data(value)
-                for key, value in resources.iteritems()
-            }
-        else:
-            raise ValueError(
-                'Unexpected resources type: {0}'.format(type(resources)))
-    else:
-        return len(resources)
-
-
 class ProviderContext(SQLModelBase):
     __tablename__ = 'provider_context'
 

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -494,7 +494,7 @@ class BaseServerTestCase(unittest.TestCase):
     def quiet_delete(file_path):
         try:
             os.remove(file_path)
-        except:
+        except Exception:
             pass
 
     @staticmethod

--- a/tests/integration_tests/framework/amqp_events_printer.py
+++ b/tests/integration_tests/framework/amqp_events_printer.py
@@ -68,7 +68,7 @@ class EventsPrinter(threading.Thread):
                 output = cloudify.logs.create_event_message_prefix(ev)
                 if output:
                     sys.stdout.write('{0}\n'.format(output))
-            except:
+            except Exception:
                 logger.error('event/log format error - output: {0}'
                              .format(body), exc_info=True)
 

--- a/tests/integration_tests/framework/env.py
+++ b/tests/integration_tests/framework/env.py
@@ -80,7 +80,7 @@ class BaseTestEnvironment(object):
             cfy.init(**kwargs)
             docl.init(resources=self._build_resource_mapping())
             self.on_environment_created()
-        except:
+        except Exception:
             self.destroy()
             raise
 

--- a/tests/integration_tests_blueprint/scripts/utils.py
+++ b/tests/integration_tests_blueprint/scripts/utils.py
@@ -30,13 +30,13 @@ def run(command, ignore_failures=False, workdir=None, out=False):
                 stdout += line
                 try:
                     ctx.logger.info(line.rstrip())
-                except:
+                except Exception:
                     ctx.logger.debug('Failed printing stdout line')
             for line in proc.stderr:
                 stderr += line
                 try:
                     ctx.logger.info(line.rstrip())
-                except:
+                except Exception:
                     ctx.logger.debug('Failed printing stderr line')
             sleep(0.1)
         ctx.logger.info(proc.stdout.read())

--- a/tests/integration_tests_plugins/mock_workflows/workflows.py
+++ b/tests/integration_tests_plugins/mock_workflows/workflows.py
@@ -175,7 +175,7 @@ def test_fail_local_task(ctx, should_fail, do_get):
         result = ctx.local_task(fail)
         if do_get:
             result.get()
-    except:
+    except Exception:
         if should_fail:
             pass
         else:
@@ -209,7 +209,7 @@ def test_fail_local_task_on_nonrecoverable_error(ctx, do_get, **_):
         result = ctx.local_task(fail)
         if do_get:
             result.get()
-    except:
+    except Exception:
         pass
     else:
         raise RuntimeError('Task should have failed')

--- a/workflows/cloudify_system_workflows/snapshots/influxdb.py
+++ b/workflows/cloudify_system_workflows/snapshots/influxdb.py
@@ -80,7 +80,7 @@ class InfluxDB(object):
                     n += 1
                     yield json.dumps(obj)
                     s = s[idx:]
-            except:
+            except Exception:
                 pass
 
         # assert not n or not s

--- a/workflows/cloudify_system_workflows/snapshots/utils.py
+++ b/workflows/cloudify_system_workflows/snapshots/utils.py
@@ -45,7 +45,7 @@ class DictToAttributes(object):
             # try to convert to json,
             # may fail on UTF-8 and stuff, don't sweat on it..
             return json.dumps(self._dict)
-        except:
+        except Exception:
             return self._dict
 
 


### PR DESCRIPTION
In this PR, the `to_response` methods are updated to handle the `get_data` flag directly. 