### PR TITLE
amqp-postgres: fallback to no batching in case of errors

### DIFF
--- a/amqp-postgres/amqp_postgres/postgres_publisher.py
+++ b/amqp-postgres/amqp_postgres/postgres_publisher.py
@@ -27,6 +27,8 @@ from collections import OrderedDict
 
 logger = logging.getLogger(__name__)
 
+BATCH_DELAY = 0.5
+
 EVENT_INSERT_QUERY = """
     INSERT INTO events (
         timestamp,
@@ -157,11 +159,11 @@ class DBLogEventPublisher(object):
         items = []
         while True:
             try:
-                items.append(self._batch.get(timeout=0.3))
+                items.append(self._batch.get(timeout=BATCH_DELAY / 2))
             except Queue.Empty:
                 pass
             if len(items) > 100 or \
-                    (items and (time() - self._last_commit > 0.5)):
+                    (items and (time() - self._last_commit > BATCH_DELAY)):
                 try:
                     self._store(conn, items)
                 except psycopg2.OperationalError:

--- a/amqp-postgres/amqp_postgres/postgres_publisher.py
+++ b/amqp-postgres/amqp_postgres/postgres_publisher.py
@@ -237,7 +237,7 @@ class DBLogEventPublisher(object):
         one by one, so that only the errorneous message is dropped.
         """
         for message, exchange, ack in items:
