### PR TITLE
IPSetter: only reload nginx if it is up

### DIFF
--- a/packaging/ip_setter/files/opt/cloudify/manager-ip-setter/manager-ip-setter.sh
+++ b/packaging/ip_setter/files/opt/cloudify/manager-ip-setter/manager-ip-setter.sh
@@ -26,7 +26,8 @@ function set_manager_ip() {
 
   echo "Creating internal SSL certificates.."
   cfy_manager create-internal-certs --manager-hostname $(hostname -s)
-  systemctl reload nginx
+  # reload nginx only if it is up
+  systemctl status nginx && systemctl reload nginx || echo "Nginx not up, not reloading"
   echo "Done!"
 
 }


### PR DESCRIPTION
No reason to otherwise, and it actually breaks (returns 1) if it's not up