### PR TITLE
CFY-7350 Fix users response in tenants

### DIFF
--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -89,7 +89,7 @@ class Tenant(SQLModelBase):
 
         """
         return {
-            user.username: sorted(list(role.name for role in user.roles))
+            user.username: sorted(list(role.name for role in roles))
             for user, roles in self.all_users.iteritems()
         }
 

--- a/rest-service/manager_rest/test/security_utils.py
+++ b/rest-service/manager_rest/test/security_utils.py
@@ -76,6 +76,7 @@ def add_users_to_db(user_list):
         default_tenant_role = user_datastore.find_role(DEFAULT_TENANT_ROLE)
         user_obj.active = user.get('active', True)
         user_tenant_association = UserTenantAssoc(
+            user=user_obj,
             tenant=default_tenant,
             role=default_tenant_role,
         )

--- a/rest-service/manager_rest/test/security_utils.py
+++ b/rest-service/manager_rest/test/security_utils.py
@@ -17,7 +17,10 @@ from flask_security.utils import encrypt_password
 
 from manager_rest.storage.models import Tenant, UserTenantAssoc
 from manager_rest.storage import user_datastore
-from manager_rest.constants import DEFAULT_TENANT_ID
+from manager_rest.constants import (
+    DEFAULT_TENANT_ID,
+    DEFAULT_TENANT_ROLE,
+)
 
 
 ADMIN_ROLE = 'sys_admin'
@@ -69,10 +72,12 @@ def add_users_to_db(user_list):
             password=encrypt_password(user['password']),
             roles=[role]
         )
+
+        default_tenant_role = user_datastore.find_role(DEFAULT_TENANT_ROLE)
         user_obj.active = user.get('active', True)
         user_tenant_association = UserTenantAssoc(
             tenant=default_tenant,
-            role_id=role.id,
+            role=default_tenant_role,
         )
         user_obj.tenant_associations.append(user_tenant_association)
     user_datastore.commit()


### PR DESCRIPTION
In this PR, the tenant users response is fixed using the tenant roles for each user, not the system role.

Also, in test data the system-wide role and the user tenant role are kept separate and different to avoid confusion.