### PR TITLE
CY-181: configurable bucket size

### DIFF
--- a/packaging/mgmtworker/files/usr/lib/systemd/system/cloudify-mgmtworker.service
+++ b/packaging/mgmtworker/files/usr/lib/systemd/system/cloudify-mgmtworker.service
@@ -25,7 +25,7 @@ ExecStart=/opt/mgmtworker/env/bin/celery worker \
     --without-gossip \
     --without-mingle \
     --with-gate-keeper \
-    --gate-keeper-bucket-size=${AGENT_MAX_WORKERS} \
+    --gate-keeper-bucket-size=${GATEKEEPER_BUCKET_SIZE} \
     --with-logging-server \
     --logging-server-logdir=${CELERY_LOG_DIR}/logs \
     --logging-server-handler-cache-size=${MAX_WORKERS}


### PR DESCRIPTION
because a hard-coded limit of 5 doesn't make any sense.