### PR TITLE
build_rpm.py: only attempt downloading http sources

### DIFF
--- a/packaging/build_rpm.py
+++ b/packaging/build_rpm.py
@@ -81,7 +81,8 @@ def main(args):
     sources += get_dependency_urls(spec_file)
     logger.info(sources)
     for url in sources:
-        download_if_newer(url)
+        if url.startswith('http')
+            download_if_newer(url)
 
     chdir(SCRIPT_DIR)
 


### PR DESCRIPTION
There's no point trying to download things that aren't URLs. Those
will simply be assumed to already be there. (eg. moved by jenkins)