### PR TITLE
CY-528: Only allow strong ciphers

### DIFF
--- a/packaging/rabbitmq/files/etc/cloudify/rabbitmq/rabbitmq.config
+++ b/packaging/rabbitmq/files/etc/cloudify/rabbitmq/rabbitmq.config
@@ -6,9 +6,23 @@
            {ssl_options, [{cacertfile,"/etc/cloudify/ssl/cloudify_internal_cert.pem"},
                           {certfile,  "/etc/cloudify/ssl/cloudify_internal_cert.pem"},
                           {keyfile,   "/etc/cloudify/ssl/cloudify_internal_key.pem"},
-                          {versions, ['tlsv1.2', 'tlsv1.1']}
-                         ]}
- ]},
+                          {versions, ['tlsv1.2', 'tlsv1.1']},
+                          {ciphers, [
+                              {ecdhe_rsa,aes_256_gcm,aead,sha384},
+                              {dhe_rsa,aes_256_gcm,aead,sha384},
+                              {ecdhe_rsa,aes_128_gcm,aead,sha256},
+                              {dhe_rsa,aes_128_gcm,aead,sha256},
+                              {ecdhe_rsa,aes_256_cbc,sha384,sha384},
+                              {dhe_rsa,aes_256_cbc,sha256},
+                              {ecdhe_rsa,aes_128_cbc,sha256,sha256},
+                              {dhe_rsa,aes_128_cbc,sha256}
+                          ]},
+                          {honor_cipher_order, true},
+                          {honor_ecc_order, true}
+                         ]
+           }
+          ]
+ },
  {rabbitmq_management, [
     {load_definitions, "/etc/cloudify/rabbitmq/definitions.json"},
     {listener, [
@@ -18,8 +32,21 @@
         {ssl_opts, [{cacertfile,"/etc/cloudify/ssl/cloudify_internal_cert.pem"},
                     {certfile,  "/etc/cloudify/ssl/cloudify_internal_cert.pem"},
                     {keyfile,   "/etc/cloudify/ssl/cloudify_internal_key.pem"},
-                    {versions, ['tlsv1.2', 'tlsv1.1']}
-                   ]}
+                    {versions, ['tlsv1.2', 'tlsv1.1']},
+                    {ciphers, [
+                        {ecdhe_rsa,aes_256_gcm,aead,sha384},
+                        {dhe_rsa,aes_256_gcm,aead,sha384},
+                        {ecdhe_rsa,aes_128_gcm,aead,sha256},
+                        {dhe_rsa,aes_128_gcm,aead,sha256},
+                        {ecdhe_rsa,aes_256_cbc,sha384,sha384},
+                        {dhe_rsa,aes_256_cbc,sha256},
+                        {ecdhe_rsa,aes_128_cbc,sha256,sha256},
+                        {dhe_rsa,aes_128_cbc,sha256}
+                    ]},
+                    {honor_cipher_order, true},
+                    {honor_ecc_order, true}
+                   ]
+        }
     ]}
  ]}
 ].


### PR DESCRIPTION
Only allow strong ciphers when connecting to RabbitMQ.
This list of ciphers covers all ciphers that are ranked as "Advanced" and "Advanced+" by OWASP (see: https://www.owasp.org/index.php/TLS_Cipher_String_Cheat_Sheet)

Seems like RabbitMQ works with the auto-generated internal cert just fine.