### PR TITLE
CFY-7805 When installing plugins, validate manager platform

### DIFF
--- a/rest-service/manager_rest/manager_exceptions.py
+++ b/rest-service/manager_rest/manager_exceptions.py
@@ -441,6 +441,10 @@ class PluginInstallationTimeout(ManagerException):
         )
 
 
+class PluginDistributionNotSupported(PluginInstallationError):
+    pass
+
+
 class ExecutionFailure(RuntimeError):
     pass
 

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -81,14 +81,18 @@ class Plugin(SQLResourceBase):
     uploaded_at = db.Column(UTCDateTime, nullable=False, index=True)
     wheels = db.Column(db.PickleType, nullable=False)
 
-    def _yaml_file_name(self):
+    def yaml_file_path(self):
         plugin_dir = path.join(config.instance.file_server_root,
                                FILE_SERVER_PLUGINS_FOLDER,
                                self.id)
         if not path.isdir(plugin_dir):
-            return ''
+            return None
         yaml_files = files_in_folder(plugin_dir, '*.yaml')
-        return path.basename(yaml_files[0]) if yaml_files else ''
+        return yaml_files[0] if yaml_files else None
+
+    def _yaml_file_name(self):
+        path = self.yaml_file_path()
+        return path.basename(path) if path else ''
 
     @property
     def file_server_path(self):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -91,8 +91,8 @@ class Plugin(SQLResourceBase):
         return yaml_files[0] if yaml_files else None
 
     def _yaml_file_name(self):
-        path = self.yaml_file_path()
-        return path.basename(path) if path else ''
+        yaml_path = self.yaml_file_path()
+        return path.basename(yaml_path) if yaml_path else ''
 
     @property
     def file_server_path(self):

--- a/rest-service/manager_rest/test/mock_blueprint/plugin.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/plugin.yaml
@@ -1,8 +1,8 @@
 plugins:
   cool:
     executor: central_deployment_agent
-    source: https://github.com/cloudify-cosmo/cloudify-cool-plugin/archive/7.7.7.zip
-    package_name: cloudify-cool-plugin
+    source: https://github.com/cloudify-cosmo/cloudify-script-plugin/archive/1.2.zip
+    package_name: cloudify-script-plugin
 
 data_types:
 


### PR DESCRIPTION
When installing a plugin with executor: central_deployment_agent,
check that the plugin is valid for the manager's distro & platform.

This validation is only done if the yaml file was provided,
and in the yaml file, the executor for the plugin is
central_deployment_agent. If the yaml file was not provided, this check
is not performed.

If the plugin's supported platform/distro differs from the manager's,
an error is raised.