### PR TITLE
Plugin update failure

### DIFF
--- a/rest-service/manager_rest/deployment_update/manager.py
+++ b/rest-service/manager_rest/deployment_update/manager.py
@@ -546,7 +546,8 @@ class DeploymentUpdateManager(object):
             workflow_id or DEFAULT_DEPLOYMENT_UPDATE_WORKFLOW,
             blueprint_id=dep_update.new_blueprint_id,
             parameters=parameters,
-            allow_custom_parameters=True
+            allow_custom_parameters=True,
+            allow_overlapping_running_wf=True
         )
 
     def finalize_commit(self, deployment_update_id):

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -629,7 +629,8 @@ class ResourceManager(object):
                          execution=None,
                          wait_after_fail=600,
                          execution_creator=None,
-                         scheduled_time=None):
+                         scheduled_time=None,
+                         allow_overlapping_running_wf=False):
         execution_creator = execution_creator or current_user
         deployment = self.sm.get(models.Deployment, deployment_id)
         self._validate_permitted_to_execute_global_workflow(deployment)
@@ -656,8 +657,13 @@ class ResourceManager(object):
 
             execution_id = str(uuid.uuid4())
 
-        should_queue = self.check_for_executions(deployment_id, force, queue,
-                                                 execution, scheduled_time)
+        should_queue = queue
+        if not allow_overlapping_running_wf:
+            should_queue = self.check_for_executions(deployment_id,
+                                                     force,
+                                                     queue,
+                                                     execution,
+                                                     scheduled_time)
         if not execution:
             new_execution = models.Execution(
                 id=execution_id,


### PR DESCRIPTION
Allowing again dep update wf to manage itself in regards to wf overlapping (which we prevent in the basic execute_wf), this is due to that plugins update needs to run multi-dep update wf.