### PR TITLE
Use the CA cert in the SSL test instead of the external cert

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_ssl.py
+++ b/tests/integration_tests/tests/agentless_tests/test_ssl.py
@@ -29,7 +29,7 @@ class TestSsl(AgentlessTestCase):
     def test_ssl(self):
         local_cert_path = join(self.workdir, 'cert.pem')
         docl.copy_file_from_manager(
-            '/etc/cloudify/ssl/cloudify_external_cert.pem', local_cert_path)
+            '/etc/cloudify/ssl/cloudify_internal_ca_cert.pem', local_cert_path)
         ssl_client = create_rest_client(
             rest_port='443', cert_path=local_cert_path)
 


### PR DESCRIPTION
This is because we're now using the CA cert to sign the external now, which makes it so that only the CA cert can be used for validation.