### PR TITLE
CY-412 : Remove filter on build_rpms job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,10 +134,7 @@ workflows:
   build_and_test:
     jobs:
       - flake8
-      - build-rpms:
-          filters:
-                branches:
-                  only: master
+      - build-rpms
       - test_v1
       - test_clientv2_endpoints
       - test_clientv2_infrastructure


### PR DESCRIPTION
- There a connection with the build of manager install repo, so this step is needed