### PR TITLE
Added --ignore-plugin-installation-failure flag to 'cfy snapshot rest…

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -165,7 +165,8 @@ class ResourceManager(object):
                          bypass_maintenance,
                          timeout,
                          restore_certificates,
-                         no_reboot):
+                         no_reboot,
+                         ignore_plugin_installation_failure):
         # Throws error if no snapshot found
         snapshot = self.sm.get(models.Snapshot, snapshot_id)
         if snapshot.status == SnapshotState.FAILED:
@@ -184,6 +185,8 @@ class ResourceManager(object):
                 'timeout': timeout,
                 'restore_certificates': restore_certificates,
                 'no_reboot': no_reboot,
+                'ignore_plugin_installation_failure':
+                    ignore_plugin_installation_failure,
                 'premium_enabled': premium_enabled,
                 'user_is_bootstrap_admin': current_user.is_bootstrap_admin
             },

--- a/rest-service/manager_rest/rest/resources_v2/snapshots.py
+++ b/rest-service/manager_rest/rest/resources_v2/snapshots.py
@@ -254,7 +254,8 @@ class SnapshotsIdRestore(SecuredResource):
     def post(self, snapshot_id):
         _verify_no_multi_node_cluster(action="restore snapshot")
         request_dict = rest_utils.get_json_and_verify_params(
-            {'recreate_deployments_envs'}
+            {'recreate_deployments_envs',
+             'ignore_plugin_installation_failure'}
         )
         recreate_deployments_envs = rest_utils.verify_and_convert_bool(
             'recreate_deployments_envs',
@@ -273,6 +274,11 @@ class SnapshotsIdRestore(SecuredResource):
             'no_reboot',
             request_dict.get('no_reboot', 'false')
         )
+        ignore_plugin_installation_failure = \
+            rest_utils.verify_and_convert_bool(
+                'ignore_plugin_installation_failure',
+                request_dict.get('ignore_plugin_installation_failure', 'false')
+            )
         if no_reboot and not restore_certificates:
             raise manager_exceptions.BadParametersError(
                 '`no_reboot` is only relevant when `restore_certificates` is '
@@ -287,6 +293,7 @@ class SnapshotsIdRestore(SecuredResource):
             bypass_maintenance,
             timeout,
             restore_certificates,
-            no_reboot
+            no_reboot,
+            ignore_plugin_installation_failure
         )
         return execution, 200

--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -83,6 +83,53 @@ class TestSnapshot(AgentlessTestCase):
         execution = client.executions.get(execution.id)
         self.assertEqual(execution.status, ExecutionState.FAILED)
 
+    def test_4_4_snapshot_restore_with_bad_plugin_wgn_file(self):
+        snapshot_path = \
+            self._get_snapshot('snap_4_4_0_bad_plugin_wgn_file.zip')
+        self._upload_and_restore_snapshot(
+            snapshot_path,
+            desired_execution_status=Execution.TERMINATED,
+            error_execution_status=Execution.FAILED,
+            ignore_plugin_install_failure=True)
+
+        # Now make sure all the resources really exist in the DB
+        # Assert snapshot restored
+        self._assert_4_4_0_snapshot_restored_bad_plugin_no_deployments()
+
+    def test_4_4_snapshot_restore_with_bad_plugin_no_directory(self):
+        snapshot_path = \
+            self._get_snapshot('snap_4_4_0_bad_plugin_no_directory.zip')
+        self._upload_and_restore_snapshot(
+            snapshot_path,
+            desired_execution_status=Execution.TERMINATED,
+            error_execution_status=Execution.FAILED,
+            ignore_plugin_install_failure=True)
+
+        # Now make sure all the resources really exist in the DB
+        # Assert snapshot restored
+        self._assert_4_4_0_snapshot_restored_bad_plugin_no_deployments()
+
+    def test_4_4_snapshot_restore_with_bad_plugin_with_deps(self):
+        snapshot_path = self._get_snapshot(
+            'snap_4_4_0_bad_plugin_no_directory_with_deps.zip')
+        self._upload_and_restore_snapshot(
+            snapshot_path,
+            desired_execution_status=Execution.TERMINATED,
+            error_execution_status=Execution.FAILED,
+            ignore_plugin_install_failure=True)
+
+        # Now make sure all the resources really exist in the DB
+        # Assert snapshot restored
+        self._assert_4_4_0_snapshot_restored_bad_plugin_no_deployments()
+
+    def test_4_4_snapshot_restore_with_bad_plugin_fails(self):
+        snapshot_path = \
+            self._get_snapshot('snap_4_4_0_bad_plugin_no_directory.zip')
+        self._upload_and_restore_snapshot(
+            snapshot_path,
+            desired_execution_status=Execution.FAILED,
+            error_execution_status=Execution.CANCELLED)
+
     def test_4_2_snapshot_with_deployment(self):
         snapshot_path = self._get_snapshot('snap_4.2.0.zip')
         self._upload_and_restore_snapshot(snapshot_path)
