### PR TITLE
amqp-postgres: drop None cached executions after every batch

### DIFF
--- a/amqp-postgres/amqp_postgres/postgres_publisher.py
+++ b/amqp-postgres/amqp_postgres/postgres_publisher.py
@@ -145,7 +145,8 @@ class DBLogEventPublisher(object):
         self.error_exit = None
 
     def _reset_cache(self):
-        self._executions_cache = LimitedSizeDict(10000)
+        self._executions_cache = LimitedSizeDict(100)
+
 
     def start(self):
         self.error_exit = None


### PR DESCRIPTION
After a batch, if an execution wasn't found, drop the fact that it
wasn't found from the cache, because it might well exist on the
next batch.