### PR TITLE
CY-730 : Add tracing framework

### DIFF
--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -14,10 +14,11 @@
 #  * limitations under the License.
 
 import os
-import yaml
 
 from json import dump
 
+import yaml
+import jaeger_client
 
 CONFIG_TYPES = [
     ('MANAGER_REST_CONFIG_PATH', ''),
@@ -79,10 +80,15 @@ class Config(object):
 
         self.warnings = []
 
+        self.enable_tracing = False
+        self.tracing_endpoint_ip = None
+        self.tracer_config = None
+
     def load_configuration(self):
         for env_var_name, namespace in CONFIG_TYPES:
             if env_var_name in os.environ:
                 self.load_from_file(os.environ[env_var_name], namespace)
+        self._create_tracer_config()
 
     def load_from_file(self, filename, namespace=''):
         with open(filename) as f:

--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -18,7 +18,6 @@ import os
 from json import dump
 
 import yaml
-import jaeger_client
 
 CONFIG_TYPES = [
     ('MANAGER_REST_CONFIG_PATH', ''),
@@ -88,7 +87,6 @@ class Config(object):
         for env_var_name, namespace in CONFIG_TYPES:
             if env_var_name in os.environ:
                 self.load_from_file(os.environ[env_var_name], namespace)
-        self._create_tracer_config()
 
     def load_from_file(self, filename, namespace=''):
         with open(filename) as f:

--- a/rest-service/manager_rest/rest/rest_decorators.py
+++ b/rest-service/manager_rest/rest/rest_decorators.py
@@ -40,7 +40,6 @@ from voluptuous import (
     Schema,
 )
 from ..security.authentication import authenticator
-from manager_rest.utils import traces
 from manager_rest import utils, config, manager_exceptions
 from manager_rest.storage.models_base import SQLModelBase
 from manager_rest.rest.rest_utils import (verify_and_convert_bool,
@@ -92,7 +91,7 @@ def insecure_rest_method(func):
 
 def exceptions_handled(func):
     @wraps(func)
-    @traces('exceptions_handled')
+    @utils.traces('exceptions_handled')
     def wrapper(*args, **kwargs):
         try:
             try:
@@ -125,7 +124,7 @@ class marshal_with(object):
 
     def __call__(self, f):
         @wraps(f)
-        @traces('marshal_with {}'.format(self.response_class.__name__))
+        @utils.traces('marshal_with {}'.format(self.response_class.__name__))
         def wrapper(*args, **kwargs):
             if hasattr(request, '__skip_marshalling'):
                 return f(*args, **kwargs)

--- a/rest-service/manager_rest/rest/rest_decorators.py
+++ b/rest-service/manager_rest/rest/rest_decorators.py
@@ -40,6 +40,7 @@ from voluptuous import (
     Schema,
 )
 from ..security.authentication import authenticator
+from manager_rest.utils import traces
 from manager_rest import utils, config, manager_exceptions
 from manager_rest.storage.models_base import SQLModelBase
 from manager_rest.rest.rest_utils import (verify_and_convert_bool,
@@ -91,6 +92,7 @@ def insecure_rest_method(func):
 
 def exceptions_handled(func):
     @wraps(func)
+    @traces('exceptions_handled')
     def wrapper(*args, **kwargs):
         try:
             try:
@@ -123,6 +125,7 @@ class marshal_with(object):
 
     def __call__(self, f):
         @wraps(f)
+        @traces('marshal_with {}'.format(self.response_class.__name__))
         def wrapper(*args, **kwargs):
             if hasattr(request, '__skip_marshalling'):
                 return f(*args, **kwargs)

--- a/rest-service/manager_rest/security/authorization.py
+++ b/rest-service/manager_rest/security/authorization.py
@@ -4,7 +4,6 @@ from functools import wraps
 from flask import request
 from flask_security import current_user
 
-from manager_rest.utils import traces
 from manager_rest import config, utils
 from manager_rest.storage.models import Tenant
 from manager_rest.storage import get_storage_manager
@@ -20,7 +19,7 @@ def authorize(action,
               allow_all_tenants=False):
     def authorize_dec(func):
         @wraps(func)
-        @traces('authorize')
+        @utils.traces('authorize')
         def wrapper(*args, **kwargs):
 
             # getting the tenant name

--- a/rest-service/manager_rest/security/authorization.py
+++ b/rest-service/manager_rest/security/authorization.py
@@ -4,6 +4,7 @@ from functools import wraps
 from flask import request
 from flask_security import current_user
 
+from manager_rest.utils import traces
 from manager_rest import config, utils
 from manager_rest.storage.models import Tenant
 from manager_rest.storage import get_storage_manager
@@ -19,6 +20,7 @@ def authorize(action,
               allow_all_tenants=False):
     def authorize_dec(func):
         @wraps(func)
+        @traces('authorize')
         def wrapper(*args, **kwargs):
 
             # getting the tenant name

--- a/rest-service/manager_rest/security/secured_resource.py
+++ b/rest-service/manager_rest/security/secured_resource.py
@@ -19,7 +19,7 @@ from flask_restful import Resource
 from flask_restful.utils import unpack
 from flask import request, current_app, Response, jsonify
 
-from manager_rest.utils import abort_error
+from manager_rest.utils import abort_error, traces
 from manager_rest.manager_exceptions import MissingPremiumPackage
 
 from .authentication import authenticator
@@ -37,6 +37,7 @@ def authenticate(func):
         return data, code, headers
 
     @wraps(func)
+    @traces('authenticate')
     def wrapper(*args, **kwargs):
         auth_response = authenticator.authenticate(request)
         if isinstance(auth_response, Response):

--- a/rest-service/manager_rest/systemddbus.py
+++ b/rest-service/manager_rest/systemddbus.py
@@ -1,5 +1,7 @@
 import dbus
 
+from manager_rest.utils import traces
+
 SYSTEMD_BUS = 'org.freedesktop.systemd1'
 SYSTEMD_PATH = '/org/freedesktop/systemd1'
 MANAGER_IFACE = 'org.freedesktop.systemd1.Manager'
@@ -12,12 +14,13 @@ UNIT_PROPERTIES = ['Id', 'Description', 'LoadState', 'ActiveState',
 
 
 class DBusClient(object):
-
+    @traces()
     def __init__(self):
         self.bus = dbus.SystemBus()
         self.proxy = self.bus.get_object(SYSTEMD_BUS, SYSTEMD_PATH)
         self.interface = dbus.Interface(self.proxy, MANAGER_IFACE)
 
+    @traces()
     def get_properties(self, name, prop_names, property_interface):
         objpath = self.interface.GetUnit(name)
         proxy = self.bus.get_object(SYSTEMD_BUS, objpath)
@@ -33,17 +36,20 @@ class DBusClient(object):
             properties = tmp_properties
         return properties
 
+    @traces()
     def get_unit_properties(self, unit_name, property_names=None):
         if property_names is None:
             property_names = UNIT_PROPERTIES
         return self.get_properties(unit_name, property_names, UNIT_IFACE)
 
+    @traces()
     def get_service_properties(self, unit_name, property_names=None):
         if property_names is None:
             property_names = SVC_PROPERTIES
         return self.get_properties(unit_name, property_names, SVC_IFACE)
 
 
+@traces()
 def get_services(units):
     out = []
     client = DBusClient()

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -160,7 +160,6 @@ class BaseServerTestCase(unittest.TestCase):
         self._create_temp_files_and_folders()
         self._init_file_server()
         self._mock_amqp_modules()
-        self._patch_jaeger_config()
 
         server_module = self._set_config_path_and_get_server_module()
         self._create_config_and_reset_app(server_module)
@@ -170,6 +169,7 @@ class BaseServerTestCase(unittest.TestCase):
         self.sm = get_storage_manager()
         self.initialize_provider_context()
         self._mock_verify_role()
+        self._patch_jaeger_config(server_module)
 
     def _mock_verify_role(self):
         self._original_verify_role = rest_utils.verify_role
@@ -351,7 +351,6 @@ class BaseServerTestCase(unittest.TestCase):
         )
         test_config.enable_tracing = self.setup_config_enable_tracing
         test_config.tracing_endpoint_ip = self.setup_config_tracing_endpoint_ip
-        test_config._create_tracer_config()
         return test_config
 
     def _version_url(self, url):
@@ -746,9 +745,9 @@ class BaseServerTestCase(unittest.TestCase):
             *args
         )
 
-    def _patch_jaeger_config(self):
-        config.jaeger_client.Config = MagicMock()
-        self.jaeger_mock_config = config.jaeger_client.Config
+    def _patch_jaeger_config(self, server_module):
+        server_module.jaeger_client.Config = MagicMock()
+        self.jaeger_mock_config = server_module.jaeger_client.Config
         self.jaeger_mock_config.return_value = self.jaeger_mock_config
 
 

--- a/rest-service/manager_rest/test/endpoints/test_app.py
+++ b/rest-service/manager_rest/test/endpoints/test_app.py
@@ -12,6 +12,8 @@
 #  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
+from flask import current_app
+from opentracing import UnsupportedFormatException
 
 from manager_rest.test import base_test
 from manager_rest.test.attribute import attr
@@ -21,6 +23,7 @@ from manager_rest.test.attribute import attr
 class AppTestCase(base_test.BaseServerTestCase):
     """Test the basic HTTP interface, app-wide error handling
     """
+
     def test_get_root_404(self):
         """GET / returns a 404.
 
@@ -29,3 +32,56 @@ class AppTestCase(base_test.BaseServerTestCase):
         """
         resp = self.app.get('/')
         self.assertEqual(404, resp.status_code)
+
+    def test_does_not_init_tracer(self):
+        # Dummy call to invoke the tracer initialization if enabled.
+        self.app.get('/')
+        self.jaeger_mock_config.assert_not_called()
+
+
+@attr(client_min_version=base_test.LATEST_API_VERSION,
+      client_max_version=base_test.LATEST_API_VERSION)
+class AppWithTracingNoIPTestCase(base_test.TracerTestCase):
+    """Test the basic setup of the tracer and dispatch wrapping for the
+    tracing when tracing is enabled but no endpoint IP is set.
+    """
+    setup_config_enable_tracing = True
+    setup_config_tracing_endpoint_ip = None
+
+    def test_does_not_init_tracer_no_tracer_ip(self):
+        self.jaeger_mock_config.assert_not_called()
+
+
+@attr(client_min_version=base_test.LATEST_API_VERSION,
+      client_max_version=base_test.LATEST_API_VERSION)
+class AppWithTracingTestCase(base_test.TracerTestCase):
+    """Test the basic setup of the tracer and dispatch wrapping for the
+    tracing when tracing is enabled and an endpoint IP is set.
+    """
+    setup_config_enable_tracing = True
+    setup_config_tracing_endpoint_ip = 'some_ip'
+
+    def test_does_init_tracer(self):
+        self.jaeger_mock_config.assert_called_with(
+            config={
+                'sampler': {'type': 'const', 'param': 1},
+                'local_agent': {
+                    'reporting_host': 'some_ip'},
+                'logging': True
+            },
+            service_name='cloudify-manager'
+        )
+        self.jaeger_mock_config.initialize_tracer.assert_called()
+
+    def test_adds_error_to_tags(self):
+        e = UnsupportedFormatException()
+        start_span_kwargs = {'tags': {"Extract failed": str(e)},
+                             'operation_name': 'None (GET)'}
+
+        def _raises(*_, **__):
+            raise e
+
+        tracer = current_app.tracer
+        tracer.extract.side_effect = _raises
+        self.app.get('/')
+        tracer.start_span.assert_called_with(**start_span_kwargs)

--- a/rest-service/manager_rest/test/endpoints/test_app.py
+++ b/rest-service/manager_rest/test/endpoints/test_app.py
@@ -69,7 +69,7 @@ class AppWithTracingTestCase(base_test.TracerTestCase):
                     'reporting_host': 'some_ip'},
                 'logging': True
             },
-            service_name='cloudify-manager'
+            service_name='cloudify-restservice'
         )
         self.jaeger_mock_config.initialize_tracer.assert_called()
 

