### PR TITLE
Change the join of the get query to left outer join

### DIFF
--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -69,7 +69,7 @@ class SQLStorageManager(object):
             # If all columns should be returned, query directly from the model
             query = model_class.query
 
-        query = query.join(*joins)
+        query = query.outerjoin(*joins)
         return query
 
     @staticmethod


### PR DESCRIPTION
* Regular join ignores records with null value in a FK column

* For example, in the deployments table we have a nullable FK - site_name.
  When we get the deployments list the recordes with the null in site_name won't return.

* It happens only when we use this column name in _include, _sort or filters