### PR TITLE
CY-269 Add api for reloading the configuration of the rest service

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/manager_config.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/manager_config.py
@@ -41,6 +41,15 @@ class ManagerConfig(SecuredResource):
             result['authorization'] = self._authorization_config()
         return result
 
+    @rest_decorators.exceptions_handled
+    @authorize('manager_config_reload')
+    def post(self):
+        """
+        Reload the Manager config
+        """
+        config.instance.load_configuration()
+        return 'The rest service configuration was reloaded', 200
+
     @staticmethod
     def _authorization_config():
         cfy_config = config.instance

--- a/tests/integration_tests/tests/agentless_tests/test_manager_config.py
+++ b/tests/integration_tests/tests/agentless_tests/test_manager_config.py
@@ -1,0 +1,51 @@
+#########
+# Copyright (c) 2016 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+
+import yaml
+import tempfile
+
+from integration_tests import AgentlessTestCase
+from integration_tests.framework.constants import AUTHORIZATION_FILE_LOCATION
+
+
+class ManagerConfigTestCase(AgentlessTestCase):
+    def test_reload_config(self):
+        new_permission = 'test_reload'
+        new_config = {new_permission: new_permission}
+        self._change_authorization_config(new_config)
+
+        # The new permission is not updated yet
+        manager_config = self.client.manager_config.get()
+        permissions = manager_config['authorization']['permissions']
+        self.assertEquals(permissions.get(new_permission, None), None)
+
+        self.client.manager_config.reload()
+
+        # The new permission is updated
+        manager_config = self.client.manager_config.get()
+        permissions = manager_config['authorization']['permissions']
+        self.assertEquals(permissions.get(new_permission, None),
+                          new_permission)
+
+    def _change_authorization_config(self, new_permissions_config):
+        auth_config = yaml.load(self.read_manager_file(
+            AUTHORIZATION_FILE_LOCATION))
+        auth_config['permissions'].update(new_permissions_config)
+        with tempfile.NamedTemporaryFile() as f:
+            yaml.dump(auth_config, f)
+            f.flush()
+            self.copy_file_to_manager(source=f.name,
+                                      target=AUTHORIZATION_FILE_LOCATION,
+                                      owner='cfyuser')

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -341,7 +341,7 @@ class SnapshotRestore(object):
         rest_security_conf.update(snapshot_security_conf)
         with open(SECURITY_FILE_LOCATION, 'w') as security_conf_file:
             json.dump(rest_security_conf, security_conf_file)
-        self._add_restart_command()
+        self._client.manager_config.reload()
 
     def _restore_db(self, postgres, schema_revision, stage_revision):
         """Restore database from snapshot.
@@ -642,7 +642,7 @@ class SnapshotRestore(object):
 
             with open(SECURITY_FILE_LOCATION, 'w') as security_conf_handle:
                 json.dump(rest_security_conf, security_conf_handle)
-            self._add_restart_command()
+            self._client.manager_config.reload()
 
         self._restore_admin_user()
 
@@ -668,11 +668,6 @@ class SnapshotRestore(object):
         ]).aggr_stdout.strip()
 
         return prefix + token_info['token']
-
-    def _add_restart_command(self):
-        restart_rest = 'sudo systemctl restart cloudify-restservice'
-        if restart_rest not in self._post_restore_commands:
-            self._post_restore_commands.append(restart_rest)
 
 
 class SnapshotRestoreValidator(object):


### PR DESCRIPTION
* Add the api post /config for reloading the rest service

* Also use this api instead of restarting the rest service after the snapshot restore