--- a/rest-service/manager_rest/test/endpoints/test_utils.py
+++ b/rest-service/manager_rest/test/endpoints/test_utils.py
@@ -15,13 +15,15 @@
 
 import os
 
-from mock import patch
-from manager_rest.test.attribute import attr
+from flask import current_app
+from mock import patch, MagicMock
 
+from manager_rest.utils import traces
 from manager_rest.utils import read_json_file, write_dict_to_json_file
 from manager_rest.utils import plugin_installable_on_current_platform
-from manager_rest.test import base_test
 from manager_rest.storage import models
+from manager_rest.test import base_test
+from manager_rest.test.attribute import attr
 
 
 @attr(client_min_version=1, client_max_version=base_test.LATEST_API_VERSION)
@@ -96,6 +98,58 @@ class TestUtils(base_test.BaseServerTestCase):
                 self.assertTrue(
                     plugin_installable_on_current_platform(plugin))
 
+    @patch('flask.current_app')
+    @patch('opentracing_instrumentation.request_context.span_in_context')
+    @patch('opentracing_instrumentation.request_context.get_current_span')
+    def test_traces_wrapper_uses_orig_func_when_not_tracing(self, curr_span, _,
+                                                            current_app):
+        dummy_f, decorated_f, return_value, _ = get_dummy_function_and_params(
+            decorator=traces)
+        current_app.tracer = False
+        result = decorated_f('bar', k='v')
+        self.assertEqual(result, return_value)
+        dummy_f.assert_called_once_with('bar', k='v')
+        curr_span.assert_not_called()
+
+
+class TestUtilsWithTracingTestCase(base_test.TracerTestCase):
+    """Test the tracing wrapper when tracing is enabled.
+    """
+    setup_config_enable_tracing = True
+    setup_config_tracing_endpoint_ip = 'some_ip'
+
+    @patch('manager_rest.utils.span_in_context')
+    @patch('manager_rest.utils.get_current_span')
+    def test_tracing_wrapper_works(self, curr_span, span_ctx):
+        curr_span.return_value = curr_span
+        current_app.tracer.start_span.reset_mock()
+
+        dummy_f, decorated_f, return_value, _ = get_dummy_function_and_params(
+            'not_foo', decorator=traces)
+        result = decorated_f('bar', k='v')
+        self.assertEqual(result, return_value)
+        dummy_f.assert_called_once_with('bar', k='v')
+        curr_span.assert_called_once()
+        current_app.tracer.start_span.assert_called_once_with(
+            'not_foo', child_of=curr_span)
+        span_ctx.assert_called_once()
+
+    @patch('manager_rest.utils.span_in_context')
+    @patch('manager_rest.utils.get_current_span')
+    def test_tracing_wrapper_works_no_name(self, curr_span, span_ctx):
+        curr_span.return_value = curr_span
+        current_app.tracer.start_span.reset_mock()
+
+        dummy_f, decorated_f, return_value, decorated_func_name = \
+            get_dummy_function_and_params(decorator=traces)
+        result = decorated_f('bar', k='v')
+        self.assertEqual(result, return_value)
+        dummy_f.assert_called_once_with('bar', k='v')
+        curr_span.assert_called_once()
+        current_app.tracer.start_span.assert_called_once_with(
+            decorated_func_name, child_of=curr_span)
+        span_ctx.assert_called_once()
+
 
 def generate_progress_func(total_size, assert_equal,
                            assert_almost_equal, buffer_size=8192):
