### PR TITLE
Resource authorization: fallback to resource_name permission 

### DIFF
--- a/rest-service/manager_rest/constants.py
+++ b/rest-service/manager_rest/constants.py
@@ -58,6 +58,9 @@ ALLOWED_LICENSE_ENDPOINTS = ALLOWED_ENDPOINTS + ['tokens', 'config', 'cluster',
 CLOUDIFY_AUTH_HEADER = 'Authorization'
 CLOUDIFY_AUTH_TOKEN_HEADER = 'Authentication-Token'
 BASIC_AUTH_PREFIX = 'Basic '
-MODELS_TO_PERMISSIONS = {'NodeInstance': 'node_instance'}
+MODELS_TO_PERMISSIONS = {
+    'NodeInstance': 'node_instance',
+    'TasksGraph': 'operations'
+}
 FORBIDDEN_METHODS = ['POST', 'PATCH', 'PUT']
 SANITY_MODE_FILE_PATH = '/opt/manager/sanity_mode'

--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -219,9 +219,14 @@ def tenant_specific_authorization(tenant, resource_name, action='list'):
     """
     resource_name = constants.MODELS_TO_PERMISSIONS.get(resource_name,
                                                         resource_name.lower())
-    permission_name = '{0}_{1}'.format(resource_name, action)
-    return current_user.has_role_in(
-        tenant, config.instance.authorization_permissions[permission_name])
+    try:
+        permission_name = '{0}_{1}'.format(resource_name, action)
+        permission_roles = \
+            config.instance.authorization_permissions[permission_name]
+    except KeyError:
+        permission_roles = \
+            config.instance.authorization_permissions[resource_name.lower()]
+    return current_user.has_role_in(tenant, permission_roles)
 
 
 def is_administrator(tenant):

--- a/tests/integration_tests/tests/test_cases.py
+++ b/tests/integration_tests/tests/test_cases.py
@@ -292,21 +292,18 @@ class BaseTestCase(unittest.TestCase):
                          wait_for_execution=True,
                          force=False,
                          queue=False,
+                         client=None,
                          **kwargs):
-        """
-        A blocking method which runs the requested workflow
-        """
-        client = test_utils.create_rest_client()
-
+        """A blocking method which runs the requested workflow"""
+        client = client or test_utils.create_rest_client()
         execution = client.executions.start(deployment_id, workflow_name,
                                             parameters=parameters or {},
                                             force=force, queue=queue, **kwargs)
-
         if wait_for_execution:
             BaseTestCase.wait_for_execution_to_end(
-                    execution,
-                    timeout_seconds=timeout_seconds)
-
+                execution,
+                client=client,
+                timeout_seconds=timeout_seconds)
         return execution
 
     @staticmethod


### PR DESCRIPTION
See commit messages.

This fixes the `KeyError: tasksgraph_list` error encountered when an operation
is retried, as a non-admin user