### PR TITLE
CY-1804: making brokers endpoint to support readonly setup

### DIFF
--- a/rest-service/manager_rest/security/__init__.py
+++ b/rest-service/manager_rest/security/__init__.py
@@ -20,6 +20,7 @@ from .secured_resource import (  # NOQA
     MissingPremiumFeatureResource,
     premium_only,
     allow_on_community,
-    SecuredResourceReadonlyMode
+    SecuredResourceReadonlyMode,
+    authenticate
 )
 from .authorization import is_user_action_allowed  # NOQA


### PR DESCRIPTION
- In case of redonly setup of the manager, there is a need to access GET /brokers endpoint.
So this endpoint needs to allow readonly for that and that alone.