### PR TITLE
reset_operations: don't reset retried tasks

### DIFF
--- a/tests/integration_tests/resources/dsl/resumable_mgmtworker.yaml
+++ b/tests/integration_tests/resources/dsl/resumable_mgmtworker.yaml
@@ -13,6 +13,7 @@ node_templates:
         op_resumable: cloudmock.cloudmock.tasks.resumable
         op_nonresumable: cloudmock.cloudmock.tasks.nonresumable
         op_failing: cloudmock.cloudmock.tasks.failing
+        op_retrying: cloudmock.cloudmock.tasks.retrying_task
 
   node2:
     type: cloudify.nodes.Root
@@ -21,6 +22,7 @@ node_templates:
         op_resumable: cloudmock.cloudmock.tasks.mark_instance
         op_nonresumable: cloudmock.cloudmock.tasks.mark_instance
         op_failing: cloudmock.cloudmock.tasks.mark_instance
+        op_retrying: cloudmock.cloudmock.tasks.mark_instance
     relationships:
       - type: cloudify.relationships.depends_on
         target: node1

--- a/tests/integration_tests_plugins/cloudmock/tasks.py
+++ b/tests/integration_tests_plugins/cloudmock/tasks.py
@@ -45,6 +45,20 @@ def task_agent(ctx, wait_message, **kwargs):
     ctx.instance.runtime_properties['resumed'] = True
 
 
+@operation
+def retrying_task(ctx, **kwargs):
+    count = ctx.instance.runtime_properties.get('count', 0)
+
+    ctx.instance.runtime_properties['count'] = count + 1
+    ctx.instance.update()
+
+    count = ctx.instance.runtime_properties['count']
+    if count == 1:
+        return ctx.operation.retry()
+    elif count == 2:
+        raise NonRecoverableError('Error')
+
+
 @operation(resumable=True)
 def resumable(**kwargs):
     _resumable_task_base(**kwargs)


### PR DESCRIPTION
Tasks that are already retried don't need to be reset, because
there's a task retrying them that will run instead