### PR TITLE
Add Ability to Test Plugins on Manager w/ Wagon Build

### DIFF
--- a/tests/integration_tests/framework/docker_interface.py
+++ b/tests/integration_tests/framework/docker_interface.py
@@ -1,0 +1,48 @@
+########
+# Copyright (c) 2018 Cloudify Platform Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import docker
+
+
+class DockerInterface(object):
+
+    @staticmethod
+    def get_docker_client(docker_base_url=None, docker_port='2375'):
+        """Get a Docker Py client.
+        docker.get_env does not work,
+        because we do not specify the port in our DOCKER_HOST env variable.
+        """
+        docker_base_url = \
+            docker_base_url or '{0}:{1}'.format(
+                os.getenv('DOCKER_HOST'), docker_port)
+        return docker.DockerClient(base_url=docker_base_url)
+
+    @property
+    def docker_client(self):
+        return self.get_docker_client()
+
+    @property
+    def docker_images(self):
+        return [image.tags for image in self.docker_client.images.list()]
+
+    def build_image(self, dockerfile_object, image_name):
+        return self.docker_client.images.build(fileobj=dockerfile_object,
+                                               tag=image_name)
+
+    def run_container(self, image_name, **kwargs):
+        """Start building the wagon."""
+        return self.docker_client.containers.run(image_name, **kwargs)

--- a/tests/integration_tests/framework/docker_interface.py
+++ b/tests/integration_tests/framework/docker_interface.py
@@ -35,9 +35,14 @@ class DockerInterface(object):
     def docker_client(self):
         return self.get_docker_client()
 
-    @property
-    def docker_images(self):
-        return [image.tags for image in self.docker_client.images.list()]
+    def list_image_tags(self):
+        image_tags = []
+        for image in self.docker_client.images.list():
+            image_tags = image_tags + image.tags
+        return image_tags
+
+    def pull_image(self, **kwargs):
+        return self.docker_client.images.pull(**kwargs)
 
     def build_image(self, dockerfile_object, image_name):
         return self.docker_client.images.build(fileobj=dockerfile_object,

--- a/tests/integration_tests/framework/wagon_build.py
+++ b/tests/integration_tests/framework/wagon_build.py
@@ -1,0 +1,85 @@
+########
+# Copyright (c) 2018 Cloudify Platform Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from integration_tests.framework.docker_interface import DockerInterface
+from integration_tests.resources.dockerfiles import centos as dockerfile
+
+# This message is always the last message when a wagon build is finished.
+WAGON_BUILD_TIMEOUT = 600
+WAGON_BUILD_DOCKER_IMAGE_NAME = 'wagonbuilder:latest'
+DOCKER_CONTAINER_BUILD_DIR = '/build'
+
+
+class WagonBuildError(RuntimeError):
+    def __init__(self, errors):
+        super(WagonBuildError, self).__init__("Failed to build wagon.")
+        self.errors = errors
+
+
+class WagonBuilderMixin(DockerInterface):
+
+    @property
+    def wagon_build_time_limit(self):
+        """Max time it should take to build the wagon."""
+        return WAGON_BUILD_TIMEOUT
+
+    @property
+    def docker_image_name(self):
+        """The name of the Docker image that is used to build
+        the plugin wagon.
+        """
+        return WAGON_BUILD_DOCKER_IMAGE_NAME
+
+    @property
+    def plugin_root_directory(self):
+        """ Path to the plugin root directory."""
+        raise NotImplementedError('Implemented by subclass.')
+
+    @property
+    def docker_target_folder(self):
+        """Where to mount the docker local folder on the docker container.
+        """
+        return DOCKER_CONTAINER_BUILD_DIR
+
+    @property
+    def docker_volume_mapping(self):
+        """A volume mapping for mounting a local directory in a container.
+        The wagon will be here at the end of the build.
+        """
+        return {
+            self.plugin_root_directory: {
+                'bind': self.docker_target_folder,
+                'mode': 'rw'
+            }
+        }
+
+    @property
+    def wagon_builder_image_exists(self):
+        """Check if the docker image already exists."""
+        return self.docker_image_name in self.docker_images
+
+    def build_docker_image(self):
+        """Build the wagon builder docker image."""
+        return self.build_image(dockerfile, self.docker_image_name)
+
+    def build_wagon(self):
+        if not self.wagon_builder_image_exists:
+            self.build_docker_image()
+        container = self.run_container(self.docker_image_name,
+                                       volumes=self.docker_volume_mapping,
+                                       detach=True)
+        response = container.wait(timeout=self.wagon_build_time_limit)
+        if response['StatusCode'] != 0:
+            raise WagonBuildError(response)

--- a/tests/integration_tests/resources/dockerfiles/__init__.py
+++ b/tests/integration_tests/resources/dockerfiles/__init__.py
@@ -1,0 +1,42 @@
+########
+# Copyright (c) 2018 Cloudify Platform Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from io import StringIO
+
+# TODO: Write Ubuntu Wagon Builder Image Dockerfile.
+
+# flake8: noqa
+
+centos_content = """FROM amd64/centos:latest
+MAINTAINER Cosmo (hello@cloudify.co)
+WORKDIR /build
+RUN echo "manylinux1_compatible = False" > "/usr/lib64/python2.7/_manylinux.py"
+RUN yum -y install python-devel gcc openssl git libxslt-devel libxml2-devel openldap-devel libffi-devel openssl-devel libvirt-devel
+RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+RUN python get-pip.py
+RUN pip install --upgrade pip==9.0.1
+RUN pip install wagon==0.3.2
+ENTRYPOINT ["wagon"]
+CMD ["create", "-s", ".", "-v", "-f"]"""
+
+
+class DockerfileIO(StringIO):
+
+    @property
+    def name(self):
+        return 'Dockerfile'
+
+
+centos = DockerfileIO(unicode(centos_content))

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -33,5 +33,6 @@ setup(
         'sh==1.11',
         'awscli==1.11.14',
         'docl',
+        'docker==3.6.0'
     ]
 )


### PR DESCRIPTION
These changes make it possible to test plugin changes on a manager.

See example in:
https://github.com/cloudify-incubator/cloudify-openstacksdk-plugin/tree/CY-800-OpenstackSDK-Integration-Testing
from there:
```python
pytest -s integration_testing/test_manager.py
```
