### PR TITLE
CFY-7444. Do not discard row duplicates in UNION operator

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -260,7 +260,10 @@ class Events(SecuredResource):
             subqueries.append(logs_query)
 
         if subqueries:
-            query = reduce(lambda left, right: left.union(right), subqueries)
+            query = reduce(
+                lambda left, right: left.union_all(right),
+                subqueries,
+            )
             query = Events._apply_sort(query, sort)
             query = (
                 query


### PR DESCRIPTION
When an events list is retrieved from the API the count might not match the actual number of events returned if a duplicate row is found.

This is because events and logs are joined together using the `UNION` operator which, as described in the PostgreSQL documentation *eliminates duplicate rows from its result, in the same way as DISTINCT, unless UNION ALL is used*.

In this PR, the advice from the documentation above is followed and `UNION ALL` is used instead of just `UNION`.

Note: two rows might be identical in a query that retrieves events and logs because the `_storage_id` column is not included in the select statement to do so.  
