### PR TITLE
CFY-7618 fix logstash jre dependency install

### DIFF
--- a/packaging/cloudify-logstash.spec.dependencies
+++ b/packaging/cloudify-logstash.spec.dependencies
@@ -1,2 +1,1 @@
-http://repository.cloudifysource.org/cloudify/components/jre1.8.0_45-1.8.0_45-fcs.x86_64.rpm
 http://repository.cloudifysource.org/cloudify/components/logstash-1.5.0-1.noarch.rpm


### PR DESCRIPTION
Quick fix removes Oracle JRE (OpenJDK doesn't cause this bad interaction, & will be automatically fetched through yum during the mock build)