### PR TITLE
CY-763 Add the state restored for agents and don't create rabbitmq us…

### DIFF
--- a/rest-service/manager_rest/amqp_manager.py
+++ b/rest-service/manager_rest/amqp_manager.py
@@ -17,6 +17,7 @@ from requests.exceptions import HTTPError
 
 from functools import wraps
 
+from cloudify.models_states import AgentState
 from cloudify.utils import generate_user_password
 from cloudify.cryptography_utils import encrypt, decrypt
 from cloudify.rabbitmq_client import RabbitMQClient, USERNAME_PATTERN
@@ -123,8 +124,9 @@ class AMQPManager(object):
             self._storage_manager.update(updated_tenant)
 
         for agent in agents:
-            updated_agent = self.create_agent_user(agent)
-            self._storage_manager.update(updated_agent)
+            if agent.state != AgentState.RESTORED:
+                updated_agent = self.create_agent_user(agent)
+                self._storage_manager.update(updated_agent)
 
     def _clear_extra_vhosts(self, tenants):
         """Remove vhosts in rabbitmq not present in the database"""

--- a/workflows/cloudify_system_workflows/snapshots/agents.py
+++ b/workflows/cloudify_system_workflows/snapshots/agents.py
@@ -175,10 +175,12 @@ class Agents(object):
         cloudify_agent['node_instance_id'] = node_instance_id
         cloudify_agent['version'] = cloudify_agent.get('version') or \
             str(self._manager_version)
+        cloudify_agent.pop('broker_user', None)
+        cloudify_agent.pop('broker_pass', None)
         install_method = cloudify_agent.get('install_method')
         if install_method and install_method != AGENT_INSTALL_METHOD_NONE:
             create_agent_record(cloudify_agent,
-                                state=AgentState.STARTED,
+                                state=AgentState.RESTORED,
                                 create_rabbitmq_user=False,
                                 client=client)
 

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -132,11 +132,11 @@ class SnapshotRestore(object):
                 self._restore_files_to_manager()
                 self._restore_db(postgres, schema_revision, stage_revision)
                 self._restore_hash_salt()
+                self._encrypt_secrets(postgres)
+                self._encrypt_rabbitmq_passwords(postgres)
                 self._possibly_update_encryption_key()
                 self._generate_new_rest_token()
                 self._restart_rest_service()
-                self._encrypt_secrets(postgres)
-                self._encrypt_rabbitmq_passwords(postgres)
                 self._restore_plugins(existing_plugins)
                 self._restore_influxdb()
                 self._restore_credentials(postgres)
@@ -543,7 +543,8 @@ class SnapshotRestore(object):
         ctx.logger.info('Encrypting the passwords of RabbitMQ vhosts')
         postgres.encrypt_values(self._encryption_key,
                                 'tenants',
-                                'rabbitmq_password')
+                                'rabbitmq_password',
+                                primary_key='id')
         ctx.logger.info('Successfully encrypted the passwords of RabbitMQ')
 
     def _restore_stage(self, postgres, tempdir, migration_version):


### PR DESCRIPTION
…er for it

* Add the state restored for agents

* Don't create rabbitmq user for restored agent

* Fix the encrypt_values funtion so it will query the appropriate primary key

* Change the order of snapshot restore so that the secrets and
  tenants encryption will be before _possibly_update_encryption_key