### PR TITLE
CY-471 : Updating pycopg2

### DIFF
--- a/workflows/dev-requirements.txt
+++ b/workflows/dev-requirements.txt
@@ -1,2 +1,1 @@
 https://github.com/cloudify-cosmo/cloudify-common/archive/master.zip
-psycopg2==2.7 --no-binary psycopg2

--- a/workflows/setup.py
+++ b/workflows/setup.py
@@ -31,7 +31,7 @@ setup(
         'cloudify-common==4.5.dev1',
         'elasticsearch==1.6.0',
         'retrying==1.3.3',
-        'psycopg2==2.7',
+        'psycopg2==2.7.4',
         'cryptography==2.1.4',
     ]
 )


### PR DESCRIPTION
this solves the binary conflict that caused the build to fail, which was in that version