### PR TITLE
CFY-7488. Disallow unknown request body keys

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v1/deployments.py
@@ -202,9 +202,25 @@ class DeploymentModifications(SecuredResource):
     @marshal_with(models.DeploymentModification)
     def post(self, **kwargs):
         request_dict = get_json_and_verify_params({
-            'deployment_id': {},
-            'context': {'optional': True, 'type': dict},
-            'nodes': {'optional': True, 'type': dict}
+            'context': {
+                'type': dict,
+                'optional': True,
+            },
+            'deployment_id': {
+                'type': unicode,
+            },
+            'modified_nodes': {
+                'type': dict,
+                'optional': True,
+            },
+            'node_instances': {
+                'type': dict,
+                'optional': True,
+            },
+            'nodes': {
+                'type': dict,
+                'optional': True,
+            },
         })
         deployment_id = request_dict['deployment_id']
         context = request_dict.get('context', {})

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -505,7 +505,15 @@ class Events(SecuredResource):
         :rtype: dict(str)
 
         """
-        request_dict = get_json_and_verify_params()
+        request_dict = get_json_and_verify_params({
+            'from': {'type': int},
+            'query': {'type': dict},
+            'size': {
+                'type': int,
+                'optional': True,
+            },
+            'sort': {'type': list},
+        })
 
         es_query = request_dict['query']['bool']
 

--- a/rest-service/manager_rest/rest/resources_v1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v1/executions.py
@@ -92,8 +92,13 @@ class Executions(SecuredResource):
     @marshal_with(models.Execution)
     def post(self, **kwargs):
         """Execute a workflow"""
-        request_dict = get_json_and_verify_params({'deployment_id',
-                                                   'workflow_id'})
+        request_dict = get_json_and_verify_params({
+            'allow_custom_parameters',
+            'deployment_id',
+            'force',
+            'parameters',
+            'workflow_id',
+        })
 
         allow_custom_parameters = verify_and_convert_bool(
             'allow_custom_parameters',
@@ -206,7 +211,15 @@ class ExecutionsId(SecuredResource):
         """
         Update execution status by id
         """
-        request_dict = get_json_and_verify_params({'status'})
+        request_dict = get_json_and_verify_params({
+            'error': {
+                'type': unicode,
+                'optional': True,
+            },
+            'status': {
+                'type': unicode,
+            },
+        })
 
         return get_resource_manager().update_execution_status(
             execution_id,

--- a/rest-service/manager_rest/rest/resources_v1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v1/nodes.py
@@ -202,9 +202,19 @@ class NodeInstancesId(SecuredResource):
     @marshal_with(models.NodeInstance)
     def patch(self, node_instance_id, **kwargs):
         """Update node instance by id."""
-        request_dict = get_json_and_verify_params(
-            {'version': {'type': int}}
-        )
+        request_dict = get_json_and_verify_params({
+            'runtime_properties': {
+                'type': dict,
+                'optional': True,
+            },
+            'state': {
+                'type': unicode,
+                'optional': True,
+            },
+            'version': {
+                'type': int,
+            },
+        })
 
         if not isinstance(request.json, collections.Mapping):
             raise manager_exceptions.BadParametersError(

--- a/rest-service/manager_rest/rest/resources_v2/snapshots.py
+++ b/rest-service/manager_rest/rest/resources_v2/snapshots.py
@@ -124,7 +124,17 @@ class SnapshotsId(SecuredResource):
     @authorize('snapshot_create')
     @rest_decorators.marshal_with(models.Execution)
     def put(self, snapshot_id):
-        request_dict = rest_utils.get_json_and_verify_params()
+        request_dict = rest_utils.get_json_and_verify_params({
+            'include_credentials': {
+                'optional': True,
+            },
+            'include_metrics': {
+                'optional': True,
+            },
+            'private_resource': {
+                'optional': True,
+            },
+        })
         include_metrics = rest_utils.verify_and_convert_bool(
             'include_metrics',
             request_dict.get('include_metrics', 'false')

--- a/rest-service/manager_rest/rest/resources_v2_1/plugins.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/plugins.py
@@ -40,7 +40,7 @@ class PluginsId(resources_v2.PluginsId):
         """
         Delete plugin by ID
         """
-        request_dict = get_json_and_verify_params()
+        request_dict = get_json_and_verify_params({'force'})
         force = verify_and_convert_bool(
             'force', request_dict.get('force', False)
         )

--- a/rest-service/manager_rest/rest/resources_v3/user_groups.py
+++ b/rest-service/manager_rest/rest/resources_v3/user_groups.py
@@ -59,7 +59,15 @@ class UserGroups(SecuredMultiTenancyResource):
         """
         Create a group
         """
-        request_dict = rest_utils.get_json_and_verify_params()
+        request_dict = rest_utils.get_json_and_verify_params({
+            'group_name': {
+                'type': unicode,
+            },
+            'ldap_group_dn': {
+                'type': unicode,
+                'optional': True,
+            }
+        })
         group_name = request_dict['group_name']
         ldap_group_dn = request_dict.get('ldap_group_dn')
         rest_utils.validate_inputs({'group_name': group_name})

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -68,6 +68,16 @@ def get_json_and_verify_params(params=None):
                 '{2}'.format(param,
                              param_type.__name__,
                              type(request_dict[param]).__name__))
+
+    # Check that there are now unknown keys in the request
+    if params is not None:
+        for key in request_dict:
+            if key not in params:
+                raise manager_exceptions.BadParametersError(
+                    'Unknown key found in request body: {0}'
+                    .format(key)
+                )
+
     return request_dict
 
 

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -442,7 +442,7 @@ class BaseServerTestCase(unittest.TestCase):
                                                 blueprint_file_name,
                                                 blueprint_id)
         blueprint_id = blueprint_response['id']
-        create_deployment_kwargs = {'inputs': inputs}
+        create_deployment_kwargs = {'inputs': inputs or {}}
         if skip_plugins_validation is not None:
             create_deployment_kwargs['skip_plugins_validation'] =\
                 skip_plugins_validation


### PR DESCRIPTION
In this PR, any request that includes an unknown key in its json body is rejected. This is to prevent errors related to typos when sending the request.

Before:
```
$ curl -s -X POST \
    -H 'Tenant: default_tenant'
    -H 'Content-Type: application/json' \
    -u admin:admin \
    -d '{"group_name": "my_group", "ldap_group_dn_with_typo": "ldap_group_dn"}'
    http://172.20.0.2/api/v3.1/user-groups | jq
{
  "ldap_dn": null,
  "tenants": 0,
  "name": "my_group",
  "users": 0
}
```

After:
```
$ curl -s -X POST \
    -H 'Tenant: default_tenant'
    -H 'Content-Type: application/json' \
    -u admin:admin \
    -d '{"group_name": "my_group", "ldap_group_dn_with_typo": "ldap_group_dn"}'
    http://172.20.0.2/api/v3.1/user-groups | jq
{
  "message": "Unkwown key found in request body: ldap_group_dn_with_typo",
  "error_code": "bad_parameters_error",
  "server_traceback": "Traceback (most recent call last):\n  File \"/opt/manager/env/lib/python2.7/site-packages/manager_rest/rest/rest_decorators.py\", line 95, in wrapper\n    return func(*args, **kwargs)\n  File \"/opt/manager/env/lib/python2.7/site-packages/manager_rest/security/authorization.py\", line 67, in wrapper\n    return func(*args, **kwargs)\n  File \"/opt/manager/env/lib/python2.7/site-packages/manager_rest/rest/rest_decorators.py\", line 135, in wrapper\n    response = f(*args, **kwargs)\n  File \"/opt/manager/env/lib/python2.7/site-packages/manager_rest/rest/resources_v3/user_groups.py\", line 68, in post\n    'optional': True,\n  File \"/opt/manager/env/lib/python2.7/site-packages/manager_rest/rest/rest_utils.py\", line 78, in get_json_and_verify_params\n    .format(key)\nBadParametersError: Unkwown key found in request body: ldap_group_dn_with_typo\n"
}
```