### PR TITLE
CY-642: changing the namespace delimiter

### DIFF
--- a/rest-service/manager_rest/test/infrastructure/test_parse_with_resolver.py
+++ b/rest-service/manager_rest/test/infrastructure/test_parse_with_resolver.py
@@ -68,7 +68,7 @@ class TestParseWithResolver(BaseServerTestCase):
 
         nodes = {node["name"] for node in plan[constants.NODES]}
 
-        self.assertEqual(nodes, {"test", "ns->vm", "ns->http_web_server"})
+        self.assertEqual(nodes, {"test", "ns--vm", "ns--http_web_server"})
 
 
 @attr(client_min_version=1, client_max_version=LATEST_API_VERSION)

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_2_layer_blueprint_import.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_2_layer_blueprint_import.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-    - namespace->blueprint:first_imported_blueprint
+    - namespace--blueprint:first_imported_blueprint
 
 node_templates:
     test_other:

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_blueprint_import.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_blueprint_import.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-    - ns->blueprint:imported_blueprint
+    - ns--blueprint:imported_blueprint
 
 node_templates:
     test:


### PR DESCRIPTION
- Due to naming limitation of the host agent name