### PR TITLE
Restore the admin token after restoring the admin user

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -51,6 +51,7 @@ from .es_snapshot import ElasticSearch
 from .credentials import restore as restore_credentials
 from .constants import (
     ADMIN_DUMP_FILE,
+    ADMIN_TOKEN_SCRIPT,
     ARCHIVE_CERT_DIR,
     CERT_DIR,
     HASH_SALT_FILENAME,
@@ -418,6 +419,9 @@ class SnapshotRestore(object):
         # We have to do this after the restore process or it'll break the
         # workflow execution updating and thus cause the workflow to fail
         self._post_restore_commands.append(command)
+        # recreate the admin REST token file
+        self._post_restore_commands.append(
+            ['sudo', ADMIN_TOKEN_SCRIPT])
 
     def _get_admin_user_token(self):
         return self._load_admin_dump()['api_token_key']
@@ -474,7 +478,6 @@ class SnapshotRestore(object):
         self._restore_security_file()
         utils.restore_stage_files(self._tempdir, stage_restore_override)
         utils.restore_composer_files(self._tempdir)
-        utils.recreate_mgmtworker_token()
         ctx.logger.info('Successfully restored archive files')
 
     def _restore_security_file(self):

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -421,7 +421,7 @@ class SnapshotRestore(object):
         self._post_restore_commands.append(command)
         # recreate the admin REST token file
         self._post_restore_commands.append(
-            ['sudo', ADMIN_TOKEN_SCRIPT])
+            'sudo {0}'.format(ADMIN_TOKEN_SCRIPT))
 
     def _get_admin_user_token(self):
         return self._load_admin_dump()['api_token_key']

--- a/workflows/cloudify_system_workflows/snapshots/utils.py
+++ b/workflows/cloudify_system_workflows/snapshots/utils.py
@@ -129,15 +129,6 @@ def copy_stage_files(archive_root):
             os.path.join(archive_root, 'stage', folder))
 
 
-def recreate_mgmtworker_token():
-    """Recreate the admin_token file.
-
-    After the databasea snapshot has been restored, recreate the token
-    file with the new hash.
-    """
-    sudo([snapshot_constants.ADMIN_TOKEN_SCRIPT])
-
-
 def restore_stage_files(archive_root, override=False):
     """Copy Cloudify Stage files from the snapshot archive to stage folder.
 


### PR DESCRIPTION
...not before, because that would create the token for the previous
admin user