### PR TITLE
CY-728 : removing the restriction of required node templates in a blueprint

### DIFF
--- a/rest-service/manager_rest/test/mock_blueprint/empty_blueprint.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/empty_blueprint.yaml
@@ -2,7 +2,3 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
     - cloudify/types/types.yaml
-
-node_templates:
-    mock_node:
-        type: cloudify.nodes.Root


### PR DESCRIPTION
- adding a test for installing an empty valid blueprint
- This was done because now you can import uploaded blueprints, so the full range of blueprints should be allowed