@@ -127,3 +181,22 @@ def generate_progress_func(total_size, assert_equal,
         iteration[0] += 1
 
     return print_progress
+
+
+def get_dummy_function_and_params(func_trace_name=None, decorator=None):
+    """Creates a dummy function using MagicMock.
+
+    :param func_trace_name: function name to pass to the traces() decorator.
+    :param decorator: decorator to decorate the function.
+    :return: (dummy function, decorated dummy function, return value,
+     function name)
+    """
+    decorated_func_name = 'foo'
+    return_value = 'something'
+    foo = MagicMock(return_value=return_value)
+    foo.__name__ = decorated_func_name
+    if decorator:
+        f = decorator(func_trace_name)(foo)
+    else:
+        f = foo
+    return foo, f, return_value, decorated_func_name

--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -24,15 +24,18 @@ import StringIO
 import tempfile
 import platform
 import traceback
+from functools import wraps
 from datetime import datetime
 from os import path, makedirs
 from base64 import urlsafe_b64encode
 
 import wagon
-from flask import g
+from flask import g, current_app
 from flask_restful import abort
 from flask_security import current_user
 from werkzeug.local import LocalProxy
+from opentracing_instrumentation.request_context import get_current_span, \
+    span_in_context
 
 from cloudify import logs
 from cloudify.amqp_client import create_events_publisher
@@ -284,3 +287,36 @@ def send_event(event, message_type):
 
     events_publisher.publish_message(event, message_type)
     events_publisher.close()
+
+
+def traces(func_name=None):
+    """Wrapper function for Flask operation call tracing.
+    This decorator must be activate iff the following condition apply. One of
+    the parent calls must be done inside a 'with span_in_context(span)' scope
+    (otherwise you'd get a parentless span).
+
+    If you'd like to trace a decorator, make sure to use this decorator on the
+    inner wrapper function and not on the decorator as the decorator runs once
+    per input while the wrapper runs every time the wrapped function is
+    invoked.
+
+    :param func_name: name to display in tracing
+    """
+
+    def decorator(f):
+        name = func_name
+        if func_name is None:
+            name = f.__name__
+
+        @wraps(f)
+        def with_tracing_wrapper(*args, **kwargs):
+            tracer = getattr(current_app, 'tracer', None)
+            if not tracer:
+                return f(*args, **kwargs)
+            root_span = get_current_span()
+            with tracer.start_span(name, child_of=root_span) as span:
+                with span_in_context(span):
+                    return f(*args, **kwargs)
+        return with_tracing_wrapper
+
+    return decorator

--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -38,7 +38,9 @@ install_requires = [
     'cryptography==2.1.4',
     'psycopg2==2.7.4',
     'pytz==2018.4',
-    'click==6.7'
+    'click==6.7',
+    'opentracing-instrumentation==2.4.3',
+    'jaeger-client==3.11.0'
 ]
 
 

--- a/tests/integration_tests/tests/test_cases.py
+++ b/tests/integration_tests/tests/test_cases.py
@@ -77,6 +77,7 @@ class BaseTestCase(unittest.TestCase):
         self.addCleanup(shutil.rmtree, self.workdir, ignore_errors=True)
         self._set_tests_framework_logger()
         self.client = None
+        self._setup_tracing()
 
     @classmethod
     def _update_config(cls, new_config):
@@ -469,6 +470,16 @@ class BaseTestCase(unittest.TestCase):
             yield
         finally:
             client._client.headers[CLOUDIFY_TENANT_HEADER] = curr_tenant
+
+    def _setup_tracing(self):
+        """Updates the rest server config to enable tracing if
+        TRACING_ENDPOINT_IP env var is set.
+        """
+        tracing_endpoint_ip = os.environ.get('TRACING_ENDPOINT_IP')
+        if tracing_endpoint_ip:
+            self._update_config(
+                {'enable_tracing': True,
+                 'tracing_endpoint_ip': tracing_endpoint_ip})
 
 
 class AgentlessTestCase(BaseTestCase):


### PR DESCRIPTION
The following features work whenever `enable_tracing` is set to `true` and
`tracing_endpoint_ip` is also set with the corresponding Jaeger API Server
IP.
- Adds automatic tracing to thread context whenever an API call is made
- Adds a decorator for tracing, it starts a new span before the function
is called.