### PR TITLE
Integration tests: agent resume tests - hardcode logs

### DIFF
--- a/tests/integration_tests_plugins/cloudmock/tasks.py
+++ b/tests/integration_tests_plugins/cloudmock/tasks.py
@@ -57,12 +57,12 @@ def _resumable_task_base(ctx):
 
 
 @operation
-def task_agent(ctx, wait_message, **kwargs):
+def task_agent(ctx, **kwargs):
     ctx.instance.runtime_properties['resumed'] = False
     ctx.instance.update()
-    ctx.logger.info(wait_message)
+    ctx.logger.info('BEFORE SLEEP')
     time.sleep(20)
-    ctx.logger.info(wait_message[::-1])
+    ctx.logger.info('AFTER SLEEP')
     ctx.instance.runtime_properties['resumed'] = True
 
 


### PR DESCRIPTION
When the logs are parametrized and sent as an argument, the "starting
operation" event log contains the arguments, so the wait_for_event
actually only waits for that - start of the operation, instead of
for the actual event to be sent.

Instead, just hardcode the messages, it's clear enough and no real
reason to parametrize them anyway