### PR TITLE
CFY-7899 Delete rabbitmq-env.conf

### DIFF
--- a/packaging/cloudify-rabbitmq.spec
+++ b/packaging/cloudify-rabbitmq.spec
@@ -39,7 +39,6 @@ cp -R ${RPM_SOURCE_DIR}/packaging/rabbitmq/files/* %{buildroot}
 /etc/cloudify/rabbitmq/definitions.json
 /etc/cloudify/rabbitmq/enabled_plugins
 /etc/cloudify/rabbitmq/rabbitmq.config
-/etc/cloudify/rabbitmq/rabbitmq-env.conf
 /etc/security/limits.d/rabbitmq.conf
 /opt/rabbitmq_NOTICE.txt
 /usr/lib/systemd/system/cloudify-rabbitmq.service

--- a/packaging/rabbitmq/files/etc/cloudify/rabbitmq/rabbitmq-env.conf
+++ b/packaging/rabbitmq/files/etc/cloudify/rabbitmq/rabbitmq-env.conf
@@ -1,1 +1,0 @@
-NODENAME=cloudify-manager@localhost


### PR DESCRIPTION
For this file to be used, we'd have to specify it in the configuration.
It's easier to simply put that value in the configuration instead.

For some reason, specifying this file with `RABBITMQ_CONF_ENV_FILE`
doesn't seem to work for me, but putting `RABBITMQ_NODENAME` in the
EnvironmentFile does work.