### PR TITLE
CY-642: updating the import blueprint api

### DIFF
--- a/rest-service/manager_rest/resolver_with_catalog_support.py
+++ b/rest-service/manager_rest/resolver_with_catalog_support.py
@@ -138,12 +138,11 @@ class ResolverWithCatalogSupport(DefaultImportResolver):
         import_url = self._resolve_blueprint_url(import_url)
         main_blueprint = super(ResolverWithCatalogSupport, self).\
             fetch_import(import_url)
-        _, merged_blueprint = parser.resolve_blueprint_imports(
+        merged_blueprint = parser.parse_from_import_blueprint(
             dsl_string=main_blueprint,
             dsl_location=import_url,
             resources_base_path=config.instance.file_server_root,
-            resolver=self,
-            validate_version=False)
+            resolver=self)
         return merged_blueprint
 
     @staticmethod

--- a/rest-service/manager_rest/test/endpoints/test_blueprints.py
+++ b/rest-service/manager_rest/test/endpoints/test_blueprints.py
@@ -404,7 +404,7 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
         """
         second_blueprint_id = 'imported_blueprint'
         self.put_blueprint('mock_blueprint',
-                           'empty_blueprint.yaml', second_blueprint_id)
+                           'blueprint.yaml', second_blueprint_id)
 
         first_blueprint_id = 'first_imported_blueprint'
         self.put_blueprint('mock_blueprint',


### PR DESCRIPTION
Using the new api for receiving fully parsed blueprint from import