### PR TITLE
integration tests test_plugins_sort: don't install the plugins

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_rest_service_pagination.py
+++ b/tests/integration_tests/tests/agentless_tests/test_rest_service_pagination.py
@@ -93,11 +93,15 @@ class TestRestServiceListPagination(AgentlessTestCase):
                 f.write('from setuptools import setup\n')
                 f.write('setup(name="cloudify-script-plugin", version={0})'
                         .format(i))
-            wagon_path = wagon.create(tmpdir, archive_destination_dir=tmpdir)
+            wagon_path = wagon.create(
+                tmpdir, archive_destination_dir=tmpdir,
+                # mark the wagon as windows-only, so that the manager doesn't
+                # attempt to install it - which would be irrelevant for this
+                # test, but add additional flakyness and runtime
+                wheel_args=['--build-option', '--plat-name=win'])
             yaml_path = resource('plugins/plugin.yaml')
             with utils.zip_files([wagon_path, yaml_path]) as zip_path:
                 self.client.plugins.upload(zip_path)
-            self._wait_for_execution_by_wf_name('install_plugin')
             shutil.rmtree(tmpdir)
         self._test_pagination(self.client.plugins.list)
 

--- a/tests/integration_tests/tests/agentless_tests/test_rest_service_sort.py
+++ b/tests/integration_tests/tests/agentless_tests/test_rest_service_sort.py
@@ -80,11 +80,15 @@ class TestRestServiceListSort(AgentlessTestCase):
                 f.write('from setuptools import setup\n')
                 f.write('setup(name="cloudify-script-plugin", version={0})'
                         .format(i))
-            wagon_path = wagon.create(tmpdir, archive_destination_dir=tmpdir)
+            wagon_path = wagon.create(
+                tmpdir, archive_destination_dir=tmpdir,
+                # mark the wagon as windows-only, so that the manager doesn't
+                # attempt to install it - which would be irrelevant for this
+                # test, but add additional flakyness and runtime
+                wheel_args=['--build-option', '--plat-name=win'])
             yaml_path = resource('plugins/plugin.yaml')
             with utils.zip_files([wagon_path, yaml_path]) as zip_path:
                 self.client.plugins.upload(zip_path)
-            self._wait_for_execution_by_wf_name('install_plugin')
             shutil.rmtree(tmpdir)
         self._test_sort('plugins', 'id')
 


### PR DESCRIPTION
For sorting, installation is irrelevant, so don't do it.
By marking the wagon as requiring a platform different than the
manager (here: windows), the manager won't attempt to install it.

This also means the plugin-name-change mechanic (where we change the
plugin name from "x" to "installing-x" while it's being installed)
won't come into play, so this will prevent the test from failing
on an unexpected plugin name.