### PR TITLE
CY-96 Tests reset_storage: move to a script

### DIFF
--- a/tests/integration_tests/framework/constants.py
+++ b/tests/integration_tests/framework/constants.py
@@ -26,6 +26,9 @@ CLOUDIFY_REST_PORT = 'CLOUDIFY_REST_PORT'
 
 PLUGIN_STORAGE_DIR = '/opt/integration-plugin-storage'
 DOCKER_COMPUTE_DIR = '/etc/cloudify/dockercompute'
+
+CONFIG_FILE_LOCATION = '/opt/manager/cloudify-rest.conf'
+SECURITY_FILE_LOCATION = '/opt/manager/rest-security.conf'
 AUTHORIZATION_FILE_LOCATION = '/opt/manager/authorization.conf'
 
 CLOUDIFY_USER = 'cfyuser'

--- a/tests/integration_tests/framework/flask_utils.py
+++ b/tests/integration_tests/framework/flask_utils.py
@@ -13,89 +13,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
 import logging
-from path import path
-from tempfile import mkstemp
-from contextlib import contextmanager
-
-from flask_migrate import upgrade
 
 from cloudify.utils import setup_logger
 
-import manager_rest
 from manager_rest.storage import db, models
-from manager_rest.amqp_manager import AMQPManager
-from manager_rest.flask_utils import setup_flask_app as _setup_flask_app
-from manager_rest.storage.storage_utils import \
-    create_default_user_tenant_and_roles
-from manager_rest.constants import (PROVIDER_CONTEXT_ID,
-                                    CURRENT_TENANT_CONFIG,
-                                    DEFAULT_TENANT_NAME)
 from integration_tests.framework import utils
-from integration_tests.framework.postgresql import safe_drop_all
-from integration_tests.framework.docl import read_file as read_manager_file
-from integration_tests.tests.constants import PROVIDER_NAME, PROVIDER_CONTEXT
-from integration_tests.framework.constants import AUTHORIZATION_FILE_LOCATION
-
+from integration_tests.framework.docl import execute, copy_file_to_manager
+from integration_tests.tests.utils import get_resource
 
 logger = setup_logger('Flask Utils', logging.INFO)
-
-security_config = None
-amqp_manager = None
-
-# This is a hacky way to get to the migrations folder
-base_dir = path(manager_rest.__file__).parent.parent.parent
-migrations_dir = base_dir / 'resources' / 'rest-service' / \
-                            'cloudify' / 'migrations'
-
-
-def setup_flask_app():
-    global security_config
-    if not security_config:
-        conf_file_str = read_manager_file('/opt/manager/rest-security.conf')
-        security_config = yaml.load(conf_file_str)
-
-    manager_ip = utils.get_manager_ip()
-    return _setup_flask_app(
-        manager_ip=manager_ip,
-        hash_salt=security_config['hash_salt'],
-        secret_key=security_config['secret_key']
-    )
-
-
-def setup_amqp_manager():
-    global amqp_manager
-    if not amqp_manager:
-        conf_file_str = read_manager_file('/opt/manager/cloudify-rest.conf')
-        config = yaml.load(conf_file_str)
-        amqp_manager = AMQPManager(
-            host=config['amqp_management_host'],
-            username=config['amqp_username'],
-            password=config['amqp_password'],
-            verify=config['amqp_ca_path']
-        )
-    return amqp_manager
 
 
 def reset_storage():
     logger.info('Resetting PostgreSQL DB')
