### PR TITLE
Fix for site validation when creating a deployment

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -144,9 +144,9 @@ class DeploymentsSetSite(SecuredResource):
 
 
 def _get_site_name(request_dict):
-    site_name = request_dict.get('site_name')
-    if site_name:
-        rest_utils.validate_inputs(
-            {'site_name': request_dict['site_name']}
-        )
+    if 'site_name' not in request_dict:
+        return None
+
+    site_name = request_dict['site_name']
+    rest_utils.validate_inputs({'site_name': site_name})
     return site_name


### PR DESCRIPTION
* Throws an error when site_name = '' instead of ignoring it