### PR TITLE
CY-763 Add create_rabbitmq_user parameter to agents create

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/agents.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/agents.py
@@ -78,7 +78,8 @@ class AgentsName(SecuredResource):
         """
         request_dict = get_json_and_verify_params({
             'node_instance_id': {'type': unicode},
-            'state': {'type': unicode}
+            'state': {'type': unicode},
+            'create_rabbitmq_user': {'type': bool}
         })
         validate_inputs({'name': name})
         state = request_dict.get('state')
@@ -95,8 +96,9 @@ class AgentsName(SecuredResource):
                                     "already exists".format(name))
             new_agent = get_storage_manager().get(models.Agent, name)
 
-        # Create rabbitmq user
-        self._get_amqp_manager().create_agent_user(new_agent)
+        if request_dict.get('create_rabbitmq_user'):
+            # Create rabbitmq user
+            self._get_amqp_manager().create_agent_user(new_agent)
         return response
 
     @rest_decorators.exceptions_handled

--- a/workflows/cloudify_system_workflows/snapshots/agents.py
+++ b/workflows/cloudify_system_workflows/snapshots/agents.py
@@ -179,6 +179,7 @@ class Agents(object):
         if install_method and install_method != AGENT_INSTALL_METHOD_NONE:
             create_agent_record(cloudify_agent,
                                 state=AgentState.STARTED,
+                                create_rabbitmq_user=False,
                                 client=client)
 
     @staticmethod


### PR DESCRIPTION
* While restoring agents, it will create the agent record in the DB but
  will not creare the rabbitmq user.

* Later in the restore we run the restore_amqp script and rabbitmq users
  will be created.