### PR TITLE
Use the tenant response with credentials only for the GET endpoint

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3/tenants.py
+++ b/rest-service/manager_rest/rest/resources_v3/tenants.py
@@ -23,7 +23,7 @@ from manager_rest.security import (MissingPremiumFeatureResource,
                                    SecuredResource)
 
 from .. import rest_decorators, rest_utils
-from ..responses_v3 import TenantResponse
+from ..responses_v3 import TenantResponse, TenantDetailsResponse
 
 try:
     from cloudify_premium import SecuredMultiTenancyResource
@@ -76,7 +76,7 @@ class Tenants(TenantsListResource):
 class TenantsId(SecuredMultiTenancyResource):
     @rest_decorators.exceptions_handled
     @authorize('tenant_create')
-    @rest_decorators.marshal_with(TenantResponse)
+    @rest_decorators.marshal_with(TenantDetailsResponse)
     def post(self, tenant_name, multi_tenancy):
         """
         Create a tenant
@@ -93,7 +93,7 @@ class TenantsId(SecuredMultiTenancyResource):
 
     @rest_decorators.exceptions_handled
     @authorize('tenant_get', get_tenant_from='param')
-    @rest_decorators.marshal_with(TenantResponse)
+    @rest_decorators.marshal_with(TenantDetailsResponse)
     def get(self, tenant_name, multi_tenancy):
         """
         Get details for a single tenant
@@ -103,7 +103,7 @@ class TenantsId(SecuredMultiTenancyResource):
 
     @rest_decorators.exceptions_handled
     @authorize('tenant_delete')
-    @rest_decorators.marshal_with(TenantResponse)
+    @rest_decorators.marshal_with(TenantDetailsResponse)
     def delete(self, tenant_name, multi_tenancy):
         """
         Delete a tenant

--- a/rest-service/manager_rest/rest/responses_v3.py
+++ b/rest-service/manager_rest/rest/responses_v3.py
@@ -70,6 +70,17 @@ class TenantResponse(BaseResponse):
         'name': fields.String,
         'groups': fields.Raw,
         'users': fields.Raw,
+        'user_roles': fields.Raw
+    }
+
+
+@swagger.model
+class TenantDetailsResponse(BaseResponse):
+
+    resource_fields = {
+        'name': fields.String,
+        'groups': fields.Raw,
+        'users': fields.Raw,
         'user_roles': fields.Raw,
         'rabbitmq_username': fields.String,
         'rabbitmq_password': fields.String,


### PR DESCRIPTION
So that listing tenants doesnt show the (encrypted) credentials