### PR TITLE
ipsetter: explicitly After= the database

### DIFF
--- a/packaging/ip_setter/files/usr/lib/systemd/system/cloudify-manager-ip-setter.service
+++ b/packaging/ip_setter/files/usr/lib/systemd/system/cloudify-manager-ip-setter.service
@@ -2,7 +2,7 @@
 Description=Cloudify Manager IP Setter
 Before=cloudify-amqpinflux.service cloudify-influxdb.service cloudify-mgmtworker.service cloudify-restservice.service cloudify-riemann.service cloudify-stage.service nginx.service cloudify-rabbitmq.service logstash.service
 Requires=postgresql-9.5.service
-After=network-online.target
+After=network-online.target postgresql-9.5.service
 
 [Service]
 Type=oneshot

--- a/packaging/ip_setter/files/usr/lib/systemd/system/cloudify-manager-ip-setter.service
+++ b/packaging/ip_setter/files/usr/lib/systemd/system/cloudify-manager-ip-setter.service
@@ -7,6 +7,10 @@ After=network-online.target postgresql-9.5.service
 [Service]
 Type=oneshot
 TimeoutStartSec=0
+Restart=on-failure
+RestartSec=5
+StartLimitIntervalSec=60
+StartLimitBurst=10
 User=root
 Group=root
 ExecStart=/opt/cloudify/manager-ip-setter/manager-ip-setter.sh


### PR DESCRIPTION
Quoting the docs,
>Note that this setting is independent of and orthogonal to the requirement dependencies as configured by Requires=, Wants= or BindsTo=. It is a common pattern to include a unit name in both the After= and Requires= options, in which case the unit listed will be started before the unit that is configured with these options.