### PR TITLE
RabbitMQ logrotate script: pass nodename to rabbitmqctl

### DIFF
--- a/packaging/rabbitmq/files/etc/logrotate.d/cloudify-rabbitmq
+++ b/packaging/rabbitmq/files/etc/logrotate.d/cloudify-rabbitmq
@@ -8,6 +8,6 @@
         notifempty
         sharedscripts
         postrotate
-            /sbin/service rabbitmq-server rotate-logs > /dev/null
+            /usr/sbin/rabbitmqctl -n cloudify-manager@localhost rotate_logs
         endscript
 }


### PR DESCRIPTION
Instead of using an init script, call rabbitmqctl directly so
that we can pass the rabbitmq nodename