### PR TITLE
CFY-7457. Disallow problematic names

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3/tenants.py
+++ b/rest-service/manager_rest/rest/resources_v3/tenants.py
@@ -14,6 +14,7 @@
 #  * limitations under the License.
 
 from manager_rest import constants
+from manager_rest.manager_exceptions import BadParametersError
 from manager_rest.storage import get_storage_manager, models
 from manager_rest.security.authorization import authorize
 from manager_rest.security import (MissingPremiumFeatureResource,
@@ -63,6 +64,13 @@ class TenantsId(SecuredMultiTenancyResource):
         Create a tenant
         """
         rest_utils.validate_inputs({'tenant_name': tenant_name})
+        if tenant_name in ('users', 'user-groups'):
+            raise BadParametersError(
+                '{0!r} is not allowed as a tenant name '
+                "because it wouldn't be possible to remove it later due to "
+                'a conflict with the remove {0} from tenant endpoint'
+                .format(str(tenant_name))
+            )
         return multi_tenancy.create_tenant(tenant_name)
 
     @rest_decorators.exceptions_handled

--- a/rest-service/manager_rest/rest/resources_v3/user_groups.py
+++ b/rest-service/manager_rest/rest/resources_v3/user_groups.py
@@ -18,7 +18,10 @@ from flask import current_app
 from manager_rest.storage import models
 from manager_rest.security.authorization import authorize
 from manager_rest.security import MissingPremiumFeatureResource
-from manager_rest.manager_exceptions import MethodNotAllowedError
+from manager_rest.manager_exceptions import (
+    BadParametersError,
+    MethodNotAllowedError,
+)
 
 from .. import rest_decorators, rest_utils
 from ..responses_v3 import BaseResponse
@@ -60,6 +63,13 @@ class UserGroups(SecuredMultiTenancyResource):
         group_name = request_dict['group_name']
         ldap_group_dn = request_dict.get('ldap_group_dn')
         rest_utils.validate_inputs({'group_name': group_name})
+        if group_name == 'users':
+            raise BadParametersError(
+                '{0!r} is not allowed as a user group name '
+                "because it wouldn't be possible to remove it later due to "
+                'a conflict with the remove {0} from user group endpoint'
+                .format(str(group_name))
+            )
         return multi_tenancy.create_group(group_name, ldap_group_dn)
 
 


### PR DESCRIPTION
In this PR, the following names are disallowed:
- tenant: `users` and `user-groups`
- user group: `users`

This is because with the current API design, if any of those resources were created, then it wouldn't be possible to delete it.