### PR TITLE
flask_utils: add missing variable

### DIFF
--- a/tests/integration_tests/framework/flask_utils.py
+++ b/tests/integration_tests/framework/flask_utils.py
@@ -32,7 +32,7 @@ from integration_tests.tests.utils import get_resource
 
 
 logger = setup_logger('Flask Utils', logging.INFO)
-
+security_config = None
 SCRIPT_PATH = '/tmp/reset_storage.py'
 CONFIG_PATH = '/tmp/reset_storage_config.json'
 


### PR DESCRIPTION
It's used with `global` so it must be defined first