### PR TITLE
Integration tests: wait after starting snapshot-restore

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -462,6 +462,7 @@ class TestSnapshot(AgentlessTestCase):
         execution = rest_client.snapshots.restore(
             snapshot_id,
             ignore_plugin_failure=ignore_plugin_failure)
+        time.sleep(10)
         execution = self._wait_for_restore_execution_to_end(
             execution, rest_client)
         if execution.status == error_execution_status:


### PR DESCRIPTION
Otherwise, we can get deadlocks randomly.

This is a temporary measure, it should be fixed properly as CY-1455