### PR TITLE
Add a 'resume' kwarg to the workflow context

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -527,6 +527,7 @@ class ResourceManager(object):
             execution_parameters=execution.parameters,
             bypass_maintenance=False,
             dry_run=False,
+            resume=True,
             execution_creator=execution.creator)
         return execution
 

--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -38,7 +38,8 @@ def execute_workflow(name,
                      dry_run=False,
                      wait_after_fail=600,
                      execution_creator=None,
-                     scheduled_time=None):
+                     scheduled_time=None,
+                     resume=False):
 
     execution_parameters = execution_parameters or {}
     task_name = workflow['operation']
@@ -65,6 +66,7 @@ def execute_workflow(name,
         'dry_run': dry_run,
         'is_system_workflow': False,
         'wait_after_fail': wait_after_fail,
+        'resume': resume,
         'plugin': {
             'name': plugin_name,
             'package_name': plugin.get('package_name'),


### PR DESCRIPTION
So that workflows can know if they are being resumed or run for the
first time