### PR TITLE
CFY-7650. Get aria resource storage in a synced directory

### DIFF
--- a/rest-service/manager_rest/storage/aria_resource.py
+++ b/rest-service/manager_rest/storage/aria_resource.py
@@ -1,0 +1,27 @@
+import aria
+from aria.storage.filesystem_rapi import FileSystemResourceAPI
+
+# Use a synced directory
+STORAGE_DIR = '/opt/manager/resources/aria'
+
+_resource_storage = None
+
+
+def resource_storage():
+    """Get aria resource storage.
+
+    The resource storage is used to access artifacts that are replicated
+    through HA.
+
+    :return: Aria resource storage
+    :rtype: :class:`aria.storage.core.ResourceStorage`
+
+    """
+    global _resource_storage
+    if _resource_storage is None:
+        _resource_storage = aria.application_resource_storage(
+            api=FileSystemResourceAPI,
+            api_kwargs={'directory': STORAGE_DIR},
+        )
+
+    return _resource_storage

--- a/workflows/cloudify_system_workflows/snapshots/utils.py
+++ b/workflows/cloudify_system_workflows/snapshots/utils.py
@@ -66,6 +66,7 @@ def copy_files_between_manager_and_snapshot(archive_root,
     ctx.logger.info('Copying files/directories...')
 
     data_to_copy = [
+        constants.FILE_SERVER_ARIA_FOLDER,
         constants.FILE_SERVER_BLUEPRINTS_FOLDER,
         constants.FILE_SERVER_DEPLOYMENTS_FOLDER,
         constants.FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER,


### PR DESCRIPTION
In this PR, the ability to create an aria resource storage is added.

Usage example:
```
>>> from manager_rest.storage import aria_resource
>>> aria_resource.resource_storage()
ResourceStorage(api=<class 'aria.storage.filesystem_rapi.FileSystemResourceAPI'>)
```

Requires: cloudify-cosmo/cloudify-plugins-common#371