### PR TITLE
amqp_postgres: pass errors to the main thread

### DIFF
--- a/amqp-postgres/amqp_postgres/main.py
+++ b/amqp-postgres/amqp_postgres/main.py
@@ -32,7 +32,7 @@ DEFAULT_LOG_PATH = '/var/log/cloudify/amqp-postgres/amqp_postgres.log'
 CONFIG_PATH = '/opt/manager/cloudify-rest.conf'
 
 
-def _create_amqp_client(config):
+def _create_connections(config):
     acks_queue = Queue.Queue()
     port = BROKER_PORT_SSL if config['amqp_ca_path'] else BROKER_PORT_NO_SSL
     amqp_client = get_client(
@@ -53,7 +53,7 @@ def _create_amqp_client(config):
 
     amqp_client.add_handler(amqp_consumer)
     db_publisher.start()
-    return amqp_client
+    return amqp_client, db_publisher
 
 
 def main(args):
@@ -62,7 +62,7 @@ def main(args):
         filename=args.get('logfile', DEFAULT_LOG_PATH))
     with open(args['config']) as f:
         config = yaml.safe_load(f)
-    amqp_client = _create_amqp_client(config)
+    amqp_client, db_publisher = _create_connections(config)
 
     logger.info('Starting consuming...')
     amqp_client.consume()

--- a/amqp-postgres/amqp_postgres/main.py
+++ b/amqp-postgres/amqp_postgres/main.py
@@ -66,6 +66,8 @@ def main(args):
 
     logger.info('Starting consuming...')
     amqp_client.consume()
+    if db_publisher.error_exit:
+        raise db_publisher.error_exit
 
 
 def cli():

--- a/amqp-postgres/amqp_postgres/tests/test_amqp_postgres.py
+++ b/amqp-postgres/amqp_postgres/tests/test_amqp_postgres.py
@@ -29,7 +29,7 @@ from manager_rest.test.base_test import BaseServerTestCase
 from manager_rest.storage.models_states import VisibilityState
 
 
-from amqp_postgres.main import _create_amqp_client
+from amqp_postgres.main import _create_connections
 from amqp_postgres.postgres_publisher import BATCH_DELAY
 
 LOG_MESSAGE = 'log'
@@ -66,7 +66,7 @@ class TestAMQPPostgres(BaseServerTestCase):
             'amqp_{0}'.format(n)
             for n in ['host', 'username', 'password', 'ca_path']
         ]
-        amqp_client = _create_amqp_client(
+        amqp_client, _ = _create_connections(
             {k: getattr(config, k) for k in config_keys})
         amqp_client.consume_in_thread()
         self.addCleanup(amqp_client.close)


### PR DESCRIPTION
Currently an error thrown in the db thread won't cause the whole
application to exit with code 1 (and be restarted by systemd).

Let's pass the error to the main thread and raise it there.