### PR TITLE
test_resources_available: check fileserver is not exposed

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_resources_available.py
+++ b/tests/integration_tests/tests/agentless_tests/test_resources_available.py
@@ -39,7 +39,7 @@ class ResourcesAvailableTest(AgentlessTestCase):
         with self.assertRaises(
                 ConnectionError,
                 msg="Resources are available through port 53229."):
-            result = requests.head(invalid_resource_url)
+            requests.head(invalid_resource_url)
 
     def test_resources_access(self):
         self.client.blueprints.upload(resource('dsl/empty_blueprint.yaml'),

--- a/tests/integration_tests/tests/agentless_tests/test_resources_available.py
+++ b/tests/integration_tests/tests/agentless_tests/test_resources_available.py
@@ -34,15 +34,12 @@ class ResourcesAvailableTest(AgentlessTestCase):
         blueprint_path = resource('dsl/{0}'.format(blueprint_name))
         self.client.blueprints.upload(blueprint_path,
                                       entity_id=blueprint_id)
-        invalid_resource_url = 'https://{0}:{1}/resources/blueprints/{1}/{2}' \
+        invalid_resource_url = 'https://{0}:{1}/blueprints/{1}/{2}' \
             .format(container_ip, 53229, blueprint_id, blueprint_name)
-        try:
+        with self.assertRaises(
+                ConnectionError,
+                msg="Resources are available through port 53229."):
             result = requests.head(invalid_resource_url)
-            self.assertEqual(
-                result.status_code, requests.status_codes.codes.not_found,
-                "Resources are available through port 53229.")
-        except ConnectionError:
-            pass
 
     def test_resources_access(self):
         self.client.blueprints.upload(resource('dsl/empty_blueprint.yaml'),


### PR DESCRIPTION
The test used to pass the wrong URL, so it appeared as if the resources
were not available, while in reality they are.
Instead, we should test that the fileserver is not exposed at all.