### PR TITLE
Add tracing framework

### DIFF
--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -65,6 +65,8 @@ class Config(object):
         self.account_lock_period = -1
 
         self.warnings = []
+        self.enable_tracing = False
+        self.jaeger_server_ip = None
 
     def load_configuration(self):
         for env_var_name, namespace in [

--- a/rest-service/manager_rest/rest/rest_decorators.py
+++ b/rest-service/manager_rest/rest/rest_decorators.py
@@ -91,6 +91,7 @@ def insecure_rest_method(func):
 
 def exceptions_handled(func):
     @wraps(func)
+    @utils.with_tracing('exceptions_handled')
     def wrapper(*args, **kwargs):
         try:
             try:
@@ -123,6 +124,8 @@ class marshal_with(object):
 
     def __call__(self, f):
         @wraps(f)
+        @utils.with_tracing('marshal_with {}'.format(
+            self.response_class.__name__))
         def wrapper(*args, **kwargs):
             if hasattr(request, '__skip_marshalling'):
                 return f(*args, **kwargs)

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -20,6 +20,7 @@ import subprocess
 from string import ascii_letters
 from contextlib import contextmanager
 
+
 from flask import current_app
 from flask import request, make_response
 from flask_restful.reqparse import Argument

--- a/rest-service/manager_rest/security/authorization.py
+++ b/rest-service/manager_rest/security/authorization.py
@@ -19,6 +19,7 @@ def authorize(action,
               allow_all_tenants=False):
     def authorize_dec(func):
         @wraps(func)
+        @utils.with_tracing('authorize')
         def wrapper(*args, **kwargs):
 
             # getting the tenant name

--- a/rest-service/manager_rest/security/secured_resource.py
+++ b/rest-service/manager_rest/security/secured_resource.py
@@ -18,7 +18,7 @@ from functools import wraps
 from flask_restful import Resource
 from flask import request, current_app, Response, jsonify
 
-from manager_rest.utils import abort_error
+from manager_rest.utils import abort_error, with_tracing
 from manager_rest.manager_exceptions import MissingPremiumPackage
 
 from .authentication import authenticator
@@ -26,6 +26,7 @@ from .authentication import authenticator
 
 def authenticate(func):
     @wraps(func)
+    @with_tracing('authenticate')
     def wrapper(*args, **kwargs):
         auth_response = authenticator.authenticate(request)
         if isinstance(auth_response, Response):

--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -19,9 +19,13 @@ import traceback
 import os
 import yaml
 
+import opentracing
 from flask_restful import Api
-from flask import Flask, jsonify, Blueprint
+from jaeger_client import Config
 from flask_security import Security
+from flask import Flask, jsonify, Blueprint
+from flask import _request_ctx_stack as stack
+from opentracing_instrumentation.request_context import span_in_context
 
 from manager_rest import config, premium_enabled
 from manager_rest.storage import db, user_datastore
@@ -88,6 +92,29 @@ class CloudifyFlaskApp(Flask):
         setup_resources(Api(self))
         self.register_blueprint(app_errors)
 
+        self.tracer = None
+        if config.instance.enable_tracing:
+            self.before_first_request(self._init_jeager_tracer)
+
+    def _init_jeager_tracer(self):
+        """Initializes the Jaeger tracer.
+        """
+        if not config.instance.jaeger_server_ip:
+            self.logger.error('Tracing has been enabled but the Jaeger API '
+                              'server IP has not been set.')
+            return
+        tracer_config = Config(
+            config={
+                'sampler': {'type': 'const', 'param': 1},
+                'local_agent': {'reporting_host':
+                                    config.instance.jaeger_server_ip},
+                'logging': True
+            },
+            service_name='cloudify-manager')
+        self.logger.debug("Initializing Jaeger tracer...")
+        self.tracer = tracer_config.initialize_tracer()
+        self.logger.debug("Done initializing Jaeger tracer.")
+
     def _set_flask_security(self):
         """Set Flask-Security specific configurations and init the extension
         """
@@ -148,6 +175,31 @@ class CloudifyFlaskApp(Flask):
             flask_handle_user_exception,
             flask_restful_handle_user_exception)
         self.config['ERROR_404_HELP'] = False
