### PR TITLE
Removed old validation interface

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -24,9 +24,6 @@ node_types:
         start: {}
         stop: {}
         delete: {}
-      cloudify.interfaces.validation:
-        creation: {}
-        deletion: {}
       cloudify.interfaces.monitoring:
         start: {}
         stop: {}


### PR DESCRIPTION
This validation was only used by the bootstrap process, in the pre-RPM era.
It has never been used in any workflow.
It should be removed.