### PR TITLE
CY-348 rabbitmq: provide the internal cert as cacertfile

### DIFF
--- a/packaging/rabbitmq/files/etc/cloudify/rabbitmq/rabbitmq.config
+++ b/packaging/rabbitmq/files/etc/cloudify/rabbitmq/rabbitmq.config
@@ -3,7 +3,7 @@
  {rabbit, [
            {loopback_users, []},
            {ssl_listeners, [5671]},
-           {ssl_options, [{cacertfile,"/etc/cloudify/ssl/cloudify_internal_ca_cert.pem"},
+           {ssl_options, [{cacertfile,"/etc/cloudify/ssl/cloudify_internal_cert.pem"},
                           {certfile,  "/etc/cloudify/ssl/cloudify_internal_cert.pem"},
                           {keyfile,   "/etc/cloudify/ssl/cloudify_internal_key.pem"},
                           {versions, ['tlsv1.2', 'tlsv1.1']}
@@ -15,7 +15,7 @@
         {ip, "127.0.0.1"},
         {port, 15671},
         {ssl, true},
-        {ssl_opts, [{cacertfile,"/etc/cloudify/ssl/cloudify_internal_ca_cert.pem"},
+        {ssl_opts, [{cacertfile,"/etc/cloudify/ssl/cloudify_internal_cert.pem"},
                     {certfile,  "/etc/cloudify/ssl/cloudify_internal_cert.pem"},
                     {keyfile,   "/etc/cloudify/ssl/cloudify_internal_key.pem"},
                     {versions, ['tlsv1.2', 'tlsv1.1']}


### PR DESCRIPTION
RabbitMQ uses the 'cacertfile' setting as the chain to send with
the server certificate (in addition to using it for client
cert verification).

This means the certfile setting must contain the server cert, and
cacertfile must contain the intermediaries, if any.

In certfile, the additional intermediary is ignored, so we can use
the cloudify_internal_cert bundle there.
In cacertfile, the server file is ignored, so there we can also use
the same bundle.