### PR TITLE
Config loading: use the new array filtering method

### DIFF
--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -108,7 +108,10 @@ class Config(object):
     def load_from_db(self):
         from manager_rest.storage import models, get_storage_manager
         sm = get_storage_manager()
-        for conf_value in sm.list(models.Config, filters={'scope': 'rest'}):
+        stored_config = sm.list(models.Config, filters={
+            'scope': lambda column: column.contains(['rest'])
+        })
+        for conf_value in stored_config:
             setattr(self, conf_value.name, conf_value.value)
 
     def to_dict(self):


### PR DESCRIPTION
Use the same new way as in endpoint, to have a postgres array contains
operator (the @> operator)