### PR TITLE
Jaeger tracing - Add tracing framework and samples

### DIFF
--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -16,7 +16,7 @@
 import os
 import yaml
 
-import jaeger_client as j_client
+import jaeger_client
 from json import dump
 
 
@@ -101,11 +101,9 @@ class Config(object):
                     "'{1}'".format(key, filename))
 
     def _create_tracer_config(self):
-        """Creates the tracer config.
-        """
         if not self.enable_tracing or not self.tracing_endpoint_ip:
             return
-        self.tracer_config = j_client.Config(
+        self.tracer_config = jaeger_client.Config(
             config={
                 'sampler': {'type': 'const', 'param': 1},
                 'local_agent': {

--- a/rest-service/manager_rest/rest/rest_decorators.py
+++ b/rest-service/manager_rest/rest/rest_decorators.py
@@ -40,6 +40,7 @@ from voluptuous import (
     Schema,
 )
 from ..security.authentication import authenticator
+from manager_rest.utils import traces
 from manager_rest import utils, config, manager_exceptions
 from manager_rest.storage.models_base import SQLModelBase
 from manager_rest.rest.rest_utils import (verify_and_convert_bool,
@@ -91,6 +92,7 @@ def insecure_rest_method(func):
 
 def exceptions_handled(func):
     @wraps(func)
+    @traces('exceptions_handled')
     def wrapper(*args, **kwargs):
         try:
             try:
@@ -123,6 +125,7 @@ class marshal_with(object):
 
     def __call__(self, f):
         @wraps(f)
+        @traces('marshal_with {}'.format(self.response_class.__name__))
         def wrapper(*args, **kwargs):
             if hasattr(request, '__skip_marshalling'):
                 return f(*args, **kwargs)

--- a/rest-service/manager_rest/security/authorization.py
+++ b/rest-service/manager_rest/security/authorization.py
@@ -4,6 +4,7 @@ from functools import wraps
 from flask import request
 from flask_security import current_user
 
+from manager_rest.utils import traces
 from manager_rest import config, utils
 from manager_rest.storage.models import Tenant
 from manager_rest.storage import get_storage_manager
@@ -19,6 +20,7 @@ def authorize(action,
               allow_all_tenants=False):
     def authorize_dec(func):
         @wraps(func)
+        @traces('authorize')
         def wrapper(*args, **kwargs):
 
             # getting the tenant name

--- a/rest-service/manager_rest/security/secured_resource.py
+++ b/rest-service/manager_rest/security/secured_resource.py
@@ -19,7 +19,7 @@ from flask_restful import Resource
 from flask_restful.utils import unpack
 from flask import request, current_app, Response, jsonify
 
-from manager_rest.utils import abort_error
+from manager_rest.utils import abort_error, traces
 from manager_rest.manager_exceptions import MissingPremiumPackage
 
 from .authentication import authenticator
@@ -37,6 +37,7 @@ def authenticate(func):
         return data, code, headers
 
     @wraps(func)
+    @traces('authenticate')
     def wrapper(*args, **kwargs):
         auth_response = authenticator.authenticate(request)
         if isinstance(auth_response, Response):

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -15,17 +15,21 @@
 
 import psutil
 from collections import OrderedDict
+from sqlalchemy.event import listen
+from sqlalchemy.engine import Engine
 from flask_security import current_user
 from sqlalchemy import or_ as sql_or, func
 from sqlalchemy.exc import SQLAlchemyError
 from flask import current_app, has_request_context
 from sqlite3 import DatabaseError as SQLiteDBError
 from sqlalchemy.orm.attributes import flag_modified
+from opentracing_instrumentation.request_context import get_current_span
 
 from manager_rest.storage.models_base import db
 from manager_rest import manager_exceptions, config, utils
 from manager_rest.storage.models_states import VisibilityState
-from manager_rest.utils import all_tenants_authorization, is_administrator
+from manager_rest.utils import all_tenants_authorization, is_administrator, \
+    traces
 
 try:
     from psycopg2 import DatabaseError as Psycopg2DBError
@@ -36,7 +40,12 @@ except ImportError:
 
 
 class SQLStorageManager(object):
+    @traces()
+    def __init__(self):
+        self._enable_sql_engine_tracing()
+
     @staticmethod
+    @traces()
     def _safe_commit():
         """Try to commit changes in the session. Roll back if exception raised
         Excepts SQLAlchemy errors and rollbacks if they're caught
@@ -49,6 +58,7 @@ class SQLStorageManager(object):
                 'SQL Storage error: {0}'.format(str(e))
             )
 
+    @traces()
     def _get_base_query(self, model_class, include, joins):
         """Create the initial query from the model class and included columns
 
@@ -70,6 +80,7 @@ class SQLStorageManager(object):
         return query
 
     @staticmethod
+    @traces()
     def _sort_query(query, sort=None):
         """Add sorting clauses to the query
 
@@ -85,6 +96,7 @@ class SQLStorageManager(object):
                 query = query.order_by(column)
         return query
 
+    @traces()
     def _filter_query(self,
                       query,
                       model_class,
@@ -105,6 +117,7 @@ class SQLStorageManager(object):
         query = self._add_substr_filter(query, substr_filters)
         return query
 
+    @traces()
     def _add_value_filter(self, query, filters):
         for column, value in filters.iteritems():
             column, value = self._update_case_insensitive(column, value)
@@ -114,6 +127,7 @@ class SQLStorageManager(object):
                 query = query.filter(column == value)
         return query
 
+    @traces()
     def _add_substr_filter(self, query, filters):
         for column, value in filters.iteritems():
             column, value = self._update_case_insensitive(column, value, True)
@@ -126,6 +140,7 @@ class SQLStorageManager(object):
         return query
 
     @staticmethod
+    @traces()
     def _update_case_insensitive(column, value, force=False):
         """Check if the column in question should be case insensitive, and
         if so, make sure the column (and the value) will be converted to lower
@@ -154,6 +169,7 @@ class SQLStorageManager(object):
 
         return column, value
 
+    @traces()
     def _add_tenant_filter(self, query, model_class, all_tenants):
         """Filter by the tenant ID associated with `model_class` (either
         directly via a relationship with the tenants table, or via an
@@ -192,6 +208,7 @@ class SQLStorageManager(object):
         )
         return query.filter(tenant_filter)
 
+    @traces()
     def _add_permissions_filter(self, query, model_class):
         """Filter by the users present in either the `viewers` or `owners`
         lists
@@ -219,6 +236,7 @@ class SQLStorageManager(object):
         return query.filter(user_filter)
 
     @staticmethod
+    @traces()
     def _get_joins(model_class, columns):
         """Get a list of all the attributes on which we need to join
 
@@ -240,6 +258,7 @@ class SQLStorageManager(object):
                 column = column.remote_attr
         return joins.values()
 
+    @traces()
     def _get_joins_and_converted_columns(self,
                                          model_class,
                                          include,
@@ -263,6 +282,7 @@ class SQLStorageManager(object):
                 model_class, include, filters, substr_filters, sort)
         return include, filters, substr_filters, sort, joins
 
+    @traces()
     def _get_query(self,
                    model_class,
                    include=None,
@@ -292,6 +312,7 @@ class SQLStorageManager(object):
         query = self._sort_query(query, sort)
         return query
 
+    @traces()
     def _get_columns_from_field_names(self,
                                       model_class,
                                       include,
@@ -312,6 +333,7 @@ class SQLStorageManager(object):
         return include, filters, substr_filters, sort
 
     @staticmethod
+    @traces()
     def _get_column(model_class, column_name):
         """Return the column on which an action (filtering, sorting, etc.)
         would need to be performed. Can be either an attribute of the class,
@@ -329,6 +351,7 @@ class SQLStorageManager(object):
             return column.remote_attr.label(column_name)
 
     @staticmethod
+    @traces()
     def _paginate(query, pagination, get_all_results=False):
         """Paginate the query by size and offset
 
@@ -356,6 +379,7 @@ class SQLStorageManager(object):
             return results, len(results), 0, 0
 
     @staticmethod
+    @traces()
     def _validate_pagination(pagination_size):
         if pagination_size < 0:
             raise manager_exceptions.IllegalActionError(
@@ -373,6 +397,7 @@ class SQLStorageManager(object):
             )
 
     @staticmethod
+    @traces()
     def _validate_returned_size(size):
         if size > config.instance.max_results:
             raise manager_exceptions.IllegalActionError(
@@ -383,6 +408,7 @@ class SQLStorageManager(object):
                 )
             )
 
+    @traces()
     def _validate_unique_resource_id_per_tenant(self, instance):
         """Assert that only a single resource exists with a given id in a
         given tenant
@@ -410,6 +436,7 @@ class SQLStorageManager(object):
                 )
             )
 
+    @traces()
     def _get_unique_resource_id_query(self, model_class, resource_id):
         """
         Query for all the resources with the same id of the given instance,
@@ -425,6 +452,7 @@ class SQLStorageManager(object):
         query = query.filter(unique_resource_filter)
         return query
 
+    @traces()
     def _associate_users_and_tenants(self, instance):
         """Associate, if necessary, the instance with the current tenant/user
         """
@@ -435,6 +463,7 @@ class SQLStorageManager(object):
                 instance.creator = current_user
 
     @staticmethod
+    @traces()
     def _load_relationships(instance):
         """A helper method used to overcome a problem where the relationships
         that rely on joins aren't being loaded automatically
@@ -444,6 +473,7 @@ class SQLStorageManager(object):
                 getattr(instance, rel.key)
 
     @property
+    @traces()
     def current_tenant(self):
         """Return the tenant with which the user accessed the app
         """
@@ -452,6 +482,7 @@ class SQLStorageManager(object):
         except manager_exceptions.TenantNotProvided:
             return None
 
+    @traces()
     def get(self,
             model_class,
             element_id,
@@ -478,6 +509,7 @@ class SQLStorageManager(object):
         return result
 
     @staticmethod
+    @traces()
     def _validate_available_memory():
         """Validate minimal available memory in manager
         """
@@ -492,6 +524,7 @@ class SQLStorageManager(object):
                 'needed: {0}mb, available: {1}mb'
                 ''.format(min_available_memory_mb, available_mb))
 
+    @traces()
     def list(self,
              model_class,
              include=None,
@@ -543,6 +576,7 @@ class SQLStorageManager(object):
         current_app.logger.debug('Returning: {0}'.format(results))
         return ListResult(items=results, metadata={'pagination': pagination})
 
+    @traces()
     def count(self, model_class, filters=None):
         query = model_class.query
         if filters:
@@ -550,6 +584,7 @@ class SQLStorageManager(object):
         count = query.order_by(None).count()  # Fastest way to count
         return count
 
+    @traces()
     def put(self, instance):
         """Create a `model_class` instance from a serializable `model` object
 
@@ -564,6 +599,7 @@ class SQLStorageManager(object):
         self._validate_unique_resource_id_per_tenant(instance)
         return instance
 
+    @traces()
     def delete(self, instance):
         """Delete the passed instance
         """
@@ -573,6 +609,7 @@ class SQLStorageManager(object):
         self._safe_commit()
         return instance
 
+    @traces()
     def update(self, instance, log=True, modified_attrs=()):
         """Add `instance` to the DB session, and attempt to commit
 
@@ -594,6 +631,7 @@ class SQLStorageManager(object):
         self._safe_commit()
         return instance
 
+    @traces()
     def refresh(self, instance):
         """Reload the instance with fresh information from the DB
 
@@ -605,7 +643,14 @@ class SQLStorageManager(object):
         self._load_relationships(instance)
         return instance
 
+    @traces()
+    def _enable_sql_engine_tracing(self):
+        """Enable tracing for all SQLAlchemy engines.
+        """
+        enable_tracing_for_all_engines()
 
+
+@traces()
 def get_storage_manager():
     """Get the current Flask app's storage manager, create if necessary
     """
@@ -629,3 +674,59 @@ class ListResult(object):
 
     def __getitem__(self, item):
         return self.items[item]
+
+
+def enable_tracing_for_all_engines():
+    listen(Engine, 'before_cursor_execute', _engine_before_cursor_handler)
+    listen(Engine, 'after_cursor_execute', _engine_after_cursor_handler)
+    listen(Engine, 'handle_error', _engine_error_handler)
+
+
+def _engine_before_cursor_handler(conn, cursor, statement, parameters, context,
+                                  executemany):
+    current_span = get_current_span()
+    if not current_span:
+        return
+
+    stmt_obj = context.compiled.statement if context.compiled else None
+
+    # Start a new span for this query.
+    name = _get_operation_name(stmt_obj)
+    span = current_app.tracer.start_span(
+        operation_name=name, child_of=current_span)
+    span.set_tag('component', 'sqlalchemy')
+    span.set_tag('db.type', 'sql')
+    span.set_tag('db.statement', statement)
+    span.set_tag('sqlalchemy.dialect', context.dialect.name)
+
+    context._span = span
+
+
+def _engine_after_cursor_handler(conn, cursor, statement, parameters, context,
+                                 executemany):
+    span = getattr(context, '_span', None)
+    if span is None:
+        return
+
+    span.finish()
+
+
+def _engine_error_handler(exception_context):
+    execution_context = exception_context.execution_context
+    span = getattr(execution_context, '_span', None)
+    if span is None:
+        return
+
+    exc = exception_context.original_exception
+    span.set_tag('sqlalchemy.exception', str(exc))
+    span.set_tag('error', True)
+    span.finish()
+
+
+def _get_operation_name(stmt_obj):
+    if stmt_obj is None:
+        # Match what the ORM shows when raw SQL
+        # statements are invoked.
+        return 'textclause'
+
+    return stmt_obj.__visit_name__

--- a/rest-service/manager_rest/systemddbus.py
+++ b/rest-service/manager_rest/systemddbus.py
@@ -1,5 +1,7 @@
 import dbus
 
+from manager_rest.utils import traces
+
 SYSTEMD_BUS = 'org.freedesktop.systemd1'
 SYSTEMD_PATH = '/org/freedesktop/systemd1'
 MANAGER_IFACE = 'org.freedesktop.systemd1.Manager'
@@ -12,12 +14,13 @@ UNIT_PROPERTIES = ['Id', 'Description', 'LoadState', 'ActiveState',
 
 
 class DBusClient(object):
-
+    @traces()
     def __init__(self):
         self.bus = dbus.SystemBus()
         self.proxy = self.bus.get_object(SYSTEMD_BUS, SYSTEMD_PATH)
         self.interface = dbus.Interface(self.proxy, MANAGER_IFACE)
 
+    @traces()
     def get_properties(self, name, prop_names, property_interface):
         objpath = self.interface.GetUnit(name)
         proxy = self.bus.get_object(SYSTEMD_BUS, objpath)
@@ -33,17 +36,20 @@ class DBusClient(object):
             properties = tmp_properties
         return properties
 
+    @traces()
     def get_unit_properties(self, unit_name, property_names=None):
         if property_names is None:
             property_names = UNIT_PROPERTIES
         return self.get_properties(unit_name, property_names, UNIT_IFACE)
 
+    @traces()
     def get_service_properties(self, unit_name, property_names=None):
         if property_names is None:
             property_names = SVC_PROPERTIES
         return self.get_properties(unit_name, property_names, SVC_IFACE)
 
 
+@traces()
 def get_services(units):
     out = []
     client = DBusClient()

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -98,6 +98,9 @@ class TestClient(FlaskClient):
 
 @attr(client_min_version=1, client_max_version=LATEST_API_VERSION)
 class BaseServerTestCase(unittest.TestCase):
+    setup_config_enable_tracing = None
+    setup_config_tracing_endpoint_ip = None
+
     def create_client_with_tenant(self,
                                   username,
                                   password,
@@ -341,11 +344,8 @@ class BaseServerTestCase(unittest.TestCase):
         test_config.authorization_permissions = auth_dict['permissions']
         test_config.security_encryption_key = \
             'f2ytTjQ-R2yKFMzgqDAw6vgQIHGZ9SiJoW-BhktapFQ='
-        if getattr(self, 'setup_config_enable_tracing', None) is not None:
-            test_config.enable_tracing = self.setup_config_enable_tracing
-        if getattr(self, 'setup_config_tracing_endpoint_ip', None) is not None:
-            test_config.tracing_endpoint_ip = \
-                self.setup_config_tracing_endpoint_ip
+        test_config.enable_tracing = self.setup_config_enable_tracing
+        test_config.tracing_endpoint_ip = self.setup_config_tracing_endpoint_ip
         test_config._create_tracer_config()
         return test_config
 

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -742,14 +742,14 @@ class BaseServerTestCase(unittest.TestCase):
         )
 
     def _patch_jaeger_config(self):
-        config.j_client.Config = MagicMock()
-        self.jaeger_mock_config = config.j_client.Config
+        config.jaeger_client.Config = MagicMock()
+        self.jaeger_mock_config = config.jaeger_client.Config
         self.jaeger_mock_config.return_value = self.jaeger_mock_config
 
 
-class WithInitTracerTestCase(BaseServerTestCase):
+class TracerTestCase(BaseServerTestCase):
     def setUp(self):
-        super(WithInitTracerTestCase, self).setUp()
+        super(TracerTestCase, self).setUp()
         self._init_tracer(current_app)
 
     @staticmethod

--- a/rest-service/manager_rest/test/endpoints/test_app.py
+++ b/rest-service/manager_rest/test/endpoints/test_app.py
@@ -12,6 +12,8 @@
 #  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
+from flask import current_app
+from opentracing import UnsupportedFormatException
 
 from manager_rest.test import base_test
 from manager_rest.test.attribute import attr
@@ -21,6 +23,7 @@ from manager_rest.test.attribute import attr
 class AppTestCase(base_test.BaseServerTestCase):
     """Test the basic HTTP interface, app-wide error handling
     """
+
     def test_get_root_404(self):
         """GET / returns a 404.
 
@@ -29,3 +32,56 @@ class AppTestCase(base_test.BaseServerTestCase):
         """
         resp = self.app.get('/')
         self.assertEqual(404, resp.status_code)
+
+    def test_does_not_init_tracer(self):
+        # Dummy call to invoke the tracer initialization if enabled.
+        self.app.get('/')
+        self.jaeger_mock_config.assert_not_called()
+
+
+@attr(client_min_version=base_test.LATEST_API_VERSION,
+      client_max_version=base_test.LATEST_API_VERSION,
+      setup_config_enable_tracing=True,
+      setup_config_tracing_endpoint_ip=None)
+class AppWithTracingNoIPTestCase(base_test.WithInitTracerTestCase):
+    """Test the basic setup of the tracer and dispatch wrapping for the
+    tracing when tracing is enabled but no endpoint IP is set.
+    """
+
+    def test_does_not_init_tracer_no_tracer_ip(self):
+        self.jaeger_mock_config.assert_not_called()
+
+
+@attr(client_min_version=base_test.LATEST_API_VERSION,
+      client_max_version=base_test.LATEST_API_VERSION,
+      setup_config_enable_tracing=True,
+      setup_config_tracing_endpoint_ip='some_ip')
+class AppWithTracingTestCase(base_test.WithInitTracerTestCase):
+    """Test the basic setup of the tracer and dispatch wrapping for the
+    tracing when tracing is enabled and an endpoint IP is set.
+    """
+
+    def test_does_init_tracer(self):
+        self.jaeger_mock_config.assert_called_with(
+            config={
+                'sampler': {'type': 'const', 'param': 1},
+                'local_agent': {
+                    'reporting_host': 'some_ip'},
+                'logging': True
+            },
+            service_name='cloudify-manager'
+        )
+        self.jaeger_mock_config.initialize_tracer.assert_called()
+
+    def test_adds_error_to_tags(self):
+        e = UnsupportedFormatException()
+        start_span_kwargs = {'tags': {"Extract failed": str(e)},
+                             'operation_name': 'None (GET)'}
+
+        def _raises(*_, **__):
+            raise e
+
+        tracer = current_app.tracer
+        tracer.extract.side_effect = _raises
+        self.app.get('/')
+        tracer.start_span.assert_called_with(**start_span_kwargs)

--- a/rest-service/manager_rest/test/endpoints/test_app.py
+++ b/rest-service/manager_rest/test/endpoints/test_app.py
@@ -40,26 +40,26 @@ class AppTestCase(base_test.BaseServerTestCase):
 
 
 @attr(client_min_version=base_test.LATEST_API_VERSION,
-      client_max_version=base_test.LATEST_API_VERSION,
-      setup_config_enable_tracing=True,
-      setup_config_tracing_endpoint_ip=None)
+      client_max_version=base_test.LATEST_API_VERSION)
 class AppWithTracingNoIPTestCase(base_test.TracerTestCase):
     """Test the basic setup of the tracer and dispatch wrapping for the
     tracing when tracing is enabled but no endpoint IP is set.
     """
+    setup_config_enable_tracing = True
+    setup_config_tracing_endpoint_ip = None
 
     def test_does_not_init_tracer_no_tracer_ip(self):
         self.jaeger_mock_config.assert_not_called()
 
 
 @attr(client_min_version=base_test.LATEST_API_VERSION,
-      client_max_version=base_test.LATEST_API_VERSION,
-      setup_config_enable_tracing=True,
-      setup_config_tracing_endpoint_ip='some_ip')
+      client_max_version=base_test.LATEST_API_VERSION)
 class AppWithTracingTestCase(base_test.TracerTestCase):
     """Test the basic setup of the tracer and dispatch wrapping for the
     tracing when tracing is enabled and an endpoint IP is set.
     """
+    setup_config_enable_tracing = True
+    setup_config_tracing_endpoint_ip = 'some_ip'
 
     def test_does_init_tracer(self):
         self.jaeger_mock_config.assert_called_with(

--- a/rest-service/manager_rest/test/endpoints/test_app.py
+++ b/rest-service/manager_rest/test/endpoints/test_app.py
@@ -43,7 +43,7 @@ class AppTestCase(base_test.BaseServerTestCase):
       client_max_version=base_test.LATEST_API_VERSION,
       setup_config_enable_tracing=True,
       setup_config_tracing_endpoint_ip=None)
-class AppWithTracingNoIPTestCase(base_test.WithInitTracerTestCase):
+class AppWithTracingNoIPTestCase(base_test.TracerTestCase):
     """Test the basic setup of the tracer and dispatch wrapping for the
     tracing when tracing is enabled but no endpoint IP is set.
     """
@@ -56,7 +56,7 @@ class AppWithTracingNoIPTestCase(base_test.WithInitTracerTestCase):
       client_max_version=base_test.LATEST_API_VERSION,
       setup_config_enable_tracing=True,
       setup_config_tracing_endpoint_ip='some_ip')
-class AppWithTracingTestCase(base_test.WithInitTracerTestCase):
+class AppWithTracingTestCase(base_test.TracerTestCase):
     """Test the basic setup of the tracer and dispatch wrapping for the
     tracing when tracing is enabled and an endpoint IP is set.
     """

--- a/rest-service/manager_rest/test/endpoints/test_utils.py
+++ b/rest-service/manager_rest/test/endpoints/test_utils.py
@@ -111,11 +111,11 @@ class TestUtils(base_test.BaseServerTestCase):
         curr_span.assert_not_called()
 
 
-@attr(setup_config_enable_tracing=True,
-      setup_config_tracing_endpoint_ip='some_ip')
 class TestUtilsWithTracingTestCase(base_test.TracerTestCase):
     """Test the tracing wrapper when tracing is enabled.
     """
+    setup_config_enable_tracing = True
+    setup_config_tracing_endpoint_ip = 'some_ip'
 
     @patch('manager_rest.utils.span_in_context')
     @patch('manager_rest.utils.get_current_span')

--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -38,7 +38,9 @@ install_requires = [
     'cryptography==2.1.4',
     'psycopg2==2.7.4',
     'pytz==2018.4',
-    'click==6.7'
+    'click==6.7',
+    'opentracing-instrumentation==2.4.3',
+    'jaeger-client==3.11.0'
 ]
 
 


### PR DESCRIPTION
The following features work whenever `enable_tracing` is set to `true` and
`jaeger_server_ip` is also set with the corresponding Jaeger API Server
IP.
- Adds automatic tracing to thread context whenever an API call is made
- Adds a decorator for tracing, it starts a new span before the function
is called.