### PR TITLE
Use the current user as the execution creator

### DIFF
--- a/rest-service/manager_rest/storage/resource_models_base.py
+++ b/rest-service/manager_rest/storage/resource_models_base.py
@@ -115,6 +115,4 @@ class SQLResourceBase(SQLModelBase):
         # get flushed to the DB, because it is still lacking data (the parent's
         # foreign key)
         with db.session.no_autoflush:
-            self.creator = parent_instance.creator
-            self.tenant = parent_instance.tenant
             self.visibility = parent_instance.visibility


### PR DESCRIPTION
Don't always inherit from the deployment

Same for deployment modifications/updates