### PR TITLE
CFY-7868: Fixed sudo usage

### DIFF
--- a/packaging/cloudify-riemann.spec
+++ b/packaging/cloudify-riemann.spec
@@ -50,6 +50,7 @@ getent passwd %_user >/dev/null || useradd -r -g %_user -d /etc/cloudify -s /sbi
 /opt/manager/scripts/activate_riemann_policies
 /opt/riemann_NOTICE.txt
 /usr/lib/systemd/system/cloudify-riemann.service
+/etc/sudoers.d/cloudify-riemann
 
 %dir %attr(770,%_user,cfyuser) /opt/riemann
 %dir %attr(-,%_user,adm) /var/log/cloudify/riemann

--- a/packaging/riemann/files/etc/sudoers.d/cloudify-riemann
+++ b/packaging/riemann/files/etc/sudoers.d/cloudify-riemann
@@ -1,0 +1,4 @@
+# Required in order to impersonate cfyuser under systemd
+Defaults:riemann !requiretty
+# Required to run the policy addition script
+riemann ALL=(cfyuser) NOPASSWD:/bin/bash

--- a/packaging/riemann/files/usr/lib/systemd/system/cloudify-riemann.service
+++ b/packaging/riemann/files/usr/lib/systemd/system/cloudify-riemann.service
@@ -4,10 +4,12 @@ Wants=cloudify-rabbitmq.service
 After=cloudify-rabbitmq.service
 
 [Service]
+User=riemann
+Group=riemann
 TimeoutStartSec=0
 Restart=always
 EnvironmentFile=/etc/sysconfig/cloudify-riemann
-ExecStart=/bin/sudo -E -uriemann /usr/bin/riemann -a ${RIEMANN_CONFIG_PATH}/main.clj
+ExecStart=/usr/bin/riemann -a ${RIEMANN_CONFIG_PATH}/main.clj
 ExecStartPost=/bin/sudo -ucfyuser /bin/bash -c "set -a && . /etc/sysconfig/cloudify-mgmtworker && /opt/mgmtworker/env/bin/python /opt/manager/scripts/activate_riemann_policies"
 
 [Install]


### PR DESCRIPTION
- Dedicated `sudoers.d` file for the `riemann` user
- Allow `riemann` to not require TTY
- Allow `riemann` to run `/bin/bash` as `cfyuser`
- Riemann service runs under `riemann` user without impersonation