### PR TITLE
Events integration test: allow some time to store events [ci skip]

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_events.py
+++ b/tests/integration_tests/tests/agent_tests/test_events.py
@@ -15,7 +15,7 @@
 
 import uuid
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from integration_tests import AgentTestWithPlugins
 from integration_tests.framework.postgresql import run_query
@@ -67,7 +67,9 @@ class TimezoneTest(AgentTestWithPlugins):
 
         start_timestamp = '{}Z'.format(datetime.utcnow().isoformat()[:-3])
         self.deploy_application(dsl_path, deployment_id=deployment_id)
-        stop_timestamp = '{}Z'.format(datetime.utcnow().isoformat()[:-3])
+        # log storing is async, add a few seconds to allow for that
+        stop_timestamp = '{}Z'.format(
+            (datetime.utcnow() + timedelta(seconds=3)).isoformat()[:-3])
 
         logs = self.client.events.list(
             include_logs=True,

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -16,7 +16,7 @@
 import uuid
 import time
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from requests.exceptions import ConnectionError
 from integration_tests import AgentlessTestCase
 from integration_tests.framework.postgresql import run_query
@@ -244,7 +244,9 @@ class EventsAlternativeTimezoneTest(EventsTest):
 
         self.start_timestamp = datetime.utcnow().isoformat()
         super(EventsAlternativeTimezoneTest, self).setUp()
-        self.stop_timestamp = datetime.utcnow().isoformat()
+        # log storing is async, add a few seconds to allow for that
+        self.stop_timestamp = \
+            (datetime.utcnow() + timedelta(seconds=3)).isoformat()
 
     def test_timestamp_in_utc(self):
         """Make sure events timestamp field is in UTC."""


### PR DESCRIPTION
Log/event storing is async, so allow additional time for it to
happen.

Integration tests arent tested in ci, therefore...
[ci skip]