### PR TITLE
CFY-7735 Get edition from the config file

### DIFF
--- a/rest-service/manager_rest/VERSION
+++ b/rest-service/manager_rest/VERSION
@@ -1,4 +1,0 @@
-{
-  "edition": "premium",
-  "version": "4.3.0-.dev1"
-}

--- a/rest-service/manager_rest/__init__.py
+++ b/rest-service/manager_rest/__init__.py
@@ -13,16 +13,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ############
-
-import json
-import pkgutil
-
-
-def get_version():
-    version_data = get_version_data()
-    return version_data['version']
-
-
-def get_version_data():
-    data = pkgutil.get_data('manager_rest', 'VERSION')
-    return json.loads(data)

--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -48,6 +48,7 @@ class Config(object):
         self.insecure_endpoints_disabled = True
         self.max_results = 1000
         self.min_available_memory_mb = None
+        self.edition = 'community'
 
         self.security_hash_salt = None
         self.security_secret_key = None

--- a/rest-service/manager_rest/rest/resources_v1/version.py
+++ b/rest-service/manager_rest/rest/resources_v1/version.py
@@ -14,16 +14,28 @@
 #  * limitations under the License.
 #
 
+import pkg_resources
 from flask_restful_swagger import swagger
 
+from manager_rest import config
 from manager_rest.rest import responses
-from manager_rest import get_version_data
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
 from manager_rest.rest.rest_decorators import (
     exceptions_handled,
     marshal_with,
 )
+
+
+def get_version():
+    return pkg_resources.get_distribution('cloudify-rest-service').version
+
+
+def get_version_data():
+    return {
+        'version': get_version(),
+        'edition': config.instance.edition
+    }
 
 
 class Version(SecuredResource):

--- a/rest-service/manager_rest/test/endpoints/test_version.py
+++ b/rest-service/manager_rest/test/endpoints/test_version.py
@@ -15,7 +15,7 @@
 
 from nose.plugins.attrib import attr
 
-from manager_rest import get_version_data
+from manager_rest.rest.resources_v1.version import get_version_data
 from manager_rest.test.security_utils import get_admin_user
 from manager_rest.constants import CLOUDIFY_TENANT_HEADER, DEFAULT_TENANT_NAME
 from manager_rest.test.base_test import BaseServerTestCase, LATEST_API_VERSION


### PR DESCRIPTION
Instead of using the VERSION file to encode the version/edition
at build time, we'll be using the config file for the edition
and we'll query the actually installed version.