### PR TITLE
CY-96 Use amqp_management_host in snapshot restore

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/restore_amqp.py
+++ b/workflows/cloudify_system_workflows/snapshots/restore_amqp.py
@@ -25,7 +25,7 @@ app = setup_flask_app()
 with app.app_context():
     instance.load_configuration()
     amqp_manager = AMQPManager(
-        host=instance.amqp_host,
+        host=instance.amqp_management_host,
         username=instance.amqp_username,
         password=instance.amqp_password,
         verify=instance.amqp_ca_path


### PR DESCRIPTION
Instead of amqp_host, which can be something other than localhost