### PR TITLE
amqp-postgres: insert timestamp at utc

### DIFF
--- a/amqp-postgres/amqp_postgres/postgres_publisher.py
+++ b/amqp-postgres/amqp_postgres/postgres_publisher.py
@@ -50,12 +50,8 @@ EVENT_INSERT_QUERY = """
     VALUES %s
 """
 
-# we use now() and not 'AT UTC'
-# to align with insertions from storage manager
-# that uses UTC in the insert, but DB is changing
-# according to timezone in postgres.conf
 EVENT_VALUES_TEMPLATE = """(
-        now(),
+        now() at time zone 'utc',
         CAST (%(timestamp)s AS TIMESTAMP),
         %(execution_id)s,
         %(tenant_id)s,
@@ -90,9 +86,9 @@ LOG_INSERT_QUERY = """
         target_id)
     VALUES %s
 """
-# see comment above regarding now()
+
 LOG_VALUES_TEMPLATE = """(
-        now(),
+        now() at time zone 'utc',
         CAST (%(timestamp)s AS TIMESTAMP),
         %(execution_id)s,
         %(tenant_id)s,

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -21,7 +21,7 @@ from requests.exceptions import ConnectionError
 from integration_tests import AgentlessTestCase
 from integration_tests.framework.postgresql import run_query
 from integration_tests.tests.utils import get_resource as resource
-from integration_tests.framework import utils
+from integration_tests.framework import docl, utils
 from cloudify_rest_client.exceptions import CloudifyClientError
 
 from manager_rest.flask_utils import get_postgres_conf
@@ -231,6 +231,10 @@ class EventsAlternativeTimezoneTest(EventsTest):
             "ALTER USER {} SET TIME ZONE '{}'"
             .format(postgres_conf.username, cls.TIMEZONE)
         )
+        # restart all users of the db so that they get a new session which
+        # uses the just-set timezone
+        docl.execute(
+            "systemctl restart cloudify-amqp-postgres cloudify-restservice")
 
     def setUp(self):
         """Update postgres timezone and create a deployment."""


### PR DESCRIPTION
This reverts #1504

We only use the TIMESTAMP WITHOUT TIME ZONE type, and those are not
affected by the timezone setting. However, the now() function is.

This means that when we used now() without the `AT TIME ZONE`
specifier, we inserted timestamps at local timezone in amqp-postgres,
however we did insert timestamps at utc in the restservice side, due
to #1493

The comment was wrong when it said that the "DB is changing": the
DB timezone setting doesn't affect neither inserts or selects from
TIMESTAMP WITHOUT TIME ZONE columns, it only affects the output of
the now() function (and it also affects TIMESTAMP WITH TIME ZONE
columns, but we don't use those).