### PR TITLE
CFY-7661 Create stubs for repos that were merged into cloudify-common

### DIFF
--- a/packaging/cloudify-mgmtworker.spec
+++ b/packaging/cloudify-mgmtworker.spec
@@ -31,7 +31,7 @@ rm /opt/mgmtworker/env/lib/python2.7/site-packages/zmq/tests/_test_asyncio.py
 
 
 # Install stubs of cloudify packages that were merged into cloudify-common
-STUBS=${RPM_SOURCE_DIR}/packaging/mgmtworker/files/stub_packages
+STUBS=${RPM_SOURCE_DIR}/packaging/mgmtworker/stub_packages
 /opt/mgmtworker/env/bin/pip install --upgrade ${STUBS}/cloudify-rest-client/
 /opt/mgmtworker/env/bin/pip install --upgrade ${STUBS}/cloudify-plugins-common/
 /opt/mgmtworker/env/bin/pip install --upgrade ${STUBS}/cloudify-dsl-parser/

--- a/packaging/cloudify-mgmtworker.spec
+++ b/packaging/cloudify-mgmtworker.spec
@@ -30,6 +30,13 @@ virtualenv /opt/mgmtworker/env
 rm /opt/mgmtworker/env/lib/python2.7/site-packages/zmq/tests/_test_asyncio.py
 
 
+# Install stubs of cloudify packages that were merged into cloudify-common
+STUBS=${RPM_SOURCE_DIR}/packaging/mgmtworker/files/stub_packages
+/opt/mgmtworker/env/bin/pip install --upgrade ${STUBS}/cloudify-rest-client/
+/opt/mgmtworker/env/bin/pip install --upgrade ${STUBS}/cloudify-plugins-common/
+/opt/mgmtworker/env/bin/pip install --upgrade ${STUBS}/cloudify-dsl-parser/
+/opt/mgmtworker/env/bin/pip install --upgrade ${STUBS}/cloudify-script-plugin/
+
 %install
 mkdir -p %{buildroot}/opt/mgmtworker
 mv /opt/mgmtworker/env %{buildroot}/opt/mgmtworker

--- a/packaging/mgmtworker/requirements.txt
+++ b/packaging/mgmtworker/requirements.txt
@@ -1,3 +1,8 @@
 git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common==4.4.dev1
 git+https://github.com/cloudify-cosmo/cloudify-agent@master#egg=cloudify-agent==4.4.dev1
 
+# These are stubs of cloudify packages that were merged into cloudify-common
+./stub_packages/cloudify-dsl-parser
+./stub_packages/cloudify-rest-client
+./stub_packages/cloudify-plugins-common
+./stub_packages/cloudify-script-plugin

--- a/packaging/mgmtworker/requirements.txt
+++ b/packaging/mgmtworker/requirements.txt
@@ -1,8 +1,2 @@
 git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common==4.4.dev1
 git+https://github.com/cloudify-cosmo/cloudify-agent@master#egg=cloudify-agent==4.4.dev1
-
-# These are stubs of cloudify packages that were merged into cloudify-common
-./stub_packages/cloudify-dsl-parser
-./stub_packages/cloudify-rest-client
-./stub_packages/cloudify-plugins-common
-./stub_packages/cloudify-script-plugin

--- a/packaging/mgmtworker/stub_packages/cloudify-dsl-parser/setup.py
+++ b/packaging/mgmtworker/stub_packages/cloudify-dsl-parser/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+
+setup(
+    name='cloudify-dsl-parser',
+    version='4.4.dev1',
+    packages=[],
+    description='[DEPRECATED] A stub for the old cloudify-dsl-parser package',
+)

--- a/packaging/mgmtworker/stub_packages/cloudify-plugins-common/setup.py
+++ b/packaging/mgmtworker/stub_packages/cloudify-plugins-common/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+
+setup(
+    name='cloudify-plugins-common',
+    version='4.4.dev1',
+    packages=[],
+    description='[DEPRECATED] A stub for the old '
+                'cloudify-plugins-common package',
+)

--- a/packaging/mgmtworker/stub_packages/cloudify-rest-client/setup.py
+++ b/packaging/mgmtworker/stub_packages/cloudify-rest-client/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+
+setup(
+    name='cloudify-rest-client',
+    version='4.4.dev1',
+    packages=[],
+    description='[DEPRECATED] A stub for the old cloudify-rest-client package',
+)

--- a/packaging/mgmtworker/stub_packages/cloudify-script-plugin/setup.py
+++ b/packaging/mgmtworker/stub_packages/cloudify-script-plugin/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+
+setup(
+    name='cloudify-script-plugin',
+    version='4.4.dev1',
+    packages=[],
+    description='[DEPRECATED] A stub for the '
+                'old cloudify-script-plugin package',
+)


### PR DESCRIPTION
This is to continue supporting old Cloudify plugins that would
otherwise break, because during installation they would install
the old plugins-common/rest-client/etc wheels that were contained in
the wagon.
This solution should make the pip freeze command we're using to create
the constraints file for the mgmtworker venv during plugin installation
contain the same package names, and thus prevent the installation
of the older ones in the plugin venv.