### PR TITLE
CY-866 Add ability to get_capability to get nested property

### DIFF
--- a/rest-service/manager_rest/dsl_functions.py
+++ b/rest-service/manager_rest/dsl_functions.py
@@ -83,6 +83,7 @@ def get_secret_method():
 def _get_methods(deployment_id, storage_manager):
     """Retrieve a dict of all the callbacks necessary for function evaluation
     """
+
     def get_node_instances(node_id=None):
         filters = dict(deployment_id=deployment_id)
         if node_id:
@@ -110,9 +111,10 @@ def _get_methods(deployment_id, storage_manager):
             raise FunctionsEvaluationError(
                 'Requested capability `{0}` is not declared '
                 'in deployment `{1}`'.format(
-                    element_id, deployment_id
+                    element_id, shared_dep_id
                 )
             )
+
         # We need to evaluate any potential intrinsic functions in the
         # capability's value in the context of the *shared* deployment,
         # instead of the current deployment, so we manually call the function
@@ -120,6 +122,16 @@ def _get_methods(deployment_id, storage_manager):
             payload=capability,
             deployment_id=shared_dep_id
         )
+
+        # If it's a nested property of the capability
+        if len(capability_path) > 2:
+            try:
+                capability = \
+                    functions.get_nested_attribute_value_of_capability(
+                        capability['value'],
+                        capability_path)
+            except parser_exceptions.FunctionEvaluationError as e:
+                raise FunctionsEvaluationError(str(e))
 
         return capability['value']
 

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_capabilities.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_capabilities.yaml
@@ -9,6 +9,9 @@ node_types:
     properties:
       key:
         default: default_value
+      key_nested:
+        default:
+          - nested: default_value
 
 node_templates:
   node1:
@@ -17,12 +20,20 @@ node_templates:
     type: test_type
     properties:
       key: override_value
+      key_nested:
+        - nested: override_value
 
 capabilities:
   node_1_key:
     value: { get_attribute: [ node1, key ]}
   node_2_key:
     value: { get_attribute: [ node2, key ]}
+  node_1_key_nested:
+    value:
+    - nested: { get_attribute: [ node1, key_nested, 0, nested ]}
+  node_2_key_nested:
+    value:
+    - nested: { get_attribute: [ node2, key_nested, 0, nested ]}
   complex_capability:
     value:
       level_1:

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_get_capability.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_get_capability.yaml
@@ -3,12 +3,19 @@ tosca_definitions_version: cloudify_dsl_1_3
 imports:
   - cloudify/types/types.yaml
 
+inputs:
+  a:
+    default: 0
+  b:
+    default: shared
 node_types:
   test_type:
     derived_from: cloudify.nodes.Root
     properties:
       key:
         default: { get_capability: [ shared, node_1_key ] }
+      key_nested:
+        default: { get_capability: [ shared, node_1_key_nested, 0, nested ] }
 
 node_templates:
   node1:
@@ -17,7 +24,10 @@ node_templates:
     type: test_type
     properties:
       key: { get_capability: [ shared, node_2_key ] }
+      key_nested: { get_capability: [ shared, node_2_key_nested, 0, nested ] }
 
 outputs:
   complex_output:
     value: { get_capability: [ shared, complex_capability ] }
+  complex_output_nested:
+    value: { get_capability: [ {get_input: b}, complex_capability, level_1, level_2, level_3, {get_input: a} ] }

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_nested_capability_bad_index_type.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_nested_capability_bad_index_type.yaml
@@ -8,13 +8,8 @@ node_types:
     derived_from: cloudify.nodes.Root
     properties:
       key:
-        default: { get_capability: [ chain_1, chain_1_capability, nested, 0 ] }
+        default: { get_capability: [ shared, complex_capability, level_1, level_2, level_3, bad_index_type ] }
 
 node_templates:
-  chain_2_node:
+  node1:
     type: test_type
-
-
-capabilities:
-  chain_2_capability:
-    value: { get_attribute: [ chain_2_node, key ]}

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_non_existent_nested_attr_of_capability.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_non_existent_nested_attr_of_capability.yaml
@@ -8,13 +8,8 @@ node_types:
     derived_from: cloudify.nodes.Root
     properties:
       key:
-        default: { get_capability: [ chain_1, chain_1_capability, nested, 0 ] }
+        default: { get_capability: [ shared, complex_capability, random_stuff ] }
 
 node_templates:
-  chain_2_node:
+  node1:
     type: test_type
-
-
-capabilities:
-  chain_2_capability:
-    value: { get_attribute: [ chain_2_node, key ]}

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_non_existent_nested_index_of_capability.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_non_existent_nested_index_of_capability.yaml
@@ -8,13 +8,8 @@ node_types:
     derived_from: cloudify.nodes.Root
     properties:
       key:
-        default: { get_capability: [ chain_1, chain_1_capability, nested, 0 ] }
+        default: { get_capability: [ shared, complex_capability, level_1, level_2, level_3, 8 ] }
 
 node_templates:
-  chain_2_node:
+  node1:
     type: test_type
-
-
-capabilities:
-  chain_2_capability:
-    value: { get_attribute: [ chain_2_node, key ]}

--- a/rest-service/manager_rest/test/mock_blueprint/capability_chain_1.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/capability_chain_1.yaml
@@ -17,4 +17,6 @@ node_templates:
 
 capabilities:
   chain_1_capability:
-    value: { get_attribute: [ chain_1_node, key ]}
+    value:
+      nested:
+      - { get_attribute: [ chain_1_node, key ]}


### PR DESCRIPTION
- This makes it behave similarly to get_attribute.
- Preserves old behavior.