### PR TITLE
CY-578 Update has_intrinsic_functions flag for an operation during snapshot …

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/fix_snapshot_ssh_db.py
+++ b/workflows/cloudify_system_workflows/snapshots/fix_snapshot_ssh_db.py
@@ -122,7 +122,9 @@ def main(original_string, secret_name):
                 fabric_changed = fix_fabric_env(inputs,
                                                 original_string,
                                                 secret_name)
-                changed = changed or key_changed or fabric_changed
+                if key_changed or fabric_changed:
+                    ops[op]['has_intrinsic_functions'] = True
+                    changed = True
             props = node.properties
             new_changed = replace_ssh_keys(props,
                                            original_string,


### PR DESCRIPTION
…restore

* During snapshot restore we replace ssh keys (of agent and fabric config)
  with secrets

* The flag has_intrinsic_functions should be true because now the operation
  has the get_secret intrinsic function