@@ -175,6 +222,13 @@ class TestSnapshot(AgentlessTestCase):
         self._assert_3_3_1_snapshot_restored()
         self._assert_3_3_1_plugins_restored()
 
+    def _assert_4_4_0_snapshot_restored_bad_plugin_no_deployments(
+            self,
+            tenant_name=DEFAULT_TENANT_NAME):
+        self._assert_4_4_0_plugins_restored_bad_plugin_no_deployments(
+            tenant_name=tenant_name,
+        )
+
     def _assert_3_3_1_snapshot_restored(self,
                                         tenant_name=DEFAULT_TENANT_NAME):
         self._assert_snapshot_restored(
@@ -229,12 +283,12 @@ class TestSnapshot(AgentlessTestCase):
         self._upload_and_restore_snapshot(snapshot_path)
         blueprints = self.client.blueprints.list(
             _include=['id', 'visibility'])
-        assert blueprints[0]['id'] == 'blueprint_1' and \
-            blueprints[0]['visibility'] == 'tenant'
-        assert blueprints[1]['id'] == 'blueprint_2' and \
-            blueprints[1]['visibility'] == 'private'
-        assert blueprints[2]['id'] == 'blueprint_3' and \
-            blueprints[2]['visibility'] == 'private'
+        assert (blueprints[0]['id'] == 'blueprint_1' and
+                blueprints[0]['visibility'] == 'tenant')
+        assert (blueprints[1]['id'] == 'blueprint_2' and
+                blueprints[1]['visibility'] == 'private')
+        assert (blueprints[2]['id'] == 'blueprint_3' and
+                blueprints[2]['visibility'] == 'private')
 
     def test_v_4_2_restore_snapshot_with_resource_availability(self):
         """
@@ -246,12 +300,12 @@ class TestSnapshot(AgentlessTestCase):
         self._upload_and_restore_snapshot(snapshot_path)
         blueprints = self.client.blueprints.list(
             _include=['id', 'visibility'])
-        assert blueprints[0]['id'] == 'blueprint_1' and \
-            blueprints[0]['visibility'] == 'private'
-        assert blueprints[1]['id'] == 'blueprint_2' and \
-            blueprints[1]['visibility'] == 'tenant'
-        assert blueprints[2]['id'] == 'blueprint_3' and \
-            blueprints[2]['visibility'] == 'global'
+        assert (blueprints[0]['id'] == 'blueprint_1' and
+                blueprints[0]['visibility'] == 'private')
+        assert (blueprints[1]['id'] == 'blueprint_2' and
+                blueprints[1]['visibility'] == 'tenant')
+        assert (blueprints[2]['id'] == 'blueprint_3' and
+                blueprints[2]['visibility'] == 'global')
 
     def test_v_4_3_restore_snapshot_with_secrets(self):
         """
@@ -295,8 +349,8 @@ class TestSnapshot(AgentlessTestCase):
         assert secret_encrypted != 'top_secret'
 
         # The secrets values are not hidden
-        assert not secret_string.is_hidden_value and \
-            not secret_file.is_hidden_value
+        assert (not secret_string.is_hidden_value and
+                not secret_file.is_hidden_value)
 
     def _assert_snapshot_restored(self,
                                   blueprint_id,
@@ -344,6 +398,24 @@ class TestSnapshot(AgentlessTestCase):
         package_names = [plugin.package_name for plugin in plugins]
         package_name_counts = Counter(package_names)
         self.assertEqual(package_name_counts['cloudify-openstack-plugin'], 1)
+        self.assertEqual(package_name_counts['cloudify-fabric-plugin'], 1)
+        self.assertEqual(package_name_counts['cloudify-script-plugin'], 1)
+        self.assertEqual(package_name_counts['cloudify-diamond-plugin'], 5)
+
+    def _assert_4_4_0_plugins_restored_bad_plugin_no_deployments(
+            self,
+            tenant_name=DEFAULT_TENANT_NAME):
+        """
+        Validate only 7 of the 8 plugins in the snapshot are being restored
+        also, no deployments have been restored
+        """
+        with self.client_using_tenant(self.client, tenant_name):
+            plugins = self.client.plugins.list()
+            deployments = self.client.deployments.list()
+        self.assertEqual(len(plugins), 7)
+        self.assertEqual(len(deployments), 0)
+        package_names = [plugin.package_name for plugin in plugins]
+        package_name_counts = Counter(package_names)
         self.assertEqual(package_name_counts['cloudify-fabric-plugin'], 1)
         self.assertEqual(package_name_counts['cloudify-script-plugin'], 1)
         self.assertEqual(package_name_counts['cloudify-diamond-plugin'], 5)
@@ -400,10 +472,14 @@ class TestSnapshot(AgentlessTestCase):
         tmp_file = os.path.join(self.workdir, name)
         return utils.download_file(snapshot_url, tmp_file)
 
-    def _upload_and_restore_snapshot(self,
-                                     snapshot_path,
-                                     tenant_name=DEFAULT_TENANT_NAME,
-                                     snapshot_id=None):
+    def _upload_and_restore_snapshot(
+            self,
+            snapshot_path,
+            tenant_name=DEFAULT_TENANT_NAME,
+            snapshot_id=None,
+            desired_execution_status=Execution.TERMINATED,
+            error_execution_status=Execution.FAILED,
+            ignore_plugin_install_failure=False):
         """Upload the snapshot and launch the restore workflow
         """
         snapshot_id = snapshot_id or self.SNAPSHOT_ID
@@ -412,30 +488,20 @@ class TestSnapshot(AgentlessTestCase):
                                            snapshot_id,
                                            rest_client)
         self.logger.debug('Restoring snapshot...')
-        execution = rest_client.snapshots.restore(snapshot_id)
+        execution = rest_client.snapshots.restore(
+            snapshot_id,
+            ignore_plugin_install_failure=ignore_plugin_install_failure)
         execution = self._wait_for_restore_execution_to_end(
             execution, rest_client)
-        if execution.status == Execution.FAILED:
+        if execution.status == error_execution_status:
             self.logger.error('Execution error: {0}'.format(execution.error))
-        self.assertEqual(Execution.TERMINATED, execution.status)
+        self.assertEqual(desired_execution_status, execution.status)
 
         # Wait for the restart of cloudify-restservice to end.
         # If the rest-security.conf file was changed the service is being
         # restarted. As you can see in snapshot_restore.py when calling the
         # function _add_restart_command.
         time.sleep(5)
-
-    def _upload_and_validate_snapshot(self,
-                                      snapshot_path,
-                                      snapshot_id,
-                                      rest_client):
-        self.logger.debug('Uploading snapshot: {0}'.format(snapshot_path))
-        rest_client.snapshots.upload(snapshot_path, snapshot_id)
-        snapshot = rest_client.snapshots.get(snapshot_id)
-        self.logger.debug('Retrieved snapshot: {0}'.format(snapshot))
-        self.assertEquals(snapshot['id'], snapshot_id)
-        self.assertEquals(snapshot['status'], 'uploaded')
-        self.logger.info('Snapshot uploaded and validated')
 
     def _wait_for_restore_execution_to_end(
             self, execution, rest_client, timeout_seconds=60):

--- a/workflows/cloudify_system_workflows/snapshot.py
+++ b/workflows/cloudify_system_workflows/snapshot.py
@@ -49,6 +49,7 @@ def restore(snapshot_id,
             no_reboot,
             premium_enabled,
             user_is_bootstrap_admin,
+            ignore_plugin_installation_failure,
             **kwargs):
     ctx.logger.info('Restoring snapshot `{0}`'.format(snapshot_id))
     ctx.logger.debug('Restoring snapshot config: {0}'.format(config))
@@ -62,7 +63,8 @@ def restore(snapshot_id,
         premium_enabled,
         user_is_bootstrap_admin,
         restore_certificates,
-        no_reboot
+        no_reboot,
+        ignore_plugin_installation_failure
     )
     restore_snapshot.restore()
 

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -69,7 +69,6 @@ from .constants import (
 
 
 class SnapshotRestore(object):
-
     SCHEMA_REVISION_4_0 = '333998bc1627'
 
     def __init__(self,
@@ -81,7 +80,8 @@ class SnapshotRestore(object):
                  premium_enabled,
                  user_is_bootstrap_admin,
                  restore_certificates,
-                 no_reboot):
+                 no_reboot,
+                 ignore_plugin_installation_failure):
         self._npm = Npm()
         self._config = utils.DictToAttributes(config)
         self._snapshot_id = snapshot_id
@@ -91,6 +91,8 @@ class SnapshotRestore(object):
         self._no_reboot = no_reboot
         self._premium_enabled = premium_enabled
         self._user_is_bootstrap_admin = user_is_bootstrap_admin
+        self._ignore_plugin_installation_failure = \
+            ignore_plugin_installation_failure
         self._post_restore_commands = []
 
         self._tempdir = None
@@ -141,9 +143,55 @@ class SnapshotRestore(object):
             ctx.logger.debug('Removing temp dir: {0}'.format(self._tempdir))
             shutil.rmtree(self._tempdir)
 
+    @staticmethod
+    def __remove_failed_deployments_footprints(tenant_client,
+                                               failed_deployments):
+        '''
+        Used to remove any deployments footprints in the DB or File System
+        :param tenant_client: Client to use to delete the deployment from
+        :param failed_deployments: Deployments that have failed to be recreated
+        and are needed to be removed from DB or File System
+        :exception ex: Caught only for informational purposes since the
+        deployment could be only partially installed, thus partially deleted
+        '''
+        for failed_deployment in failed_deployments:
+            try:
+                ctx.logger.info('Removing failed deployment {0}'
+                                ' footprints'.format(failed_deployment))
+                tenant_client.deployments.delete(failed_deployment)
+            except Exception as ex:
+                ctx.logger.warning('Failed to delete deployment footprints {0}'
+                                   ' with error: {1}'.format(failed_deployment,
+                                                             ex.message))
+
+    @staticmethod
+    def __log_message_for_deployment_restore(deployments,
+                                             failed_deployments,
+                                             tenant):
+        if not failed_deployments:
+            ctx.logger.info(
+                'Finished restoring deployment environments for '
+                '{tenant}'.format(tenant=tenant, )
+            )
+        else:
+            ctx.logger.warning(
+                'Finished restoring {0}/{1} deployment environments for '
+                '{tenant}'.format(
+                    len(deployments) - len(failed_deployments),
+                    len(deployments),
+                    tenant=tenant,
+                )
+            )
+
+    def __should_ignore_deployment_failure(self,
+                                           message):
+        return 'cloudify_agent.operations.install_plugins' in \
+               message and self._ignore_plugin_installation_failure
+
     def _restore_deployment_envs(self, postgres):
         deps = utils.get_dep_contexts(self._snapshot_version)
         token_info = postgres.get_deployment_creator_ids_and_tokens()
+        failed_deployments = []
         for tenant, deployments in deps:
             ctx.logger.info(
                 'Restoring deployment environments for {tenant}'.format(
@@ -152,36 +200,46 @@ class SnapshotRestore(object):
             )
             tenant_client = get_rest_client(tenant=tenant)
             for deployment_id, dep_ctx in deployments.iteritems():
-                ctx.logger.info('Restoring deployment {dep_id}'.format(
-                    dep_id=deployment_id,
-                ))
-                api_token = self._get_api_token(
-                    token_info[tenant][deployment_id]
-                )
-                with dep_ctx:
-                    dep = tenant_client.deployments.get(deployment_id)
-                    blueprint = tenant_client.blueprints.get(
-                        dep_ctx.blueprint.id,
+                try:
+                    ctx.logger.info('Restoring deployment {dep_id}'.format(
+                        dep_id=deployment_id,
+                    ))
+                    api_token = self._get_api_token(
+                        token_info[tenant][deployment_id]
                     )
-                    tasks_graph = self._get_tasks_graph(
-                        dep_ctx,
-                        blueprint,
-                        dep,
-                        api_token,
-                    )
-                    tasks_graph.execute()
-                    ctx.logger.info(
-                        'Successfully created deployment environment '
-                        'for deployment {deployment}'.format(
-                            deployment=deployment_id,
+                    with dep_ctx:
+                        dep = tenant_client.deployments.get(deployment_id)
+                        blueprint = tenant_client.blueprints.get(
+                            dep_ctx.blueprint.id,
                         )
-                    )
-            ctx.logger.info(
-                'Finished restoring deployment environments for '
-                '{tenant}'.format(
-                    tenant=tenant,
-                )
-            )
+                        tasks_graph = self._get_tasks_graph(
+                            dep_ctx,
+                            blueprint,
+                            dep,
+                            api_token,
+                        )
+                        tasks_graph.execute()
+                        ctx.logger.info(
+                            'Successfully created deployment environment '
+                            'for deployment {deployment}'.format(
+                                deployment=deployment_id,
+                            )
+                        )
+                except RuntimeError as re:
+                    if self.__should_ignore_deployment_failure(re.message):
+                        ctx.logger.warning('Failed to create deployment: {0},'
+                                           'ignore_plugin_installation_failure'
+                                           'flag used, proceeding...'
+                                           .format(deployment_id))
+                        ctx.logger.debug('Deployment creation error: {0}'
+                                         .format(re))
+                        failed_deployments.append(deployment_id)
+                    else:
+                        raise re
+            SnapshotRestore.__remove_failed_deployments_footprints(
+                tenant_client, failed_deployments)
+            SnapshotRestore.__log_message_for_deployment_restore(
+                deployments, failed_deployments, tenant)
 
     def _restore_amqp_vhosts_and_users(self):
         subprocess.check_call(
@@ -218,9 +276,9 @@ class SnapshotRestore(object):
 
         if not os.path.exists(
                 os.path.join(archive_cert_dir, INTERNAL_CA_CERT_FILENAME)):
-            for source, target in [
-                    (INTERNAL_CERT_FILENAME, INTERNAL_CA_CERT_FILENAME),
-                    (INTERNAL_KEY_FILENAME, INTERNAL_CA_KEY_FILENAME)]:
+            for source, target in \
+                    [(INTERNAL_CERT_FILENAME, INTERNAL_CA_CERT_FILENAME),
+                     (INTERNAL_KEY_FILENAME, INTERNAL_CA_KEY_FILENAME)]:
                 source = os.path.join(CERT_DIR, source)
                 target = os.path.join(CERT_DIR, target)
                 command += 'cp {source} {target};'.format(
@@ -319,7 +377,7 @@ class SnapshotRestore(object):
         # if this snapshot version is the same as the manager version
         # or from 4.3 onwards we support stage upgrade
         if self._snapshot_version == self._manager_version or \
-           self._snapshot_version >= V_4_3_0:
+                self._snapshot_version >= V_4_3_0:
             stage_restore_override = True
         else:
             stage_restore_override = False
@@ -504,6 +562,7 @@ class SnapshotRestore(object):
 
         :param existing_plugins: Names of already installed plugins
         """
+
         def should_install(plugin):
             # Can't just do 'not in' as plugin is a dict
             hashable_existing = (frozenset(p) for p in existing_plugins)
@@ -555,9 +614,12 @@ class SnapshotRestore(object):
             shutil.copyfile(plugin['path'], temp_plugin)
 
         client.plugins.delete(plugin['id'], force=True)
-        client.plugins.upload(temp_plugin,
-                              visibility=plugin['visibility'])
-        os.remove(temp_plugin)
+        try:
+            client.plugins.upload(temp_plugin,
+                                  visibility=plugin['visibility'])
+        finally:
+            # In any case, failure or success, delete tmp* folder
+            os.remove(temp_plugin)
 
     def _wait_for_plugin_executions(self, client):
         while True:
@@ -576,9 +638,31 @@ class SnapshotRestore(object):
                 msg = ', '.join('{0} (state: {1})'
                                 .format(execution.id, execution.status))
                 ctx.logger.info(
-                    'Waiting for plugin install executions to finish: {0}'
-                    .format(msg))
+                    'Waiting for plugin install executions to finish: '
+                    '{0}'.format(msg))
                 time.sleep(3)
+
+    @staticmethod
+    def __remove_failed_plugins_footprints(client, failed_plugins):
+        for failed_plugin in failed_plugins:
+            # Removing failed plugins from the database and file server
+            try:
+                ctx.logger.info('Removing failed plugin footprints')
+                client.plugins.delete(failed_plugin['id'], force=True)
+            except Exception as ex:
+                ctx.logger.warning('Failed to delete plugin footprints {0} '
+                                   'with error: {1}. Proceeding...'
+                                   .format(failed_plugin, ex.message))
+
+    @staticmethod
+    def __log_message_for_plugin_restore(failed_plugins):
+        if not failed_plugins:
+            ctx.logger.info('Successfully restored plugins')
+        else:
+            plugin_installation_log_message = \
+                'Plugins: {0} have not been installed ' \
+                'successfully'.format(failed_plugins)
+            ctx.logger.warning(plugin_installation_log_message)
 
     def _restore_plugins(self, existing_plugins):
         """Install any plugins that weren't installed prior to the restore
@@ -587,16 +671,34 @@ class SnapshotRestore(object):
         """
         ctx.logger.info('Restoring plugins')
         plugins_to_install = self._get_plugins_to_install(existing_plugins)
+        failed_plugins = []
         for tenant, plugins in plugins_to_install.items():
             client = get_rest_client(tenant=tenant)
             plugins_tmp = tempfile.mkdtemp()
             try:
                 for plugin in plugins:
-                    self._restore_plugin(client, tenant, plugin, plugins_tmp)
+                    try:
+                        self._restore_plugin(client,
+                                             tenant,
+                                             plugin,
+                                             plugins_tmp)
+                    except Exception as ex:
+                        if self._ignore_plugin_installation_failure:
+                            ctx.logger.warning(
+                                'Failed to restore plugin: {0}, '
+                                'ignore-plugin-installation-failure flag '
+                                'used. Proceeding...'.format(plugin))
+                            ctx.logger.debug('Restore plugin failure error: '
+                                             '{0}'.format(ex))
+                            failed_plugins.append(plugin)
+                        else:
+                            raise ex
                 self._wait_for_plugin_executions(client)
+                SnapshotRestore.__remove_failed_plugins_footprints(
+                    client, failed_plugins)
             finally:
                 os.rmdir(plugins_tmp)
-        ctx.logger.info('Successfully restored plugins')
+        SnapshotRestore.__log_message_for_plugin_restore(failed_plugins)
 
     @staticmethod
     def _plugin_installable_on_current_platform(plugin):


### PR DESCRIPTION
…ore' command, will ignore any plugins failing to install during a snapshot restore operation.