### PR TITLE
Snapshot tests: allow for ConnectionError

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -403,7 +403,7 @@ class TestSnapshot(AgentlessTestCase):
             # real time - it's OK. Just try again
             try:
                 execution = rest_client.executions.get(execution.id)
-            except CloudifyClientError:
+            except (requests.exceptions.ConnectionError, CloudifyClientError):
                 pass
             if time.time() > deadline:
                 raise utils.TimeoutException(


### PR DESCRIPTION
While restoring the database, 500 errors other than CloudifyClientError
can be thrown as well.