### PR TITLE
CY-1539: keeping blueprint_id in executions list

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/62a8d746d13b_5_0_to_5_0_5.py
+++ b/resources/rest-service/cloudify/migrations/versions/62a8d746d13b_5_0_to_5_0_5.py
@@ -1,0 +1,26 @@
+"""
+5_0 to 5_0_5
+
+
+Revision ID: 62a8d746d13b
+Revises: 423a1643f365
+Create Date: 2019-08-23 13:36:03.985636
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '62a8d746d13b'
+down_revision = '423a1643f365'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('executions', sa.Column('blueprint_id', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('executions', 'blueprint_id')

--- a/rest-service/manager_rest/deployment_update/manager.py
+++ b/rest-service/manager_rest/deployment_update/manager.py
@@ -590,10 +590,9 @@ class DeploymentUpdateManager(object):
                 execution_parameters),
             is_system_workflow=False
         )
-        if deployment:
-            new_execution.set_deployment(deployment,
-                                         deployment_update.new_blueprint_id)
-            deployment_update.execution = new_execution
+        new_execution.set_deployment(deployment,
+                                     deployment_update.new_blueprint_id)
+        deployment_update.execution = new_execution
         self.sm.put(new_execution)
 
         # executing the user workflow

--- a/rest-service/manager_rest/deployment_update/manager.py
+++ b/rest-service/manager_rest/deployment_update/manager.py
@@ -588,11 +588,11 @@ class DeploymentUpdateManager(object):
             error='',
             parameters=ResourceManager._get_only_user_execution_parameters(
                 execution_parameters),
-            is_system_workflow=False,
-            blueprint_id=deployment.blueprint_id
+            is_system_workflow=False
         )
         if deployment:
-            new_execution.set_deployment(deployment)
+            new_execution.set_deployment(deployment,
+                                         deployment_update.new_blueprint_id)
             deployment_update.execution = new_execution
         self.sm.put(new_execution)
 

--- a/rest-service/manager_rest/deployment_update/manager.py
+++ b/rest-service/manager_rest/deployment_update/manager.py
@@ -588,7 +588,8 @@ class DeploymentUpdateManager(object):
             error='',
             parameters=ResourceManager._get_only_user_execution_parameters(
                 execution_parameters),
-            is_system_workflow=False
+            is_system_workflow=False,
+            blueprint_id=deployment.blueprint_id
         )
         if deployment:
             new_execution.set_deployment(deployment)

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -952,7 +952,9 @@ class ResourceManager(object):
                 workflow_id=wf_id,
                 error='',
                 parameters=execution_parameters,
-                is_system_workflow=is_system_workflow)
+                is_system_workflow=is_system_workflow,
+                blueprint_id=deployment.blueprint_id
+            )
 
             if deployment:
                 execution.set_deployment(deployment)

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -666,7 +666,8 @@ class ResourceManager(object):
                 parameters=execution_parameters,
                 is_system_workflow=False,
                 is_dry_run=dry_run,
-                scheduled_for=scheduled_time
+                scheduled_for=scheduled_time,
+                blueprint_id=deployment.blueprint_id
             )
 
             if deployment:

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -952,9 +952,7 @@ class ResourceManager(object):
                 workflow_id=wf_id,
                 error='',
                 parameters=execution_parameters,
-                is_system_workflow=is_system_workflow,
-                blueprint_id=deployment.blueprint_id
-            )
+                is_system_workflow=is_system_workflow)
 
             if deployment:
                 execution.set_deployment(deployment)

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -666,8 +666,7 @@ class ResourceManager(object):
                 parameters=execution_parameters,
                 is_system_workflow=False,
                 is_dry_run=dry_run,
-                scheduled_for=scheduled_time,
-                blueprint_id=deployment.blueprint_id
+                scheduled_for=scheduled_time
             )
 
             if deployment:

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -669,8 +669,7 @@ class ResourceManager(object):
                 scheduled_for=scheduled_time
             )
 
-            if deployment:
-                new_execution.set_deployment(deployment)
+            new_execution.set_deployment(deployment)
         if should_queue and not scheduled_time:
             # Scheduled executions are passed to rabbit, no need to break here
             self.sm.put(new_execution)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -300,10 +300,12 @@ class Execution(CreatedAtMixin, SQLResourceBase):
         id_dict['status'] = self.status
         return id_dict
 
-    def set_deployment(self, deployment):
+    def set_deployment(self, deployment, blueprint_id=None):
         self._set_parent(deployment)
         self.deployment = deployment
-        self.blueprint_id = deployment.blueprint_id
+        current_blueprint_id = (blueprint_id if blueprint_id else
+                                deployment.blueprint_id)
+        self.blueprint_id = current_blueprint_id
 
     @classproperty
     def resource_fields(cls):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -303,6 +303,7 @@ class Execution(CreatedAtMixin, SQLResourceBase):
     def set_deployment(self, deployment):
         self._set_parent(deployment)
         self.deployment = deployment
+        self.blueprint_id = deployment.blueprint_id
 
     @classproperty
     def resource_fields(cls):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -279,7 +279,7 @@ class Execution(CreatedAtMixin, SQLResourceBase):
         return one_to_many_relationship(cls, Deployment, cls._deployment_fk)
 
     deployment_id = association_proxy('deployment', 'id')
-    blueprint_id = association_proxy('deployment', 'blueprint_id')
+    blueprint_id = db.Column(db.Text, nullable=True)
 
     @hybrid_property
     def status_display(self):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -303,8 +303,7 @@ class Execution(CreatedAtMixin, SQLResourceBase):
     def set_deployment(self, deployment, blueprint_id=None):
         self._set_parent(deployment)
         self.deployment = deployment
-        current_blueprint_id = (blueprint_id if blueprint_id else
-                                deployment.blueprint_id)
+        current_blueprint_id = blueprint_id or deployment.blueprint_id
         self.blueprint_id = current_blueprint_id
 
     @classproperty

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -806,7 +806,9 @@ class BaseServerTestCase(unittest.TestCase):
             created_at=utils.get_formatted_timestamp(),
             error='',
             parameters=dict(),
-            is_system_workflow=False)
+            is_system_workflow=False,
+            blueprint_id=deployment.blueprint_id
+        )
         execution.deployment = deployment
         return self.sm.put(execution)
 

--- a/rest-service/manager_rest/test/endpoints/test_deployment_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_updates.py
@@ -41,8 +41,7 @@ class DeploymentUpdatesBase(base_test.BaseServerTestCase):
                 **kwargs):
         blueprint_path = resource(os.path.join('deployment_update',
                                                'depup_step'))
-        blueprint_id = (blueprint_id if blueprint_id else
-                        'b-{0}'.format(uuid.uuid4()))
+        blueprint_id = blueprint_id or 'b-{0}'.format(uuid.uuid4())
         self.put_blueprint(blueprint_path, blueprint_name, blueprint_id)
         kwargs['blueprint_id'] = blueprint_id
         return self.put(

--- a/rest-service/manager_rest/test/endpoints/test_deployment_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_updates.py
@@ -131,8 +131,8 @@ class DeploymentUpdatesTestCase(DeploymentUpdatesBase):
                               len(execution.parameters[param]))
 
         executions = self.client.executions.list()
-        self.assertEqual('first', executions[1]['blueprint_id'])
-        self.assertEqual('blueprint', executions[0]['blueprint_id'])
+        self.assertEqual('first', executions[1].blueprint_id)
+        self.assertEqual('blueprint', executions[0].blueprint_id)
 
     def test_remove_node_and_relationship(self):
         deployment_id = 'dep'

--- a/rest-service/manager_rest/test/endpoints/test_deployment_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_updates.py
@@ -37,10 +37,12 @@ class DeploymentUpdatesBase(base_test.BaseServerTestCase):
     def _update(self,
                 deployment_id,
                 blueprint_name,
+                blueprint_id=None,
                 **kwargs):
         blueprint_path = resource(os.path.join('deployment_update',
                                                'depup_step'))
-        blueprint_id = 'b-{0}'.format(uuid.uuid4())
+        blueprint_id = (blueprint_id if blueprint_id else
+                        'b-{0}'.format(uuid.uuid4()))
         self.put_blueprint(blueprint_path, blueprint_name, blueprint_id)
         kwargs['blueprint_id'] = blueprint_id
         return self.put(
@@ -115,16 +117,22 @@ class DeploymentUpdatesTestCase(DeploymentUpdatesBase):
     def test_add_node_and_relationship(self):
         deployment_id = 'dep'
         changed_params = ['added_instance_ids', 'added_target_instances_ids']
-        self._deploy_base(deployment_id, 'one_node.yaml')
+        self._deploy_base(deployment_id,
+                          'one_node.yaml')
 
-        self._update(deployment_id, 'two_nodes.yaml')
+        self._update(deployment_id, 'two_nodes.yaml', 'first')
         dep_update = \
             self.client.deployment_updates.list(deployment_id=deployment_id,
                                                 _include=['execution_id'])[0]
         execution = self.client.executions.get(dep_update.execution_id)
+
         for param in self.execution_parameters:
             self.assertEquals(1 if param in changed_params else 0,
                               len(execution.parameters[param]))
+
+        executions = self.client.executions.list()
+        self.assertEqual('first', executions[1]['blueprint_id'])
+        self.assertEqual('blueprint', executions[0]['blueprint_id'])
 
     def test_remove_node_and_relationship(self):
         deployment_id = 'dep'
@@ -293,6 +301,7 @@ class DeploymentUpdatesTestCase(DeploymentUpdatesBase):
     def _deploy_base(self,
                      deployment_id,
                      blueprint_name,
+                     blueprint_id='blueprint',
                      inputs=None):
         blueprint_path = os.path.join('resources',
                                       'deployment_update',
@@ -300,7 +309,8 @@ class DeploymentUpdatesTestCase(DeploymentUpdatesBase):
         self.put_deployment(deployment_id,
                             inputs=inputs,
                             blueprint_file_name=blueprint_name,
-                            blueprint_dir=blueprint_path)
+                            blueprint_dir=blueprint_path,
+                            blueprint_id=blueprint_id)
 
     def test_storage_serialization_and_response(self):
         blueprint = self._add_blueprint()
@@ -440,7 +450,7 @@ class DeploymentUpdatesStepAndStageTestCase(base_test.BaseServerTestCase):
 
 
 @attr(client_min_version=3.1, client_max_version=base_test.LATEST_API_VERSION)
-class DeploymentUpdatesFromSourceTestCase(DeploymentUpdatesBase):
+class DeploymentUpdatesSourcePluginsTestCase(DeploymentUpdatesBase):
 
     def _deploy_base(self,
                      deployment_id,

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -100,7 +100,9 @@ class ExecutionsTestCase(BaseServerTestCase):
             created_at=utils.get_formatted_timestamp(),
             error='',
             parameters=dict(),
-            is_system_workflow=True)
+            is_system_workflow=True,
+            blueprint_id=blueprint_id
+        )
         deployment = self.sm.get(models.Deployment, deployment_id)
         system_wf_execution.deployment = deployment
         self.sm.put(system_wf_execution)
@@ -786,7 +788,8 @@ class ExecutionsTestCase(BaseServerTestCase):
             created_at=datetime.now(),
             is_system_workflow=False,
             workflow_id='install',
-            status=status
+            status=status,
+            blueprint_id=deployment.blueprint_id
         ))
         tasks_graph = self.sm.put(models.TasksGraph(
             _execution_fk=execution._storage_id,
@@ -845,7 +848,8 @@ class ExecutionsTestCase(BaseServerTestCase):
             _deployment_fk=deployment._storage_id,
             created_at=datetime.now(),
             is_system_workflow=False,
-            workflow_id='install'
+            workflow_id='install',
+            blueprint_id=deployment.blueprint_id
         ))
 
         for execution_status in [ExecutionState.PENDING,
@@ -874,7 +878,8 @@ class ExecutionsTestCase(BaseServerTestCase):
             _deployment_fk=deployment._storage_id,
             created_at=datetime.now(),
             is_system_workflow=False,
-            workflow_id='install'
+            workflow_id='install',
+            blueprint_id=deployment.blueprint_id
         ))
 
         for execution_status in [ExecutionState.PENDING,

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_misc.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_misc.py
@@ -72,10 +72,10 @@ class TestDeploymentUpdateMisc(DeploymentUpdateBase):
             deployment, remodification_bp_path, 2, True, 'second')
 
         executions = self.client.executions.list(is_descending=False)
-        self.assertEqual('start', executions[0]['blueprint_id'])
-        self.assertEqual('start', executions[1]['blueprint_id'])
-        self.assertEqual('first', executions[2]['blueprint_id'])
-        self.assertEqual('second', executions[3]['blueprint_id'])
+        self.assertEqual('start', executions[0].blueprint_id)
+        self.assertEqual('start', executions[1].blueprint_id)
+        self.assertEqual('first', executions[2].blueprint_id)
+        self.assertEqual('second', executions[3].blueprint_id)
 
     def test_modify_deployment_update_schema(self):
         # this test verifies that storage (elasticsearch) can deal with

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_misc.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_misc.py
@@ -33,7 +33,8 @@ class TestDeploymentUpdateMisc(DeploymentUpdateBase):
             'update_deployment_twice',
             'deployment_updated_twice_remodification.yaml')
 
-        deployment, _ = self.deploy_application(base_bp_path)
+        deployment, _ = self.deploy_application(base_bp_path,
+                                                blueprint_id='start')
         # assert initial deployment state
         deployment = self.client.deployments.get(deployment.id)
         self.assertDictContainsSubset({'custom_output': {'value': 0}},
@@ -43,8 +44,8 @@ class TestDeploymentUpdateMisc(DeploymentUpdateBase):
         def update_deployment_wait_and_assert(dep,
                                               bp_path,
                                               expected_output_value,
-                                              is_description_modified):
-            blueprint_id = 'b{0}'.format(uuid4())
+                                              is_description_modified,
+                                              blueprint_id):
             self.client.blueprints.upload(bp_path, blueprint_id)
             dep_update = \
                 self.client.deployment_updates.update_with_existing_blueprint(
@@ -65,10 +66,16 @@ class TestDeploymentUpdateMisc(DeploymentUpdateBase):
 
         # modify output and verify
         update_deployment_wait_and_assert(
-            deployment, modification_bp_path, 1, False)
+            deployment, modification_bp_path, 1, False, 'first')
         # modify output again and modify description
         update_deployment_wait_and_assert(
-            deployment, remodification_bp_path, 2, True)
+            deployment, remodification_bp_path, 2, True, 'second')
+
+        executions = self.client.executions.list(is_descending=False)
+        self.assertEqual('start', executions[0]['blueprint_id'])
+        self.assertEqual('start', executions[1]['blueprint_id'])
+        self.assertEqual('first', executions[2]['blueprint_id'])
+        self.assertEqual('second', executions[3]['blueprint_id'])
 
     def test_modify_deployment_update_schema(self):
         # this test verifies that storage (elasticsearch) can deal with


### PR DESCRIPTION
- Adding blueprint_id to Execution table

- Creating the migration script and adding the field
- Adding blueprint_id to relevant execution creation