### PR TITLE
Revert "IPSetter: reload nginx" - move to cfy_manager

### DIFF
--- a/packaging/ip_setter/files/opt/cloudify/manager-ip-setter/manager-ip-setter.sh
+++ b/packaging/ip_setter/files/opt/cloudify/manager-ip-setter/manager-ip-setter.sh
@@ -26,7 +26,7 @@ function set_manager_ip() {
 
   echo "Creating internal SSL certificates.."
   cfy_manager create-internal-certs --manager-hostname $(hostname -s)
-  systemctl reload nginx
+
   echo "Done!"
 
 }


### PR DESCRIPTION
Reverts cloudify-cosmo/cloudify-manager#1953

We'll be moving the reload to `cfy_manager create-internal-certs` instead