-    app = setup_flask_app()
-    setup_amqp_manager()
-
-    # Clear the old RabbitMQ resources
-    amqp_manager.remove_tenant_vhost_and_user(DEFAULT_TENANT_NAME)
-
-    # Rebuild the DB
-    safe_drop_all(keep_tables=['roles'])
-    upgrade(directory=migrations_dir)
-
-    # Add default tenant, admin user and provider context
-    _add_defaults(app)
-
-    # Clear the connection
-    close_session(app)
+    reset_script = get_resource('scripts/reset_storage.py')
+    target_script_path = '/tmp/reset_storage.py'
+    # reset the storage by calling a script on the manager, to access
+    # localhost-only APIs (rabbitmq management api)
+    copy_file_to_manager(reset_script, target_script_path)
+    execute("bash -c 'MANAGER_REST_CONFIG_PATH={config_path} "
+            "MANAGER_REST_SECURITY_CONFIG_PATH={security_config_path} "
+            "MANAGER_REST_AUTHORIZATION_CONFIG_PATH={auth_config_path} "
+            "/opt/manager/env/bin/python {target_script_path} "
+            "--manager-ip {ip} "
+            "--username {username} "
+            "--password {password}'".format(
+                config_path='/opt/manager/cloudify-rest.conf',
+                security_config_path='/opt/manager/rest-security.conf',
+                auth_config_path='/opt/manager/authorization.conf',
+                target_script_path=target_script_path,
+                ip=utils.get_manager_ip(),
+                username=utils.get_manager_username(),
+                password=utils.get_manager_password(),
+            ))
 
 
 def close_session(app):
@@ -116,45 +67,3 @@ def load_user(app, username=None):
     # And then load the admin as the currently active user
     app.extensions['security'].login_manager.reload_user(user)
     return user
-
-
-def _add_defaults(app):
-    """Add default tenant, admin user and provider context to the DB
-    """
-    # Add the default network to the provider context
-    networks = PROVIDER_CONTEXT['cloudify']['cloudify_agent']['networks']
-    networks['default'] = utils.get_manager_ip()
-
-    provider_context = models.ProviderContext(
-        id=PROVIDER_CONTEXT_ID,
-        name=PROVIDER_NAME,
-        context=PROVIDER_CONTEXT
-    )
-    db.session.add(provider_context)
-
-    with _get_local_authorization_conf_path() as auth_conf_path:
-        default_tenant = create_default_user_tenant_and_roles(
-            admin_username=utils.get_manager_username(),
-            admin_password=utils.get_manager_password(),
-            amqp_manager=amqp_manager,
-            authorization_file_path=auth_conf_path
-        )
-
-    app.config[CURRENT_TENANT_CONFIG] = default_tenant
-    return default_tenant
-
-
-@contextmanager
-def _get_local_authorization_conf_path():
-    """ Read the auth config from the manager, and write it to a temp file """
-
-    content = read_manager_file(AUTHORIZATION_FILE_LOCATION)
-    yaml_content = yaml.load(content)
-    fd, file_path = mkstemp()
-    os.close(fd)
-    with open(file_path, 'w') as f:
-        yaml.dump(yaml_content, f)
-
-    yield file_path
-
-    os.remove(file_path)

--- a/tests/integration_tests/framework/flask_utils.py
+++ b/tests/integration_tests/framework/flask_utils.py
@@ -21,9 +21,12 @@ import tempfile
 from cloudify.utils import setup_logger
 
 from manager_rest.storage import db, models
-from integration_tests.framework import utils
+from integration_tests.framework import constants, utils
 from integration_tests.framework.docl import execute, copy_file_to_manager
+from integration_tests.tests.constants import PROVIDER_CONTEXT
 from integration_tests.tests.utils import get_resource
+
+
 logger = setup_logger('Flask Utils', logging.INFO)
 
 SCRIPT_PATH = '/tmp/reset_storage.py'
@@ -36,13 +39,14 @@ def prepare_reset_storage_script():
     with tempfile.NamedTemporaryFile(delete=False) as f:
         json.dump({
             'config': {
-                '': '/opt/manager/cloudify-rest.conf',
-                'security': '/opt/manager/rest-security.conf',
-                'authorization': '/opt/manager/authorization.conf',
+                '': constants.CONFIG_FILE_LOCATION,
+                'security': constants.SECURITY_FILE_LOCATION,
+                'authorization': constants.AUTHORIZATION_FILE_LOCATION
             },
             'ip': utils.get_manager_ip(),
             'username': utils.get_manager_username(),
             'password': utils.get_manager_password(),
+            'provider_context': PROVIDER_CONTEXT
         }, f)
     try:
         copy_file_to_manager(f.name, CONFIG_PATH)

