### PR TITLE
CFY-7350. Return tenant role

### DIFF
--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -292,8 +292,16 @@ class User(SQLModelBase, UserMixin):
         added directly and/or indirectly as members of different groups.
 
         """
+        tenant_roles = {
+            tenant_association.tenant.name: tenant_association.role.name
+            for tenant_association in self.tenant_associations
+        }
+
         return {
-            tenant.name: sorted(list(role.name for role in roles))
+            tenant.name: {
+                'tenant-role': tenant_roles.get(tenant.name),
+                'roles': sorted(list(role.name for role in roles)),
+            }
             for tenant, roles in self.all_tenants.iteritems()
         }
 

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -88,8 +88,16 @@ class Tenant(SQLModelBase):
         added directly and/or indirectly as members of different groups.
 
         """
+        tenant_roles = {
+            user_association.user.username: user_association.role.name
+            for user_association in self.user_associations
+        }
+
         return {
-            user.username: sorted(list(role.name for role in roles))
+            user.username: {
+                'tenant-role': tenant_roles.get(user.username),
+                'roles': sorted(list(role.name for role in roles)),
+            }
             for user, roles in self.all_users.iteritems()
         }
 


### PR DESCRIPTION
In this PR, the response for the `cfy tenants` and `cfy users` commands is updated to include the `tenant-role` field to make clear what is the role assigned to a user in a tenant. All other roles coming from groups are also listed.

Before:
```
$ cfy tenants get my-tenant --get-data
Getting info for tenant `my-tenant`...

Requested tenant info:
+-----------+---------------------------------------------------+------------------------------------------------+
|    name   |                       groups                      |                     users                      |
+-----------+---------------------------------------------------+------------------------------------------------+
| my-tenant | {u'my-group-2': u'manager', u'my-group': u'user'} | {u'my-user': [u'manager', u'user', u'viewer']} |
+-----------+---------------------------------------------------+------------------------------------------------+
$ cfy users get my-user --get-data
Getting info for user `my-user`...

Requested user info:
+----------+---------------------+------------------+--------------------------------------------------+--------+---------------+
| username |        groups       | system_wide_role |                     tenants                      | active | last_login_at |
+----------+---------------------+------------------+--------------------------------------------------+--------+---------------+
| my-user  | my-group,my-group-2 |     default      | {u'my-tenant': [u'manager', u'user', u'viewer']} |  True  |               |
+----------+---------------------+------------------+--------------------------------------------------+--------+---------------+

```

After:
```
$ cfy tenants get my-tenant --get-data
Getting info for tenant `my-tenant`...

Requested tenant info:
+-----------+---------------------------------------------------+---------------------------------------------------------------------------------------+
|    name   |                       groups                      |                                         users                                         |
+-----------+---------------------------------------------------+---------------------------------------------------------------------------------------+
| my-tenant | {u'my-group-2': u'manager', u'my-group': u'user'} | {u'my-user': {u'tenant-role': u'viewer', u'roles': [u'manager', u'user', u'viewer']}} |
+-----------+---------------------------------------------------+---------------------------------------------------------------------------------------+
$ cfy users get my-user --get-data
Getting info for user `my-user`...

Requested user info:
+----------+---------------------+------------------+-----------------------------------------------------------------------------------------+--------+---------------+
| username |        groups       | system_wide_role |                                         tenants                                         | active | last_login_at |
+----------+---------------------+------------------+-----------------------------------------------------------------------------------------+--------+---------------+
| my-user  | my-group,my-group-2 |     default      | {u'my-tenant': {u'tenant-role': u'viewer', u'roles': [u'manager', u'user', u'viewer']}} |  True  |               |
+----------+---------------------+------------------+-----------------------------------------------------------------------------------------+--------+---------------+
```