### PR TITLE
status endpoint - fix services check

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/status.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/status.py
@@ -113,8 +113,9 @@ class Status(SecuredResourceReadonlyMode):
         statuses = []
         for service in systemd_services:
             if should_be_in_services_output(service, OPTIONAL_SERVICES):
-                status = ACTIVE_STATE if service['instances'][0]['state'] == \
-                                         'running' else INACTIVE_STATE
+                is_service_running = service['instances'] and (
+                        service['instances'][0]['state'] == 'running')
+                status = ACTIVE_STATE if is_service_running else INACTIVE_STATE
                 services[service['display_name']] = {
                     'status': status,
                     'is_external': False,


### PR DESCRIPTION
If a service that is run by systemd is not up yet, it's in falied state and no need to use uninit data