### PR TITLE
CFY-7917 Make ipsetter require postgresql in systemd

### DIFF
--- a/packaging/ip_setter/files/usr/lib/systemd/system/cloudify-manager-ip-setter.service
+++ b/packaging/ip_setter/files/usr/lib/systemd/system/cloudify-manager-ip-setter.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Cloudify Manager IP Setter
 Before=cloudify-amqpinflux.service cloudify-influxdb.service cloudify-mgmtworker.service cloudify-restservice.service cloudify-riemann.service cloudify-stage.service nginx.service cloudify-rabbitmq.service logstash.service
+Requires=postgresql-9.5.service
 After=network-online.target
 
 [Service]


### PR DESCRIPTION
The scripts require the database, so it should be declared as well