### PR TITLE
gunicorn only listens to localhost

### DIFF
--- a/packaging/rest-service/files/usr/lib/systemd/system/cloudify-restservice.service
+++ b/packaging/rest-service/files/usr/lib/systemd/system/cloudify-restservice.service
@@ -13,7 +13,7 @@ ExecStart=/bin/sh -c '/opt/manager/env/bin/gunicorn \
     --pid /run/cloudify-restservice/pid \
     -w ${GUNICORN_WORKER_COUNT} \
     --max-requests ${GUNICORN_MAX_REQUESTS} \
-    -b 0.0.0.0:${REST_PORT} \
+    -b 127.0.0.1:${REST_PORT} \
     --timeout 300 manager_rest.wsgi:app \
     --log-file /var/log/cloudify/rest/gunicorn.log \
     --access-logfile /var/log/cloudify/rest/gunicorn-access.log'


### PR DESCRIPTION
Access to port 8100 is only expected from within the manager's machine.
We should bind to 127.0.0.1 as a security measure.