### PR TITLE
CY-156 Implement a rabbitmq API client using requests

### DIFF
--- a/rest-service/manager_rest/amqp_manager.py
+++ b/rest-service/manager_rest/amqp_manager.py
@@ -16,6 +16,7 @@
 import random
 import string
 import requests
+from urllib import quote
 from requests.exceptions import HTTPError
 
 from functools import wraps
@@ -70,9 +71,11 @@ class RabbitMQClient(object):
         return self._do_request(requests.get, 'vhosts').json()
 
     def create_vhost(self, vhost):
+        vhost = quote(vhost, '')
         self._do_request(requests.put, 'vhosts/{0}'.format(vhost))
 
     def delete_vhost(self, vhost):
+        vhost = quote(vhost, '')
         self._do_request(requests.delete, 'vhosts/{0}'.format(vhost))
 
     def get_users(self):
@@ -86,6 +89,7 @@ class RabbitMQClient(object):
         self._do_request(requests.delete, 'users/{0}'.format(username))
 
     def set_vhost_permissions(self, vhost, username, configure, write, read):
+        vhost = quote(vhost, '')
         self._do_request(requests.put,
                          'permissions/{0}/{1}'.format(vhost, username),
                          json={

--- a/rest-service/manager_rest/amqp_manager.py
+++ b/rest-service/manager_rest/amqp_manager.py
@@ -78,9 +78,9 @@ class RabbitMQClient(object):
     def get_users(self):
         return self._do_request(requests.get, 'users').json()
 
-    def create_user(self, username, password):
+    def create_user(self, username, password, tags=''):
         self._do_request(requests.put, 'users/{0}'.format(username),
-                         json={'password': password})
+                         json={'password': password, 'tags': tags})
 
     def delete_user(self, username):
         self._do_request(requests.delete, 'users/{0}'.format(username))

--- a/rest-service/manager_rest/amqp_manager.py
+++ b/rest-service/manager_rest/amqp_manager.py
@@ -38,6 +38,7 @@ def ignore_not_found(func):
                 raise
     return wrapper
 
+
 RABBITMQ_MANAGEMENT_PORT = 15671
 
 

--- a/rest-service/manager_rest/amqp_manager.py
+++ b/rest-service/manager_rest/amqp_manager.py
@@ -58,6 +58,9 @@ class RabbitMQClient(object):
     def _do_request(self, request_method, url, **kwargs):
         request_kwargs = self._request_kwargs.copy()
         request_kwargs.update(kwargs)
+        request_kwargs.setdefault('headers', {})\
+            .setdefault('Content-Type', 'application/json',)
+
         url = '{0}/api/{1}'.format(self.base_url, url)
         response = request_method(url, **request_kwargs)
         response.raise_for_status()

--- a/rest-service/manager_rest/amqp_manager.py
+++ b/rest-service/manager_rest/amqp_manager.py
@@ -48,7 +48,7 @@ class RabbitMQClient(object):
         self._host = host
         self._port = port
         self._scheme = scheme
-        self._auth = (username, password)
+        request_kwargs.setdefault('auth', (username, password))
         self._request_kwargs = request_kwargs
 
     @property

--- a/rest-service/manager_rest/amqp_manager.py
+++ b/rest-service/manager_rest/amqp_manager.py
@@ -15,11 +15,10 @@
 
 import random
 import string
+import requests
+from requests.exceptions import HTTPError
 
 from functools import wraps
-
-from pyrabbit.api import Client
-from pyrabbit.http import HTTPError
 
 from manager_rest.storage.models import Tenant
 from manager_rest.storage import get_storage_manager
@@ -32,22 +31,74 @@ def ignore_not_found(func):
     def wrapper(*args, **kwargs):
         try:
             func(*args, **kwargs)
-        except HTTPError, e:
-            if e.status == 404:
+        except HTTPError as e:
+            if e.response.status_code == 404:
                 pass
             else:
                 raise
     return wrapper
 
+RABBITMQ_MANAGEMENT_PORT = 15671
+
+
+class RabbitMQClient(object):
+    def __init__(self, host, username, password, port=RABBITMQ_MANAGEMENT_PORT,
+                 scheme='https', **request_kwargs):
+        self._host = host
+        self._port = port
+        self._scheme = scheme
+        self._auth = (username, password)
+        self._request_kwargs = request_kwargs
+
+    @property
+    def base_url(self):
+        return '{0}://{1}:{2}'.format(self._scheme, self._host, self._port)
+
+    def _do_request(self, request_method, url, **kwargs):
+        request_kwargs = self._request_kwargs.copy()
+        request_kwargs.update(kwargs)
+        url = '{0}/api/{1}'.format(self.base_url, url)
+        response = request_method(url, **request_kwargs)
+        response.raise_for_status()
+        return response
+
+    def get_vhost_names(self):
+        return self._do_request(requests.get, 'vhosts').json()
+
+    def create_vhost(self, vhost):
+        self._do_request(requests.put, 'vhosts/{0}'.format(vhost))
+
+    def delete_vhost(self, vhost):
+        self._do_request(requests.delete, 'vhosts/{0}'.format(vhost))
+
+    def get_users(self):
+        return self._do_request(requests.get, 'users').json()
+
+    def create_user(self, username, password):
+        self._do_request(requests.put, 'users/{0}'.format(username),
+                         json={'password': password})
+
+    def delete_user(self, username):
+        self._do_request(requests.delete, 'users/{0}'.format(username))
+
+    def set_vhost_permissions(self, vhost, username, configure, write, read):
+        self._do_request(requests.put,
+                         'permissions/{0}/{1}'.format(vhost, username),
+                         json={
+                             'configure': configure,
+                             'write': write,
+                             'read': read
+                         })
+
 
 class AMQPManager(object):
-    RABBITMQ_MANAGEMENT_PORT = 15672
+
     VHOST_NAME_PATTERN = 'rabbitmq_vhost_{0}'
     USERNAME_PATTERN = 'rabbitmq_user_{0}'
 
-    def __init__(self, host, username, password):
-        host_str = '{0}:{1}'.format(host, self.RABBITMQ_MANAGEMENT_PORT)
-        self._client = Client(host_str, username, password)
+    def __init__(self, host, username, password, **request_kwargs):
+        self._client = RabbitMQClient(host, username, password,
+                                      **request_kwargs)
         self._storage_manager = get_storage_manager()
 
     def create_tenant_vhost_and_user(self, tenant):

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -163,9 +163,9 @@ class BaseServerTestCase(unittest.TestCase):
         rest_utils.verify_role = self._original_verify_role
 
     def _mock_amqp_manager(self):
-        """ Mock the pyrabbit.Client for all unittests - no RabbitMQ """
+        """ Mock the RabbitMQClient for all unittests - no RabbitMQ """
 
-        self._amqp_patcher = patch('manager_rest.amqp_manager.Client')
+        self._amqp_patcher = patch('manager_rest.amqp_manager.RabbitMQClient')
         self.addCleanup(self._amqp_patcher.stop)
         self._amqp_patcher.start()
 

--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -38,7 +38,6 @@ install_requires = [
     'python-dateutil==2.5.3',
     'voluptuous==0.9.3',
     'toolz==0.8.2',
-    'pyrabbit==1.1.0',
 ]
 
 

--- a/tests/integration_tests/framework/flask_utils.py
+++ b/tests/integration_tests/framework/flask_utils.py
@@ -60,7 +60,6 @@ def setup_flask_app():
     manager_ip = utils.get_manager_ip()
     return _setup_flask_app(
         manager_ip=manager_ip,
-        driver='pg8000',
         hash_salt=security_config['hash_salt'],
         secret_key=security_config['secret_key']
     )
@@ -74,7 +73,8 @@ def setup_amqp_manager():
         amqp_manager = AMQPManager(
             host=config['amqp_host'],
             username=config['amqp_username'],
-            password=config['amqp_password']
+            password=config['amqp_password'],
+            verify=config['amqp_ca_path']
         )
     return amqp_manager
 

--- a/workflows/cloudify_system_workflows/snapshots/restore_amqp.py
+++ b/workflows/cloudify_system_workflows/snapshots/restore_amqp.py
@@ -27,6 +27,7 @@ with app.app_context():
     amqp_manager = AMQPManager(
         host=instance.amqp_host,
         username=instance.amqp_username,
-        password=instance.amqp_password
+        password=instance.amqp_password,
+        verify=instance.amqp_ca_path
     )
     amqp_manager.sync_metadata()


### PR DESCRIPTION
Instead of using pyrabbit, which doesn't support ssl, let's drop
down to requests, and reimplement the required simple functionality