+
+    def dispatch_request(self):
+        """Wraps up the super 'dispatch_request' func to enable easier tracing.
+        """
+        if not self.tracer:
+            return super(CloudifyFlaskApp, self).dispatch_request()
+
+        request = stack.top.request
+        operation_name = '{} ({})'.format(str(request.endpoint),
+                                          str(request.method))
+        headers = {}
+        for k, v in request.headers:
+            headers[k.lower()] = v
+        kw = {'operation_name': operation_name}
+        span_ctx = None
+        try:
+            span_ctx = self.tracer.extract(
+                opentracing.Format.HTTP_HEADERS, headers)
+            kw['child_of'] = span_ctx
+        except opentracing.UnsupportedFormatException as e:
+            kw['tags'] = {"Extract failed": str(e)}
+
+        with self.tracer.start_span(**kw) as span:
+            with span_in_context(span):
+                return super(CloudifyFlaskApp, self).dispatch_request()
 
 
 def reset_app(configuration=None):

--- a/rest-service/manager_rest/storage/models_base.py
+++ b/rest-service/manager_rest/storage/models_base.py
@@ -25,7 +25,7 @@ from sqlalchemy.ext.associationproxy import ASSOCIATION_PROXY
 from sqlalchemy.ext.hybrid import HYBRID_PROPERTY
 from sqlalchemy.orm.interfaces import NOT_EXTENSION
 
-from manager_rest.utils import classproperty
+from manager_rest.utils import classproperty, with_tracing
 
 
 db = SQLAlchemy(metadata=MetaData(naming_convention={

--- a/rest-service/manager_rest/systemddbus.py
+++ b/rest-service/manager_rest/systemddbus.py
@@ -1,4 +1,5 @@
 import dbus
+from manager_rest.utils import with_tracing
 
 SYSTEMD_BUS = 'org.freedesktop.systemd1'
 SYSTEMD_PATH = '/org/freedesktop/systemd1'
@@ -12,12 +13,13 @@ UNIT_PROPERTIES = ['Id', 'Description', 'LoadState', 'ActiveState',
 
 
 class DBusClient(object):
-
+    @with_tracing()
     def __init__(self):
         self.bus = dbus.SystemBus()
         self.proxy = self.bus.get_object(SYSTEMD_BUS, SYSTEMD_PATH)
         self.interface = dbus.Interface(self.proxy, MANAGER_IFACE)
 
+    @with_tracing()
     def get_properties(self, name, prop_names, property_interface):
         objpath = self.interface.GetUnit(name)
         proxy = self.bus.get_object(SYSTEMD_BUS, objpath)
@@ -33,17 +35,19 @@ class DBusClient(object):
             properties = tmp_properties
         return properties
 
+    @with_tracing()
     def get_unit_properties(self, unit_name, property_names=None):
         if property_names is None:
             property_names = UNIT_PROPERTIES
         return self.get_properties(unit_name, property_names, UNIT_IFACE)
 
+    @with_tracing()
     def get_service_properties(self, unit_name, property_names=None):
         if property_names is None:
             property_names = SVC_PROPERTIES
         return self.get_properties(unit_name, property_names, SVC_IFACE)
 
-
+@with_tracing()
 def get_services(units):
     out = []
     client = DBusClient()

--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -38,7 +38,9 @@ install_requires = [
     'cryptography==2.1.4',
     'psycopg2==2.7.4',
     'pytz==2018.4',
-    'click==6.7'
+    'click==6.7',
+    'opentracing-instrumentation==2.4.3',
+    'jaeger-client==3.11.0'
 ]
 
 


### PR DESCRIPTION
The following features work whenever `enable_tracing` is set to `true` and
`jaeger_server_ip` is also set with the corresponding Jaeger API Server
IP.
- Adds automatic tracing to thread context whenever an API call is made
- Adds a decorator for tracing, it starts a new span before the function
is called.