### PR TITLE
CY-1711 Accessing operations: use the right cloudify-context

### DIFF
--- a/rest-service/manager_rest/deployment_update/handlers.py
+++ b/rest-service/manager_rest/deployment_update/handlers.py
@@ -193,12 +193,13 @@ class OperationHandler(ModifiableEntityHandlerBase):
 
         def _filter_operation(column):
             # path in the parameters dict that stores the node name
-            node_name_path = ('task_kwargs', 'cloudify_context', 'node_name')
+            node_name_path = ('task_kwargs', 'kwargs',
+                              '__cloudify_context', 'node_name')
             # ..and the operation interface name,
             # eg. cloudify.interfaces.lifecycle.create
             # (NOT eg. script.runner.tasks.run)
-            operation_name_path = ('task_kwargs', 'cloudify_context',
-                                   'operation', 'name')
+            operation_name_path = ('task_kwargs', 'kwargs',
+                                   '__cloudify_context', 'operation', 'name')
             # this will use postgres' json operators
             json_column = cast(column, JSON)
             return and_(
@@ -236,8 +237,6 @@ class OperationHandler(ModifiableEntityHandlerBase):
             try:
                 op.parameters['task_kwargs']['kwargs'].update(new_op_inputs)
                 op.parameters['task_kwargs']['kwargs']['__cloudify_context'][
-                    'has_intrinsic_functions'] = True
-                op.parameters['task_kwargs']['cloudify_context'][
                     'has_intrinsic_functions'] = True
             except KeyError:
                 continue

--- a/tests/integration_tests/tests/agentless_tests/test_depends_on_lifecycle_operation.py
+++ b/tests/integration_tests/tests/agentless_tests/test_depends_on_lifecycle_operation.py
@@ -80,14 +80,14 @@ node_templates:
                 operations_id[op.id]['dependencies'] = op.dependencies
                 operations_id[op.id]['info'] = op.info
 
-                task_kwargs = op.parameters.get('task_kwargs', {})
-                if task_kwargs.get('cloudify_context', None):
-                    node_task = op.parameters['task_kwargs']
-                    cloudify_context = node_task['cloudify_context']
-                    op_name = cloudify_context['operation']['name']
-                    node_name = cloudify_context['node_name']
-                    operations_info[(op_name,
-                                     node_name)] = op.containing_subgraph
+                try:
+                    cloudify_context = op.parameters['task_kwargs'][
+                        'kwargs']['__clooudify_context']
+                except KeyError:
+                    continue
+                op_name = cloudify_context['operation']['name']
+                node_name = cloudify_context['node_name']
+                operations_info[(op_name, node_name)] = op.containing_subgraph
 
         # Doest not matter from what operation the node's main subgraph id
         # will be taken from.


### PR DESCRIPTION
The context used to be duplicated in task_kwargs.cloudify_context and
in task_kwargs.kwargs.__cloudify_context.

Now it's only the latter, so stop using the first one, which doesn't
exist anymore.