### PR TITLE
Integration tests: wait_for_event match by substring

### DIFF
--- a/tests/integration_tests/tests/test_cases.py
+++ b/tests/integration_tests/tests/test_cases.py
@@ -493,7 +493,7 @@ class BaseTestCase(unittest.TestCase):
         client = client or self.client
         deadline = time.time() + timeout_seconds
         all_events = []
-        while message not in [e['message'] for e in all_events]:
+        while not any(message in e['message'] for e in all_events):
             time.sleep(0.5)
             if time.time() > deadline:
                 raise utils.TimeoutException(


### PR DESCRIPTION
Use `in` to match events by substring. This works for how it's used
in both the events tests and the resume tests

[ci skip]