### PR TITLE
CY-780 rabbitmq config: set heartbeat to 0

### DIFF
--- a/packaging/rabbitmq/files/etc/cloudify/rabbitmq/rabbitmq.config
+++ b/packaging/rabbitmq/files/etc/cloudify/rabbitmq/rabbitmq.config
@@ -1,6 +1,7 @@
 [
  {ssl, [{versions, ['tlsv1.2', 'tlsv1.1']}]},
  {rabbit, [
+           {heartbeat, 0},  % clients can override this
            {loopback_users, []},
            {ssl_listeners, [5671]},
            {ssl_options, [{cacertfile,"/etc/cloudify/ssl/cloudify_internal_cert.pem"},


### PR DESCRIPTION
This gives the control over the connection heartbeat to each client.

While this was the default (60, ie. non-zero), then clients could not
disable heartbeat by themselves, because if they try to, server
default will be used instead.