### PR TITLE
CFY-7332 Set SSL in cluster: re-assign cluster options

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/manager.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/manager.py
@@ -73,4 +73,7 @@ class SSLConfig(SecuredResource):
 
     @staticmethod
     def _cluster_set_ssl_state(state):
-        cluster_status.cluster_options[options.CLUSTER_SSL_ENABLED] = state
+        # mutation isn't enough, need to set it for it to be saved
+        cluster_opts = cluster_status.cluster_options
+        cluster_opts[options.CLUSTER_SSL_ENABLED] = state
+        cluster_status.cluster_options = cluster_opts


### PR DESCRIPTION
The mutation is not detected, we need to actually assign it for the
options to be saved.