### PR TITLE
Mgmtworker: don't resume executions on startup

### DIFF
--- a/mgmtworker/mgmtworker/worker.py
+++ b/mgmtworker/mgmtworker/worker.py
@@ -17,15 +17,8 @@
 import argparse
 import logging
 
-from cloudify_rest_client.exceptions import (
-    CloudifyClientError,
-)
-
 from cloudify.logs import setup_agent_logger
-from cloudify.models_states import ExecutionState
-from cloudify.manager import get_rest_client
 
-from cloudify.utils import get_admin_api_token
 from cloudify.amqp_client import AMQPConnection
 from cloudify_agent.worker import (
     ProcessRegistry,
@@ -44,38 +37,6 @@ def _setup_logger():
     global logger
     setup_agent_logger('mgmtworker')
     logger = logging.getLogger('mgmtworker')
-
-
-def _resume_stuck_executions():
-    """Resume executions that were in the STARTED state.
-
-    This runs after the mgmtworker has started, and will find and resume
-    all executions that are in the STARTED state, which would otherwise
-    become stuck.
-
-    For every tenant, query the executions, and for every execution in
-    STARTED state, resume it.
-
-    This uses the admin token.
-    """
-    admin_api_token = get_admin_api_token()
-    rest_client = get_rest_client(tenant='default_tenant',
-                                  api_token=admin_api_token)
-    tenants = rest_client.tenants.list()
-    for tenant in tenants:
-        tenant_client = get_rest_client(tenant=tenant.name,
-                                        api_token=admin_api_token)
-        for execution in tenant_client.executions.list(
-                status=ExecutionState.STARTED):
-            try:
-                tenant_client.executions.resume(execution.id)
-            except CloudifyClientError as e:
-                logger.warning('Could not resume execution {0} on '
-                               'tenant {1}: {2}'
-                               .format(execution.id, tenant.name, e))
-            else:
-                logger.info('Resuming execution {0} on tenant {1}'
-                            .format(execution.id, tenant.name))
 
 
 def make_amqp_worker(args):
@@ -107,7 +68,6 @@ def main():
 
     _setup_logger()
     _setup_cloudify_agent_logger('mgmtworker')
-    _resume_stuck_executions()
 
     worker = make_amqp_worker(args)
     worker.consume()


### PR DESCRIPTION
No need to do that, they will be executed again by virtue of
using late-acks