### PR TITLE
amqp-postgres service: set RestartSec=2

### DIFF
--- a/packaging/amqp-postgres/files/usr/lib/systemd/system/cloudify-amqp-postgres.service
+++ b/packaging/amqp-postgres/files/usr/lib/systemd/system/cloudify-amqp-postgres.service
@@ -5,6 +5,7 @@ After=postgresql-9.5.service cloudify-rabbitmq.service
 
 [Service]
 TimeoutStartSec=0
+RestartSec=2
 Restart=on-failure
 EnvironmentFile=/etc/sysconfig/cloudify-amqp-postgres
 User=cfyuser


### PR DESCRIPTION
Without a restart delay, the service is restarted many times in a short time
if the database is down. Then, systemd's burst limiting kicks in, and it stops
restarting it.

Instead, let's wait after each restart, to give the db some time to actually start.
Then systemd will keep restarting amqp-postgres until it actually starts, and it
will never limit it, because it restarts slowly enough.