### PR TITLE
CY-568: removed /var prefix

### DIFF
--- a/packaging/rabbitmq/files/usr/lib/systemd/system/cloudify-rabbitmq.service
+++ b/packaging/rabbitmq/files/usr/lib/systemd/system/cloudify-rabbitmq.service
@@ -12,10 +12,10 @@ EnvironmentFile=/etc/sysconfig/cloudify-rabbitmq
 ExecStartPre=-/bin/sh -c "/usr/sbin/rabbitmqctl status > /dev/null 2>&1"
 
 ExecStart=/usr/sbin/rabbitmq-server
-ExecStartPost=/usr/sbin/rabbitmqctl wait /var/run/rabbitmq/rabbitmq.pid
+ExecStartPost=/usr/sbin/rabbitmqctl wait /run/rabbitmq/rabbitmq.pid
 
-ExecStop=/usr/sbin/rabbitmqctl stop /var/run/rabbitmq/rabbitmq.pid
-ExecStopPost=-/usr/bin/rm /var/run/rabbitmq/rabbitmq.pid
+ExecStop=/usr/sbin/rabbitmqctl stop /run/rabbitmq/rabbitmq.pid
+ExecStopPost=-/usr/bin/rm /run/rabbitmq/rabbitmq.pid
 
 LimitNOFILE=102400
 


### PR DESCRIPTION
`/var/run` is deprecated, should use `/run` instead.