### PR TITLE
CFY-7877 No longer update influxDB IP in IP setter

### DIFF
--- a/packaging/ip_setter/files/opt/cloudify/manager-ip-setter/manager-ip-setter.sh
+++ b/packaging/ip_setter/files/opt/cloudify/manager-ip-setter/manager-ip-setter.sh
@@ -9,7 +9,6 @@ function set_manager_ip() {
 
   echo "Updating cloudify-amqpinflux.."
   /usr/bin/sed -i -e "s/AMQP_HOST=.*/AMQP_HOST="'"'"${ip}"'"'"/" /etc/sysconfig/cloudify-amqpinflux
-  /usr/bin/sed -i -e "s/INFLUXDB_HOST=.*/INFLUXDB_HOST="'"'"${ip}"'"'"/" /etc/sysconfig/cloudify-amqpinflux
 
   echo "Updating cloudify-riemann.."
   /usr/bin/sed -i -e "s/RABBITMQ_HOST=.*/RABBITMQ_HOST="'"'"${ip}"'"'"/" /etc/sysconfig/cloudify-riemann


### PR DESCRIPTION
Because we're either binding on `localhost` or an external endpoint, there's no point in replacing this IP with the private one.