--- a/tests/integration_tests/framework/flask_utils.py
+++ b/tests/integration_tests/framework/flask_utils.py
@@ -21,17 +21,20 @@ from manager_rest.storage import db, models
 from integration_tests.framework import utils
 from integration_tests.framework.docl import execute, copy_file_to_manager
 from integration_tests.tests.utils import get_resource
-
 logger = setup_logger('Flask Utils', logging.INFO)
+
+SCRIPT_PATH = '/tmp/reset_storage.py'
+
+
+def prepare_reset_storage_script():
+    reset_script = get_resource('scripts/reset_storage.py')
+    copy_file_to_manager(reset_script, SCRIPT_PATH)
 
 
 def reset_storage():
     logger.info('Resetting PostgreSQL DB')
-    reset_script = get_resource('scripts/reset_storage.py')
-    target_script_path = '/tmp/reset_storage.py'
     # reset the storage by calling a script on the manager, to access
     # localhost-only APIs (rabbitmq management api)
-    copy_file_to_manager(reset_script, target_script_path)
     execute("bash -c 'MANAGER_REST_CONFIG_PATH={config_path} "
             "MANAGER_REST_SECURITY_CONFIG_PATH={security_config_path} "
             "MANAGER_REST_AUTHORIZATION_CONFIG_PATH={auth_config_path} "
@@ -42,7 +45,7 @@ def reset_storage():
                 config_path='/opt/manager/cloudify-rest.conf',
                 security_config_path='/opt/manager/rest-security.conf',
                 auth_config_path='/opt/manager/authorization.conf',
-                target_script_path=target_script_path,
+                target_script_path=SCRIPT_PATH,
                 ip=utils.get_manager_ip(),
                 username=utils.get_manager_username(),
                 password=utils.get_manager_password(),

--- a/tests/integration_tests/resources/scripts/reset_storage.py
+++ b/tests/integration_tests/resources/scripts/reset_storage.py
@@ -76,13 +76,14 @@ def _add_defaults(app, amqp_manager, script_config):
     """Add default tenant, admin user and provider context to the DB
     """
     # Add the default network to the provider context
-    networks = PROVIDER_CONTEXT['cloudify']['cloudify_agent']['networks']
+    context = script_config['provider_context']
+    networks = context['cloudify']['cloudify_agent']['networks']
     networks['default'] = script_config['ip']
 
     provider_context = models.ProviderContext(
         id=PROVIDER_CONTEXT_ID,
         name=PROVIDER_NAME,
-        context=PROVIDER_CONTEXT
+        context=context
     )
     db.session.add(provider_context)
 

--- a/tests/integration_tests/resources/scripts/reset_storage.py
+++ b/tests/integration_tests/resources/scripts/reset_storage.py
@@ -1,0 +1,139 @@
+########
+# Copyright (c) 2018 Cloudify Platform Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+import os
+import argparse
+
+from manager_rest.storage import db, models
+
+from flask_migrate import upgrade
+from manager_rest import config
+from manager_rest.amqp_manager import AMQPManager
+from manager_rest.flask_utils import setup_flask_app
+from manager_rest.constants import (PROVIDER_CONTEXT_ID,
+                                    CURRENT_TENANT_CONFIG,
+                                    DEFAULT_TENANT_NAME)
+from manager_rest.storage.storage_utils import \
+    create_default_user_tenant_and_roles
+
+
+# This is a hacky way to get to the migrations folder
+migrations_dir = '/opt/manager/resources/cloudify/migrations'
+PROVIDER_NAME = 'integration_tests'
+PROVIDER_CONTEXT = {
+    'cloudify': {
+        'workflows': {
+            'task_retries': 0,
+            'task_retry_interval': 0,
+            'subgraph_retries': 0
+        },
+        'cloudify_agent':
+            {
+                'broker_ip': '',
+                'broker_user': 'cloudify',
+                'broker_pass': 'c10udify',
+                'networks': {}
+        },
+    }
+}
+
+
+def setup_amqp_manager():
+    amqp_manager = AMQPManager(
+        host=config.instance.amqp_management_host,
+        username=config.instance.amqp_username,
+        password=config.instance.amqp_password,
+        verify=config.instance.amqp_ca_path
+    )
+    return amqp_manager
+
+
+def safe_drop_all(keep_tables):
+    """Creates a single transaction that *always* drops all tables, regardless
+    of relationships and foreign key constraints (as opposed to `db.drop_all`)
+    """
+    meta = db.metadata
+    for table in reversed(meta.sorted_tables):
+        if table.name in keep_tables:
+            continue
+        db.session.execute(table.delete())
+    db.session.commit()
+
+
+def _add_defaults(app, amqp_manager, manager_ip, username, password):
+    """Add default tenant, admin user and provider context to the DB
+    """
+    # Add the default network to the provider context
+    networks = PROVIDER_CONTEXT['cloudify']['cloudify_agent']['networks']
+    networks['default'] = manager_ip
+
+    provider_context = models.ProviderContext(
+        id=PROVIDER_CONTEXT_ID,
+        name=PROVIDER_NAME,
+        context=PROVIDER_CONTEXT
+    )
+    db.session.add(provider_context)
+
+    default_tenant = create_default_user_tenant_and_roles(
+        admin_username=username,
+        admin_password=password,
+        amqp_manager=amqp_manager,
+        authorization_file_path=os.environ[
+            'MANAGER_REST_AUTHORIZATION_CONFIG_PATH']
+    )
+
+    app.config[CURRENT_TENANT_CONFIG] = default_tenant
+    return default_tenant
+
+
+def close_session(app):
+    db.session.remove()
+    db.get_engine(app).dispose()
+
+
+def reset_storage(manager_ip, username, password):
+    app = setup_flask_app()
+    amqp_manager = setup_amqp_manager()
+
+    # Clear the old RabbitMQ resources
+    amqp_manager.remove_tenant_vhost_and_user(DEFAULT_TENANT_NAME)
+
+    # Rebuild the DB
+    safe_drop_all(keep_tables=['roles'])
+    upgrade(directory=migrations_dir)
+
+    # Add default tenant, admin user and provider context
+    _add_defaults(app, amqp_manager, manager_ip, username, password)
+
+    # Clear the connection
+    close_session(app)
+
+
+if __name__ == '__main__':
+    for required_env_var in [
+        'MANAGER_REST_CONFIG_PATH',
+        'MANAGER_REST_SECURITY_CONFIG_PATH',
+        'MANAGER_REST_AUTHORIZATION_CONFIG_PATH'
+    ]:
+        if required_env_var not in os.environ:
+            raise RuntimeError('{0} is a required environment variable'
+                               .format(required_env_var))
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--manager-ip', dest='manager_ip')
+    parser.add_argument('--username', dest='username')
+    parser.add_argument('--password', dest='password')
+    args = parser.parse_args()
+    config.instance.load_configuration()
+    reset_storage(args.manager_ip, args.username, args.password)

--- a/tests/integration_tests/tests/test_cases.py
+++ b/tests/integration_tests/tests/test_cases.py
@@ -40,7 +40,8 @@ from manager_rest.utils import mkdirs
 from manager_rest.constants import CLOUDIFY_TENANT_HEADER
 
 from integration_tests.framework import utils, hello_world, docl
-from integration_tests.framework.flask_utils import reset_storage
+from integration_tests.framework.flask_utils import reset_storage, \
+    prepare_reset_storage_script
 from integration_tests.framework.riemann import RIEMANN_CONFIGS_DIR
 from integration_tests.tests import utils as test_utils
 from integration_tests.framework.constants import (PLUGIN_STORAGE_DIR,
@@ -449,6 +450,11 @@ class BaseTestCase(unittest.TestCase):
 
 
 class AgentlessTestCase(BaseTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(AgentlessTestCase, cls).setUpClass()
+        prepare_reset_storage_script()
 
     def setUp(self):
         super(AgentlessTestCase, self).setUp()


### PR DESCRIPTION
The storage resetting parts must connect to the database, and to the
rabbitmq management API. Those should be only listening on localhost,
and not be reachable from outside, so to connect to them, the script
must live on the manager.

This change is about moving the reset_storage code from being run on
the test host, to a script that is being run on the manager container