### PR TITLE
Fix test_deploy_with_operation_executor_override by setting back the …

### DIFF
--- a/tests/integration_tests/resources/plugins/target-aware-mock/setup.py
+++ b/tests/integration_tests/resources/plugins/target-aware-mock/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup
 
 setup(
     name='target-aware-mock',
-    version='4.2',
+    version='1.0',
     packages=['target_aware_mock'],
 )


### PR DESCRIPTION
…version of target_aware_mock plugin to 1.0