### PR TITLE
Tests: use config to set retries

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_subgraph_retries.py
+++ b/tests/integration_tests/tests/agentless_tests/test_subgraph_retries.py
@@ -20,7 +20,7 @@ from integration_tests.tests.utils import get_resource as resource
 
 
 class TaskRetriesTest(AgentlessTestCase):
-    def test_subgraph_retries_provider_config_config(self):
+    def test_subgraph_retries_config(self):
         self.client.manager.put_config('task_retries', 0)
         self.client.manager.put_config('task_retry_interval', 0)
         self.client.manager.put_config('subgraph_retries', 2)

--- a/tests/integration_tests/tests/agentless_tests/test_subgraph_retries.py
+++ b/tests/integration_tests/tests/agentless_tests/test_subgraph_retries.py
@@ -17,23 +17,14 @@ import uuid
 
 from integration_tests import AgentlessTestCase
 from integration_tests.tests.utils import get_resource as resource
-from integration_tests.tests import utils as test_utils
 
 
 class TaskRetriesTest(AgentlessTestCase):
-
-    def setUp(self):
-        super(TaskRetriesTest, self).setUp()
-        test_utils.delete_provider_context()
-
     def test_subgraph_retries_provider_config_config(self):
-        context = {'cloudify': {'workflows': {
-            'task_retries': 0,
-            'task_retry_interval': 0,
-            'subgraph_retries': 2
-        }}}
+        self.client.manager.put_config('task_retries', 0)
+        self.client.manager.put_config('task_retry_interval', 0)
+        self.client.manager.put_config('subgraph_retries', 2)
         deployment_id = 'd{0}'.format(uuid.uuid4())
-        self.client.manager.create_context(self._testMethodName, context)
         self.deploy_application(
             resource('dsl/workflow_subgraph_retries.yaml'),
             deployment_id=deployment_id)

--- a/tests/integration_tests/tests/agentless_tests/test_task_retries.py
+++ b/tests/integration_tests/tests/agentless_tests/test_task_retries.py
@@ -17,7 +17,6 @@ import uuid
 
 from integration_tests import AgentlessTestCase
 from integration_tests.tests.utils import get_resource as resource
-from integration_tests.tests import utils as test_utils
 
 INFINITY = -1
 
@@ -26,15 +25,11 @@ class TaskRetriesTest(AgentlessTestCase):
 
     def setUp(self):
         super(TaskRetriesTest, self).setUp()
-        test_utils.delete_provider_context()
         self.events = []
 
     def configure(self, retries, retry_interval):
-        context = {'cloudify': {'workflows': {
-            'task_retries': retries,
-            'task_retry_interval': retry_interval
-        }}}
-        self.client.manager.create_context(self._testMethodName, context)
+        self.client.manager.put_config('task_retries', retries)
+        self.client.manager.put_config('task_retry_interval', retry_interval)
 
     def test_retries_and_retry_interval(self):
         self._test_retries_and_retry_interval_impl(

--- a/tests/integration_tests/tests/agentless_tests/test_wf_api.py
+++ b/tests/integration_tests/tests/agentless_tests/test_wf_api.py
@@ -19,7 +19,6 @@ from cloudify_rest_client.executions import Execution
 
 from integration_tests import AgentlessTestCase
 from integration_tests.tests.utils import get_resource as resource
-from integration_tests.tests import utils as test_utils
 
 
 class WorkflowsAPITest(AgentlessTestCase):
@@ -30,12 +29,8 @@ class WorkflowsAPITest(AgentlessTestCase):
         self.configure(retries=2, interval=1)
 
     def configure(self, retries, interval):
-        test_utils.delete_provider_context()
-        context = {'cloudify': {'workflows': {
-            'task_retries': retries,
-            'task_retry_interval': interval
-        }}}
-        self.client.manager.create_context(self._testMethodName, context)
+        self.client.manager.put_config('task_retries', retries)
+        self.client.manager.put_config('task_retry_interval', interval)
 
     def test_simple(self):
         parameters = {


### PR DESCRIPTION
[ci skip] because CI doesn't test integration tests