### PR TITLE
ipsetter: remove restart

### DIFF
--- a/packaging/ip_setter/files/usr/lib/systemd/system/cloudify-manager-ip-setter.service
+++ b/packaging/ip_setter/files/usr/lib/systemd/system/cloudify-manager-ip-setter.service
@@ -7,10 +7,6 @@ After=network-online.target postgresql-9.5.service
 [Service]
 Type=oneshot
 TimeoutStartSec=0
-Restart=on-failure
-RestartSec=5
-StartLimitIntervalSec=60
-StartLimitBurst=10
 User=root
 Group=root
 ExecStart=/opt/cloudify/manager-ip-setter/manager-ip-setter.sh


### PR DESCRIPTION
it's not allowed for `oneshot` services