### PR TITLE
CFY-7562. Secret create update_if_exists

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3/secrets.py
+++ b/rest-service/manager_rest/rest/resources_v3/secrets.py
@@ -58,12 +58,13 @@ class SecretsKey(SecuredResource):
         rest_utils.validate_inputs({'key': key})
 
         sm = get_storage_manager()
+        timestamp = utils.get_formatted_timestamp()
         try:
             new_secret = models.Secret(
                 id=key,
                 value=value,
-                created_at=utils.get_formatted_timestamp(),
-                updated_at=utils.get_formatted_timestamp(),
+                created_at=timestamp,
+                updated_at=timestamp,
             )
             return sm.put(new_secret)
         except ConflictError:
@@ -71,7 +72,7 @@ class SecretsKey(SecuredResource):
             if secret and upsert:
                 get_resource_manager().validate_modification_permitted(secret)
                 secret.value = value
-                secret.updated_at = utils.get_formatted_timestamp()
+                secret.updated_at = timestamp
                 return sm.update(secret)
             raise
 

--- a/rest-service/manager_rest/rest/resources_v3/secrets.py
+++ b/rest-service/manager_rest/rest/resources_v3/secrets.py
@@ -47,7 +47,6 @@ class SecretsKey(SecuredResource):
                 'type': unicode,
             },
             'upsert': {
-                'type': unicode,
                 'optional': True,
             }
         })

--- a/rest-service/manager_rest/rest/resources_v3/secrets.py
+++ b/rest-service/manager_rest/rest/resources_v3/secrets.py
@@ -46,14 +46,14 @@ class SecretsKey(SecuredResource):
             'value': {
                 'type': unicode,
             },
-            'upsert': {
+            'update_if_exists': {
                 'optional': True,
             }
         })
         value = request_dict['value']
-        upsert = rest_utils.verify_and_convert_bool(
-            'upsert',
-            request_dict.get('upsert', False),
+        update_if_exists = rest_utils.verify_and_convert_bool(
+            'update_if_exists',
+            request_dict.get('update_if_exists', False),
         )
         rest_utils.validate_inputs({'key': key})
 
@@ -69,7 +69,7 @@ class SecretsKey(SecuredResource):
             return sm.put(new_secret)
         except ConflictError:
             secret = sm.get(models.Secret, key)
-            if secret and upsert:
+            if secret and update_if_exists:
                 get_resource_manager().validate_modification_permitted(secret)
                 secret.value = value
                 secret.updated_at = timestamp

--- a/rest-service/manager_rest/rest/resources_v3/secrets.py
+++ b/rest-service/manager_rest/rest/resources_v3/secrets.py
@@ -41,7 +41,9 @@ class SecretsKey(SecuredResource):
         """
         Create a new secret
         """
-        key, value = self._validate_secret_inputs(key)
+        request_dict = rest_utils.get_json_and_verify_params({'value'})
+        value = request_dict['value']
+        rest_utils.validate_inputs({'key': key})
 
         return get_storage_manager().put(models.Secret(
             id=key,
@@ -57,7 +59,10 @@ class SecretsKey(SecuredResource):
         """
         Update an existing secret
         """
-        key, value = self._validate_secret_inputs(key)
+        request_dict = rest_utils.get_json_and_verify_params({'value'})
+        value = request_dict['value']
+        rest_utils.validate_inputs({'key': key})
+
         secret = get_storage_manager().get(models.Secret, key)
         get_resource_manager().validate_modification_permitted(secret)
         secret.value = value
@@ -76,12 +81,6 @@ class SecretsKey(SecuredResource):
         secret = storage_manager.get(models.Secret, key)
         get_resource_manager().validate_modification_permitted(secret)
         return storage_manager.delete(secret)
-
-    def _validate_secret_inputs(self, key):
-        request_dict = rest_utils.get_json_and_verify_params({'value'})
-        value = request_dict['value']
-        rest_utils.validate_inputs({'key': key})
-        return key, value
 
 
 class Secrets(SecuredResource):


### PR DESCRIPTION
In this PR, the API endpoint to create a secret is updated to allow for an `upsert` flag to be passed in the json data. When the flag is set, if the secret already exists, it is updated.