### PR TITLE
CY-821 Allow resuming failed/cancelled executions

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -25,6 +25,7 @@ from flask import current_app
 from flask_security import current_user
 
 from cloudify import constants as cloudify_constants, utils as cloudify_utils
+from cloudify.workflows import tasks as cloudify_tasks
 from cloudify.models_states import (SnapshotState,
                                     ExecutionState,
                                     VisibilityState,
@@ -466,10 +467,42 @@ class ResourceManager(object):
         else:
             return self.sm.delete(deployment)
 
-    def resume_execution(self, execution_id):
-        execution = self.sm.list(
-            models.Execution, filters={'id': execution_id},
-            get_all_results=True)[0]
+    def _reset_failed_operations(self, execution):
+        """Force-resume the execution: restart failed operations.
+
+        All operations that were failed are going to be retried,
+        the execution itself is going to be set to pending again.
+
+        :return: Whether to continue with running the execution
+        """
+        if execution.status in (ExecutionState.FAILED,
+                                ExecutionState.CANCELLED):
+            execution.status = ExecutionState.PENDING
+            self.sm.update(execution, modified_attrs=('status',))
+        else:
+            return False
+
+        tasks_graphs = self.sm.list(models.TasksGraph,
+                                    filters={'execution': execution},
+                                    get_all_results=True)
+        for graph in tasks_graphs:
+            operations = self.sm.list(models.Operation,
+                                      filters={'tasks_graph': graph},
+                                      get_all_results=True)
+            for operation in operations:
+                if operation.state in (cloudify_tasks.TASK_RESCHEDULED,
+                                       cloudify_tasks.TASK_FAILED):
+                    operation.state = cloudify_tasks.TASK_PENDING
+                    operation.parameters['current_retries'] = 0
+                    self.sm.update(operation,
+                                   modified_attrs=('parameters', 'state'))
+
+    def resume_execution(self, execution_id, force=False):
+        execution = self.sm.get(models.Execution, execution_id)
+        if force:
+            if not self._reset_failed_operations(execution):
+                return execution
+
         if execution.status in ExecutionState.END_STATES or \
                 execution.status in ExecutionState.QUEUED_STATE:
             raise manager_exceptions.ConflictError(

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -499,14 +499,14 @@ class ResourceManager(object):
             if execution.status not in (ExecutionState.CANCELLED,
                                         ExecutionState.FAILED):
                 raise manager_exceptions.ConflictError(
-                    'Cannot force-resume execution in state {0}'
-                    .format(execution.status))
+                    'Cannot force-resume execution: `{0}` in state: `{1}`'
+                    .format(execution.id, execution.status))
             self._reset_failed_operations(execution)
 
         if execution.status != ExecutionState.STARTED:
             raise manager_exceptions.ConflictError(
-                'Cannot resume execution in state {0}'
-                .format(execution.status))
+                'Cannot resume execution: `{0}` in state: `{1}`'
+                .format(execution.id, execution.status))
         self.sm.update(execution)
 
         workflow_id = execution.workflow_id

--- a/rest-service/manager_rest/rest/resources_v1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v1/executions.py
@@ -174,15 +174,17 @@ class ExecutionsId(SecuredResource):
         request_dict = get_json_and_verify_params({'action'})
         action = request_dict['action']
 
-        valid_actions = ['cancel', 'force-cancel', 'kill', 'resume']
+        valid_actions = ['cancel', 'force-cancel', 'kill', 'resume',
+                         'force-resume']
 
         if action not in valid_actions:
             raise manager_exceptions.BadParametersError(
                 'Invalid action: {0}, Valid action values are: {1}'.format(
                     action, valid_actions))
 
-        if action == 'resume':
-            return get_resource_manager().resume_execution(execution_id)
+        if action in ('resume', 'force-resume'):
+            return get_resource_manager().resume_execution(
+                execution_id, force=action == 'force-resume')
         return get_resource_manager().cancel_execution(
             execution_id, action == 'force-cancel', action == 'kill')
 

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -806,6 +806,8 @@ class ExecutionsTestCase(BaseServerTestCase):
         self.assertIn(execution.status,
                       (ExecutionState.STARTED, ExecutionState.TERMINATED))
 
+    @attr(client_min_version=3.1,
+          client_max_version=LATEST_API_VERSION)
     def test_resume_force_failed(self):
         """Force-resume resets operation state and restart count"""
         _, deployment_id, _, _ = self.put_deployment(
@@ -813,6 +815,8 @@ class ExecutionsTestCase(BaseServerTestCase):
         deployment = self.sm.get(models.Deployment, deployment_id)
         self._execution_resume_test(deployment, ExecutionState.FAILED)
 
+    @attr(client_min_version=3.1,
+          client_max_version=LATEST_API_VERSION)
     def test_resume_force_cancelled(self):
         """Force-resume resets operation state and restart count"""
         _, deployment_id, _, _ = self.put_deployment(
@@ -820,6 +824,8 @@ class ExecutionsTestCase(BaseServerTestCase):
         deployment = self.sm.get(models.Deployment, deployment_id)
         self._execution_resume_test(deployment, ExecutionState.CANCELLED)
 
+    @attr(client_min_version=3.1,
+          client_max_version=LATEST_API_VERSION)
     def test_resume_failed_no_force(self):
         """Cannot non-force-resume a failed execution"""
         _, deployment_id, _, _ = self.put_deployment(
@@ -840,6 +846,8 @@ class ExecutionsTestCase(BaseServerTestCase):
         self.assertEqual(cm.exception.status_code, 409)
         self.assertIn('Cannot resume execution', str(cm.exception))
 
+    @attr(client_min_version=3.1,
+          client_max_version=LATEST_API_VERSION)
     def test_resume_invalid_state(self):
         """Resuming is allowed in the STARTED state"""
         _, deployment_id, _, _ = self.put_deployment(
@@ -868,6 +876,8 @@ class ExecutionsTestCase(BaseServerTestCase):
             self.assertEqual(cm.exception.status_code, 409)
             self.assertIn('Cannot resume execution', str(cm.exception))
 
+    @attr(client_min_version=3.1,
+          client_max_version=LATEST_API_VERSION)
     def test_force_resume_invalid_state(self):
         """Force-resuming is allowed in the FAILED, CANCELLED  states
         """

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -818,7 +818,7 @@ class ExecutionsTestCase(BaseServerTestCase):
         _, deployment_id, _, _ = self.put_deployment(
             self.DEPLOYMENT_ID, 'empty_blueprint.yaml')
         deployment = self.sm.get(models.Deployment, deployment_id)
-        self._execution_resume_test(deployment, ExecutionState.FAILED)
+        self._execution_resume_test(deployment, ExecutionState.CANCELLED)
 
     def test_resume_failed_no_force(self):
         """Cannot non-force-resume a failed execution"""


### PR DESCRIPTION
Resuming a failed/cancelled executions (needs to be done manually,
and is called a "force resume" as opposed to a regular automatic
"resume" which happens on mgmtworker restarts) resets the failed
operations to pending and sets their restart count to 0.