### PR TITLE
CY-96 Make rabbitmq management port be localhost-only and SSL

### DIFF
--- a/packaging/rabbitmq/files/etc/cloudify/rabbitmq/rabbitmq.config
+++ b/packaging/rabbitmq/files/etc/cloudify/rabbitmq/rabbitmq.config
@@ -9,5 +9,17 @@
                           {versions, ['tlsv1.2', 'tlsv1.1']}
                          ]}
  ]},
- {rabbitmq_management, [{load_definitions, "/etc/cloudify/rabbitmq/definitions.json"}]}
+ {rabbitmq_management, [
+    {load_definitions, "/etc/cloudify/rabbitmq/definitions.json"},
+    {listener, [
+        {ip, "127.0.0.1"},
+        {port, 15671},
+        {ssl, true},
+        {ssl_opts, [{cacertfile,"/etc/cloudify/ssl/cloudify_internal_ca_cert.pem"},
+                    {certfile,  "/etc/cloudify/ssl/cloudify_internal_cert.pem"},
+                    {keyfile,   "/etc/cloudify/ssl/cloudify_internal_key.pem"},
+                    {versions, ['tlsv1.2', 'tlsv1.1']}
+                   ]}
+    ]}
+ ]}
 ].


### PR DESCRIPTION
The management UI is still potentially useful, so let's not disable
it entirely just yet.

Docs for these configuration options are at:
https://www.rabbitmq.com/management.html