### PR TITLE
CY-271 Fix the restore of snapshot with agents

### DIFF
--- a/rest-service/manager_rest/cryptography_utils.py
+++ b/rest-service/manager_rest/cryptography_utils.py
@@ -17,10 +17,10 @@ from cryptography.fernet import Fernet
 
 
 def encrypt(key, data):
-    fernet = Fernet(key)
+    fernet = Fernet(str(key))
     return fernet.encrypt(bytes(data))
 
 
 def decrypt(key, encrypted_data):
-    fernet = Fernet(key)
+    fernet = Fernet(str(key))
     return fernet.decrypt(bytes(encrypted_data))

--- a/rest-service/manager_rest/rest/resources_v3/secrets.py
+++ b/rest-service/manager_rest/rest/resources_v3/secrets.py
@@ -121,8 +121,9 @@ class SecretsKey(SecuredResource):
         get_resource_manager().validate_modification_permitted(secret)
         return storage_manager.delete(secret)
 
-    def _encrypt_secret_value(self, value):
-        encryption_key = config.instance.security_encryption_key
+    def _encrypt_secret_value(self, value, encryption_key=None):
+        encryption_key = encryption_key or \
+                         config.instance.security_encryption_key
         return cryptography_utils.encrypt(encryption_key, value)
 
     def _is_value_permitted(self, creator):

--- a/rest-service/manager_rest/rest/resources_v3_1/secrets.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/secrets.py
@@ -66,7 +66,10 @@ class SecretsKey(resources_v3.SecretsKey):
         update_if_exists is set to true
         """
         secret_params = self._get_secret_params(key)
-        encrypted_value = self._encrypt_secret_value(secret_params['value'])
+        encrypted_value = self._encrypt_secret_value(
+            secret_params['value'],
+            secret_params['encryption_key']  # Used only in restore snapshot
+        )
         sm = get_storage_manager()
         timestamp = utils.get_formatted_timestamp()
 
@@ -117,6 +120,7 @@ class SecretsKey(resources_v3.SecretsKey):
             'value': request_dict['value'],
             'update_if_exists': update_if_exists,
             'visibility': visibility,
-            'is_hidden_value': is_hidden_value
+            'is_hidden_value': is_hidden_value,
+            'encryption_key': request_dict.get('encryption_key', None)
         }
         return secret_params


### PR DESCRIPTION
When restoring a snapshot with agents, in the restore process we save the ssh keys as secrets. In the restore we are using the current encryption key but after the restore the key is changed to the one in the snapshot. So after the snapshot restore those secrets can't be decrypted. We added the encryption_key parameter to secrets create rest api. It should be used internally only in snapshot restore process, when we create the agent's ssh keys as secrets and want to use the encryption key from the snapshot.