-            item = self._get_db_item(message, exchange)
+            item = self._get_db_item(conn, message, exchange)
             if item is None:
                 continue
             insert = (self._insert_events if exchange == EVENTS_EXCHANGE_NAME

--- a/amqp-postgres/amqp_postgres/postgres_publisher.py
+++ b/amqp-postgres/amqp_postgres/postgres_publisher.py
@@ -23,6 +23,7 @@ from threading import Thread, Lock
 import psycopg2
 from psycopg2.extras import execute_values, DictCursor
 from collections import OrderedDict
+from cloudify.constants import EVENTS_EXCHANGE_NAME, LOGS_EXCHANGE_NAME
 
 
 logger = logging.getLogger(__name__)
@@ -198,9 +199,9 @@ class DBLogEventPublisher(object):
             logger.warning('No execution found: %s', execution_id)
             return
 
-        if exchange == 'cloudify-events':
+        if exchange == EVENTS_EXCHANGE_NAME:
             get_item = self._get_event
-        elif exchange == 'cloudify-logs':
+        elif exchange == LOGS_EXCHANGE_NAME:
             get_item = self._get_log
         else:
             raise ValueError('Unknown exchange type: {0}'.format(exchange))
@@ -215,7 +216,7 @@ class DBLogEventPublisher(object):
             item = self._get_db_item(conn, message, exchange)
             if item is None:
                 continue
-            target = events if exchange == 'cloudify-events' else logs
+            target = events if exchange == EVENTS_EXCHANGE_NAME else logs
             target.append(item)
 
         with conn.cursor() as cur:
@@ -239,7 +240,7 @@ class DBLogEventPublisher(object):
             item = self._get_db_item(message, exchange)
             if item is None:
                 continue
-            insert = (self._insert_events if exchange == 'cloudify-events'
+            insert = (self._insert_events if exchange == EVENTS_EXCHANGE_NAME
                       else self._insert_logs)
             try:
                 with conn.cursor() as cur:

--- a/amqp-postgres/amqp_postgres/postgres_publisher.py
+++ b/amqp-postgres/amqp_postgres/postgres_publisher.py
@@ -170,6 +170,7 @@ class DBLogEventPublisher(object):
                     logger.exception('Error storing %d logs+events',
                                      len(items))
                     conn.rollback()
+                    self._store_nobatch(conn, items)
                 items = []
                 self._last_commit = time()
 
@@ -188,39 +189,77 @@ class DBLogEventPublisher(object):
             self._executions_cache[execution_id] = execution
         return self._executions_cache[execution_id]
 
+    def _get_db_item(self, conn, message, exchange):
+        execution_id = message['context']['execution_id']
+        execution = self._get_execution(conn, execution_id)
+        if execution is None:
+            logger.warning('No execution found: %s', execution_id)
+            return
+
+        if exchange == 'cloudify-events':
+            get_item = self._get_event
+        elif exchange == 'cloudify-logs':
+            get_item = self._get_log
+        else:
+            raise ValueError('Unknown exchange type: {0}'.format(exchange))
+        return get_item(message, execution)
+
     def _store(self, conn, items):
         events, logs = [], []
 
         acks = []
-        for item, exchange, ack in items:
+        for message, exchange, ack in items:
             acks.append(ack)
-            execution_id = item['context']['execution_id']
-            execution = self._get_execution(conn, execution_id)
-            if execution is None:
-                logger.warning('No execution found: %s', execution_id)
+            item = self._get_db_item(conn, message, exchange)
+            if item is None:
                 continue
-            if exchange == 'cloudify-events':
-                event = self._get_event(item, execution)
-                if event is not None:
-                    events.append(event)
-            elif exchange == 'cloudify-logs':
-                log = self._get_log(item, execution)
-                if log is not None:
-                    logs.append(log)
-            else:
-                raise ValueError('Unknown exchange type: {0}'.format(exchange))
+            target = events if exchange == 'cloudify-events' else logs
+            target.append(item)
 
         with conn.cursor() as cur:
-            if events:
-                execute_values(cur, EVENT_INSERT_QUERY, events,
-                               template=EVENT_VALUES_TEMPLATE)
-            if logs:
-                execute_values(cur, LOG_INSERT_QUERY, logs,
-                               template=LOG_VALUES_TEMPLATE)
+            execute_values(cur, EVENT_INSERT_QUERY, events,
+                           template=EVENT_VALUES_TEMPLATE)
+            execute_values(cur, LOG_INSERT_QUERY, logs,
+                           template=LOG_VALUES_TEMPLATE)
         logger.debug('commit %s', len(logs) + len(events))
         conn.commit()
         for ack in acks:
             self._amqp_connection.acks_queue.put(ack)
+
+    def _store_nobatch(self, conn, items):
+        """Store the items one by one, without batching.
+
+        This is to be used in the anomalous cases where inserting the whole
+        batch throws an IntegrityError - we fall back to inserting the items
+        one by one, so that only the errorneous message is dropped.
+        """
+        for message, exchange, ack in items:
+            item = self._get_db_item(message, exchange)
+            if item is None:
+                continue
+            insert = (self._insert_events if exchange == 'cloudify-events'
+                      else self._insert_logs)
+            try:
+                with conn.cursor() as cur:
+                    insert(cur, [item])
+                conn.commit()
+            except psycopg2.OperationalError:
+                self.on_db_connection_error()
+            except psycopg2.IntegrityError:
+                logger.debug('Error storing %s: %s', exchange, item)
+                conn.rollback()
+
+    def _insert_events(self, cursor, events):
+        if not events:
+            return
+        execute_values(cursor, EVENT_INSERT_QUERY, events,
+                       template=EVENT_VALUES_TEMPLATE)
+
+    def _insert_logs(self, cursor, logs):
+        if not logs:
+            return
+        execute_values(cursor, LOG_INSERT_QUERY, logs,
+                       template=LOG_VALUES_TEMPLATE)
 
     def on_db_connection_error(self):
         logger.critical('Database down - cannot continue')

--- a/amqp-postgres/amqp_postgres/tests/test_amqp_postgres.py
+++ b/amqp-postgres/amqp_postgres/tests/test_amqp_postgres.py
@@ -30,6 +30,9 @@ from manager_rest.storage.models_states import VisibilityState
 
 from amqp_postgres.main import _create_amqp_client
 
+LOG_MESSAGE = 'log'
+EVENT_MESSAGE = 'event'
+
 
 class TestAMQPPostgres(BaseServerTestCase):
 
@@ -76,8 +79,8 @@ class TestAMQPPostgres(BaseServerTestCase):
 
         events_publisher = create_events_publisher()
 
-        events_publisher.publish_message(log, message_type='log')
-        events_publisher.publish_message(event, message_type='event')
+        events_publisher.publish_message(log, message_type=LOG_MESSAGE)
+        events_publisher.publish_message(event, message_type=EVENT_MESSAGE)
 
         # The messages are dumped to the DB every 0.5 seconds, so we should
         # wait before trying to query SQL
@@ -99,7 +102,7 @@ class TestAMQPPostgres(BaseServerTestCase):
 
         # insert a log for execution 1 so that the execution gets cached
         log = self._get_log(execution_id)
-        events_publisher.publish_message(log, message_type='log')
+        events_publisher.publish_message(log, message_type=LOG_MESSAGE)
         sleep(2)
         db_log = self._get_db_element(models.Log)
         self._assert_log(log, db_log)
@@ -110,8 +113,8 @@ class TestAMQPPostgres(BaseServerTestCase):
         self._delete_execution(execution_id)
         log = self._get_log(execution_id)
         log_2 = self._get_log(execution_id_2)
-        events_publisher.publish_message(log, message_type='log')
-        events_publisher.publish_message(log_2, message_type='log')
+        events_publisher.publish_message(log, message_type=LOG_MESSAGE)
+        events_publisher.publish_message(log_2, message_type=LOG_MESSAGE)
         sleep(2)
 
         execution_1_logs = self.sm.list(

--- a/amqp-postgres/amqp_postgres/tests/test_amqp_postgres.py
+++ b/amqp-postgres/amqp_postgres/tests/test_amqp_postgres.py
@@ -20,6 +20,7 @@ from dateutil import parser as date_parser
 
 from cloudify.amqp_client import create_events_publisher
 
+from manager_rest.server import db
 from manager_rest.storage import models
 from manager_rest.config import instance
 from manager_rest.amqp_manager import AMQPManager
@@ -36,8 +37,6 @@ EVENT_MESSAGE = 'event'
 
 
 class TestAMQPPostgres(BaseServerTestCase):
-    sql_dialect = 'postgresql'
-
     def create_configuration(self):
         """
         Override here to allow using postgresql instead of sqlite
@@ -48,6 +47,14 @@ class TestAMQPPostgres(BaseServerTestCase):
         config.postgresql_username = 'cloudify'
         config.postgresql_password = 'cloudify'
         return config
+
+    def _create_config_and_reset_app(self, server):
+        """
+        Override here to allow using postgresql instead of sqlite
+        """
+        super(TestAMQPPostgres, self)._create_config_and_reset_app(server)
+        server.SQL_DIALECT = 'postgresql'
+        server.reset_app(self.server_configuration)
 
     def setUp(self):
         super(TestAMQPPostgres, self).setUp()
@@ -64,6 +71,11 @@ class TestAMQPPostgres(BaseServerTestCase):
         amqp_client.consume_in_thread()
         self.addCleanup(amqp_client.close)
         self.events_publisher = create_events_publisher()
+        self.addCleanup(self._cleanup_db)
+
+    def _cleanup_db(self):
+        db.session.remove()
+        db.drop_all()
 
     def publish_messages(self, messages):
         for message, message_type in messages:
@@ -114,16 +126,13 @@ class TestAMQPPostgres(BaseServerTestCase):
         log = self._get_log(execution_id)
         log_2 = self._get_log(execution_id_2)
         self.publish_messages([
-            (log, LOG_MESSAGE)
+            (log, LOG_MESSAGE),
             (log_2, LOG_MESSAGE)
         ])
 
-        execution_1_logs = self.sm.list(
-            models.Log, filters={'execution_id': execution_id})
         execution_2_logs = self.sm.list(
             models.Log, filters={'execution_id': execution_id_2})
 
-        self.assertEqual(len(execution_1_logs), 1)
         self.assertEqual(len(execution_2_logs), 1)
 
         self._assert_log(log_2, execution_2_logs[0])

--- a/amqp-postgres/amqp_postgres/tests/test_amqp_postgres.py
+++ b/amqp-postgres/amqp_postgres/tests/test_amqp_postgres.py
@@ -82,8 +82,8 @@ class TestAMQPPostgres(BaseServerTestCase):
             self.events_publisher.publish_message(
                 message, message_type=message_type)
 
-        # The messages are dumped to the DB every 0.5 seconds, so we should
-        # wait before trying to query SQL
+        # The messages are dumped to the DB every BATCH_DELAY seconds, so
+        # we should wait before trying to query SQL
         sleep(BATCH_DELAY * 2)
 
     def test_insert(self):

--- a/amqp-postgres/amqp_postgres/tests/test_amqp_postgres.py
+++ b/amqp-postgres/amqp_postgres/tests/test_amqp_postgres.py
@@ -36,6 +36,7 @@ EVENT_MESSAGE = 'event'
 
 
 class TestAMQPPostgres(BaseServerTestCase):
+    sql_dialect = 'postgresql'
 
     def create_configuration(self):
         """
@@ -47,14 +48,6 @@ class TestAMQPPostgres(BaseServerTestCase):
         config.postgresql_username = 'cloudify'
         config.postgresql_password = 'cloudify'
         return config
-
-    def _create_config_and_reset_app(self, server):
-        """
-        Override here to allow using postgresql instead of sqlite
-        """
-        super(TestAMQPPostgres, self)._create_config_and_reset_app(server)
-        server.SQL_DIALECT = 'postgresql'
-        server.reset_app(self.server_configuration)
 
     def setUp(self):
         super(TestAMQPPostgres, self).setUp()

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -96,8 +96,6 @@ class TestClient(FlaskClient):
 
 @attr(client_min_version=1, client_max_version=LATEST_API_VERSION)
 class BaseServerTestCase(unittest.TestCase):
-    sql_dialect = 'sqlite'
-
     def create_client_with_tenant(self,
                                   username,
                                   password,
@@ -231,7 +229,7 @@ class BaseServerTestCase(unittest.TestCase):
         """
         self.server_configuration = self.create_configuration()
         utils.copy_resources(self.server_configuration.file_server_root)
-        server.SQL_DIALECT = self.sql_dialect
+        server.SQL_DIALECT = 'sqlite'
         server.reset_app(self.server_configuration)
 
     def _handle_flask_app_and_db(self, server):

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -96,9 +96,7 @@ class TestClient(FlaskClient):
 
 @attr(client_min_version=1, client_max_version=LATEST_API_VERSION)
 class BaseServerTestCase(unittest.TestCase):
-
-    def __init__(self, *args, **kwargs):
-        super(BaseServerTestCase, self).__init__(*args, **kwargs)
+    sql_dialect = 'sqlite'
 
     def create_client_with_tenant(self,
                                   username,
@@ -179,7 +177,7 @@ class BaseServerTestCase(unittest.TestCase):
             patch('manager_rest.amqp_manager.RabbitMQClient'),
             patch('manager_rest.workflow_executor._execute_task',
                   mock_execute_task),
-            ]
+        ]
         for amqp_patch in amqp_patches:
             self.addCleanup(amqp_patch.stop)
             amqp_patch.start()
@@ -233,7 +231,7 @@ class BaseServerTestCase(unittest.TestCase):
         """
         self.server_configuration = self.create_configuration()
         utils.copy_resources(self.server_configuration.file_server_root)
-        server.SQL_DIALECT = 'sqlite'
+        server.SQL_DIALECT = self.sql_dialect
         server.reset_app(self.server_configuration)
 
     def _handle_flask_app_and_db(self, server):


### PR DESCRIPTION
The batch `INSERT` can fail in case the execution was already deleted.
If this happens, the whole batch of logs/events used to be discarded.

This change makes it so that in that case, the batch is not discarded
anymore, but we retry inserting it - one event/log at a time, no batching
in this fallback case.

This case makes inserts slower in case of errors, but keeps them fast in
the common no-error case.