### PR TITLE
Integration tests: use docker via unix socket, not tcp

### DIFF
--- a/tests/integration_tests/framework/docl.py
+++ b/tests/integration_tests/framework/docl.py
@@ -123,7 +123,7 @@ def init(expose=None, resources=None):
 def run_manager(label=None, tag=None):
     start = time.time()
     label = label or []
-    args = ['--mount']
+    args = ['--mount', '--mount-docker']
     if tag:
         args += ['--tag', tag]
     for l in label:

--- a/tests/integration_tests_plugins/dockercompute/operations.py
+++ b/tests/integration_tests_plugins/dockercompute/operations.py
@@ -159,13 +159,17 @@ def _wait_for_ssh_setup(container_id, retry_number=100, retry_interval=0.1):
 
 
 def _docker_exec(container_id, args, quiet=False):
-    return _docker('exec', '{0} {1}'.format(container_id, args), quiet=quiet)
+    return _docker('exec', [container_id] + args, quiet=quiet)
 
 
 def _docker(subcommand, args, quiet=False):
-    return _run('docker -H {0} {1} {2}'.format(_docker_conf()['docker_host'],
-                                               subcommand, args),
-                quiet=quiet)
+    command = ['docker']
+    docker_host = _docker_conf()['docker_host']
+    if docker_host:
+        command += ['-H', docker_host]
+    command.append(subcommand)
+    command += args
+    return _run(command, quiet=quiet)
 
 
 def _run(command, quiet=False):

--- a/tests/integration_tests_plugins/dockercompute/operations.py
+++ b/tests/integration_tests_plugins/dockercompute/operations.py
@@ -150,7 +150,7 @@ def _wait_for_ssh_setup(container_id, retry_number=100, retry_interval=0.1):
     for _ in range(retry_number):
         try:
             return _docker_exec(container_id,
-                                'cat {0}'.format(PUBLIC_KEY_CONTAINER_PATH),
+                                ['cat', PUBLIC_KEY_CONTAINER_PATH],
                                 quiet=True)
         except CommandExecutionException:
             time.sleep(retry_interval)


### PR DESCRIPTION
This allows running integration tests without the network setup