### PR TITLE
CY-1444: handling creation of existing secrets

### DIFF
--- a/cloudify_types/cloudify_types/component/component.py
+++ b/cloudify_types/cloudify_types/component/component.py
@@ -21,7 +21,6 @@ from cloudify.exceptions import NonRecoverableError
 from cloudify_rest_client.client import CloudifyClient
 from cloudify_rest_client.exceptions import CloudifyClientError
 
-
 from .constants import (
     EXECUTIONS_TIMEOUT,
     POLLING_INTERVAL,

--- a/cloudify_types/cloudify_types/component/component.py
+++ b/cloudify_types/cloudify_types/component/component.py
@@ -36,8 +36,7 @@ from .utils import (
     deployment_id_exists,
     update_runtime_properties,
     get_local_path,
-    zip_files,
-    get_secret_by_name
+    zip_files
 )
 
 
@@ -231,17 +230,12 @@ class Component(object):
                             for secret in
                             self._http_client_wrapper('secrets', 'list')}
 
-        duplicate_secrets = set(self.secrets).intersection(set(existing_secrets))
+        duplicate_secrets = set(self.secrets).intersection(existing_secrets)
 
         if duplicate_secrets:
-            for secret_name in duplicate_secrets:
-                if existing_secrets[secret_name] != self.secrets[secret_name]:
-                    raise NonRecoverableError('Secret "{0}" already exists, '
-                                              'not updating...'.format(
-                                                ', '.join(duplicate_secrets)))
-                else:
-                    # No need to create it twice
-                    self.secrets.pop(secret_name)
+            raise NonRecoverableError('The secrets: {{ {0} }} already exist, '
+                                      'not updating...'.format(
+                                        ', '.join(duplicate_secrets)))
 
     def _set_secrets(self):
         if not self.secrets:

--- a/cloudify_types/cloudify_types/component/tests/client_mock.py
+++ b/cloudify_types/cloudify_types/component/tests/client_mock.py
@@ -77,6 +77,10 @@ class MockEventsClient(BaseMockClient):
     pass
 
 
+class MockSecretsClient(BaseMockClient):
+    pass
+
+
 class MockCloudifyRestClient(object):
 
     def __init__(self):
@@ -84,5 +88,5 @@ class MockCloudifyRestClient(object):
         self.deployments = MockDeploymentsClient()
         self.executions = MockExecutionsClient()
         self.events = MockEventsClient()
-        self.secrets = MagicMock()
+        self.secrets = MockSecretsClient()
         self.plugins = MagicMock()

--- a/cloudify_types/cloudify_types/component/tests/test_deployment.py
+++ b/cloudify_types/cloudify_types/component/tests/test_deployment.py
@@ -58,6 +58,7 @@ class TestDeployment(TestDeploymentBase):
 
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:
             mock_client.return_value = self.cfy_mock_client
+            self.cfy_mock_client.secrets.delete = mock.Mock()
 
             poll_with_timeout_test = \
                 'cloudify_types.component.polling.poll_with_timeout'
@@ -277,7 +278,7 @@ class TestComponentSecrets(TestDeploymentBase):
             self.cfy_mock_client.secrets.create.assert_called_with(key='a',
                                                                    value='b')
 
-    def test_create_deployment_with_existing_identical_secrets(self):
+    def test_create_deployment_with_existing_secrets(self):
         self._ctx.node.properties['secrets'] = {'a': 'b'}
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:
             self.cfy_mock_client.executions.set_existing_objects(
@@ -293,40 +294,13 @@ class TestComponentSecrets(TestDeploymentBase):
             ])
             mock_client.return_value = self.cfy_mock_client
 
-            poll_with_timeout_test = \
-                'cloudify_types.component.polling.poll_with_timeout'
-            with mock.patch(poll_with_timeout_test) as poll:
-                poll.return_value = True
-
-                output = create(operation='create_deployment',
-                                timeout=MOCK_TIMEOUT)
-                self.assertTrue(output)
-
-            assert not self.cfy_mock_client.secrets.create.called
-
-    def test_create_deployment_with_non_identical_existing_secrets(self):
-        self._ctx.node.properties['secrets'] = {'a': 'b'}
-        with mock.patch('cloudify.manager.get_rest_client') as mock_client:
-            self.cfy_mock_client.executions.set_existing_objects(
-                [{
-                    'id': 'exec_id',
-                    'workflow_id': 'create_deployment_environment',
-                    'deployment_id': 'dep'
-                }])
-
-            self.cfy_mock_client.secrets.create = mock.Mock()
-            self.cfy_mock_client.secrets.set_existing_objects([
-                self.Secret(key='a', value='not_the_same')
-            ])
-            mock_client.return_value = self.cfy_mock_client
-
             error = self.assertRaises(
                 NonRecoverableError,
                 create,
                 operation='create_deployment',
                 timeout=MOCK_TIMEOUT)
 
-            self.assertIn('Secret "a" already exists, not updating...',
+            self.assertIn('The secrets: { a } already exist, not updating...',
                           error.message)
 
             assert not self.cfy_mock_client.secrets.create.called

--- a/cloudify_types/cloudify_types/component/utils.py
+++ b/cloudify_types/cloudify_types/component/utils.py
@@ -133,3 +133,14 @@ def blueprint_id_exists(client, blueprint_id):
 def deployment_id_exists(client, deployment_id):
     deployment = get_deployment_by_id(client, deployment_id)
     return True if deployment else False
+
+
+@handle_client_exception('Fetching secret failed')
+def get_secret_by_name(client, secret_id):
+    """
+    Searching for deployment_id in all deployments in order to differentiate
+    not finding the deployment then other kinds of errors, like server
+    failure.
+    """
+    secrets = client.secrets.list(_include=['id'], id=secret_id)
+    return secrets[0] if secrets else None

--- a/cloudify_types/cloudify_types/component/utils.py
+++ b/cloudify_types/cloudify_types/component/utils.py
@@ -133,14 +133,3 @@ def blueprint_id_exists(client, blueprint_id):
 def deployment_id_exists(client, deployment_id):
     deployment = get_deployment_by_id(client, deployment_id)
     return True if deployment else False
-
-
-@handle_client_exception('Fetching secret failed')
-def get_secret_by_name(client, secret_id):
-    """
-    Searching for deployment_id in all deployments in order to differentiate
-    not finding the deployment then other kinds of errors, like server
-    failure.
-    """
-    secrets = client.secrets.list(_include=['id'], id=secret_id)
-    return secrets[0] if secrets else None


### PR DESCRIPTION
When trying to upload already existing secrets with the same value, we should pass else fail