### PR TITLE
CY-1752: fixing blueprint upload race cond

### DIFF
--- a/cloudify_types/cloudify_types/component/component.py
+++ b/cloudify_types/cloudify_types/component/component.py
@@ -144,7 +144,8 @@ class Component(object):
                 application_file_name=self.blueprint_file_name)
         except CloudifyClientError as ex:
             if 'already exists' not in str(ex):
-                raise NonRecoverableError('Client action "_upload" failed: {0}.'.format(ex))
+                raise NonRecoverableError(
+                    'Client action "_upload" failed: {0}.'.format(ex))
         return True
 
     def upload_blueprint(self):

--- a/cloudify_types/cloudify_types/component/component.py
+++ b/cloudify_types/cloudify_types/component/component.py
@@ -332,7 +332,7 @@ class Component(object):
         try:
             self.client.plugins.delete(plugin_id=plugin_id)
         except CloudifyClientError as ex:
-            if 'currently in use in blueprints' in ex.message:
+            if 'currently in use in blueprints' in str(ex):
                 ctx.logger.warn('Could not remove plugin "{0}", it '
                                 'is currently in use...'.format(plugin_id))
             else:

--- a/cloudify_types/cloudify_types/component/component.py
+++ b/cloudify_types/cloudify_types/component/component.py
@@ -170,6 +170,14 @@ class Component(object):
         elif self.blueprint.get(EXTERNAL_RESOURCE) and blueprint_exists:
             ctx.logger.info("Using external blueprint.")
             return True
+        elif blueprint_exists:
+            ctx.logger.info(
+                'Blueprint ID "{0}" exists, '
+                'but {1} is {2}, will use the existing one.'.format(
+                    self.blueprint_id,
+                    EXTERNAL_RESOURCE,
+                    self.blueprint.get(EXTERNAL_RESOURCE)))
+            return True
         if not self.blueprint_archive:
             raise NonRecoverableError(
                 'No blueprint_archive supplied, '

--- a/cloudify_types/cloudify_types/component/component.py
+++ b/cloudify_types/cloudify_types/component/component.py
@@ -143,9 +143,8 @@ class Component(object):
                 archive_location=self.blueprint_archive,
                 application_file_name=self.blueprint_file_name)
         except CloudifyClientError as ex:
-            if 'already exists' in ex._message:
-                return False
-            raise NonRecoverableError('Client action "_upload" failed: {0}.'.format(ex))
+            if 'already exists' not in str(ex):
+                raise NonRecoverableError('Client action "_upload" failed: {0}.'.format(ex))
         return True
 
     def upload_blueprint(self):
@@ -168,8 +167,8 @@ class Component(object):
                     EXTERNAL_RESOURCE,
                     self.blueprint.get(EXTERNAL_RESOURCE)))
         elif self.blueprint.get(EXTERNAL_RESOURCE) and blueprint_exists:
-            ctx.logger.info("Used external blueprint.")
-            return False
+            ctx.logger.info("Using external blueprint.")
+            return True
         if not self.blueprint_archive:
             raise NonRecoverableError(
                 'No blueprint_archive supplied, '

--- a/cloudify_types/cloudify_types/component/tests/test_blueprint_handling.py
+++ b/cloudify_types/cloudify_types/component/tests/test_blueprint_handling.py
@@ -50,7 +50,7 @@ class TestBlueprint(ComponentTestBase):
                                       operation='upload_blueprint',
                                       **self.resource_config)
 
-            self.assertIn('action "_upload" failed', error.message)
+            self.assertIn('action "_upload" failed', str(error))
 
     def test_upload_blueprint_rest_client_error(self):
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:
@@ -171,5 +171,5 @@ class TestBlueprint(ComponentTestBase):
                                       operation='upload_blueprint',
                                       **self.resource_config)
 
-            self.assertIn('Blueprint ID \"{0}\" does not exist'.format('test'),
-                          error.message)
+            self.assertIn('Blueprint ID \"{0}\" does not exist'.format(
+                'test'), str(error))

--- a/cloudify_types/cloudify_types/component/tests/test_blueprint_handling.py
+++ b/cloudify_types/cloudify_types/component/tests/test_blueprint_handling.py
@@ -52,6 +52,24 @@ class TestBlueprint(ComponentTestBase):
 
             self.assertIn('action "_upload" failed', error.message)
 
+    def test_upload_blueprint_rest_client_error(self):
+        with mock.patch('cloudify.manager.get_rest_client') as mock_client:
+            self.cfy_mock_client.blueprints._upload = REST_CLIENT_EXCEPTION
+            mock_client.return_value = self.cfy_mock_client
+
+            blueprint_params = dict()
+            blueprint_params['blueprint'] = {}
+            blueprint_params['blueprint']['blueprint_id'] = 'blu_name'
+            blueprint_params['blueprint']['blueprint_archive'] = self.archive
+            self.resource_config['resource_config'] = blueprint_params
+
+            error = self.assertRaises(NonRecoverableError,
+                                      upload_blueprint,
+                                      operation='upload_blueprint',
+                                      **self.resource_config)
+
+            self.assertIn('action "_upload" failed', error.message)
+
     def test_upload_blueprint_exists(self):
         blueprint_id = 'blu_name'
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:
@@ -120,7 +138,7 @@ class TestBlueprint(ComponentTestBase):
                                       **self.resource_config)
             self.assertFalse(output)
 
-    def test_fail_uploading_existing_blueprint_id_when_using_external(self):
+    def test_not_fail_uploading_existing_blueprint_id_when_using_external(self):
         blueprint_id = 'blu_name'
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:
             self.cfy_mock_client.blueprints.set_existing_objects(
@@ -136,7 +154,7 @@ class TestBlueprint(ComponentTestBase):
             mock_client.return_value = self.cfy_mock_client
             output = upload_blueprint(operation='upload_blueprint',
                                       **self.resource_config)
-            self.assertFalse(output)
+            self.assertTrue(output)
 
     def test_upload_blueprint_use_not_existing_external(self):
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:

--- a/cloudify_types/cloudify_types/component/tests/test_blueprint_handling.py
+++ b/cloudify_types/cloudify_types/component/tests/test_blueprint_handling.py
@@ -52,10 +52,11 @@ class TestBlueprint(ComponentTestBase):
 
             self.assertIn('action "_upload" failed', str(error))
 
-    def test_upload_existing_blueprint_and_skipping_failure(self):
+    def test_successful_upload_existing_blueprint(self):
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:
             self.cfy_mock_client.blueprints._upload = (
-                mock.MagicMock(side_effect=CloudifyClientError('already exists')))
+                mock.MagicMock(
+                    side_effect=CloudifyClientError('already exists')))
             mock_client.return_value = self.cfy_mock_client
 
             blueprint_params = dict()
@@ -64,24 +65,6 @@ class TestBlueprint(ComponentTestBase):
             blueprint_params['blueprint']['blueprint_archive'] = self.archive
             self.resource_config['resource_config'] = blueprint_params
 
-            output = upload_blueprint(operation='upload_blueprint',
-                                      **self.resource_config)
-            self.assertTrue(output)
-
-    def test_upload_external_blueprint_exists_cont_install(self):
-        blueprint_id = 'blu_name'
-        with mock.patch('cloudify.manager.get_rest_client') as mock_client:
-            self.cfy_mock_client.blueprints.set_existing_objects(
-                [{'id': blueprint_id}])
-
-            blueprint_params = dict()
-            blueprint_params['blueprint'] = {}
-            blueprint_params['blueprint']['id'] = blueprint_id
-            blueprint_params['blueprint']['blueprint_archive'] = self.archive
-            blueprint_params['blueprint'][EXTERNAL_RESOURCE] = True
-            self.resource_config['resource_config'] = blueprint_params
-
-            mock_client.return_value = self.cfy_mock_client
             output = upload_blueprint(operation='upload_blueprint',
                                       **self.resource_config)
             self.assertTrue(output)
@@ -117,7 +100,7 @@ class TestBlueprint(ComponentTestBase):
             self.assertIn('No blueprint_archive supplied, but '
                           'external_resource is False', str(error))
 
-    def test_not_fail_uploading_existing_blueprint_id_when_using_external(self):
+    def test_uploading_existing_blueprint_id_when_using_external(self):
         blueprint_id = 'blu_name'
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:
             self.cfy_mock_client.blueprints.set_existing_objects(

--- a/cloudify_types/cloudify_types/component/tests/test_blueprint_handling.py
+++ b/cloudify_types/cloudify_types/component/tests/test_blueprint_handling.py
@@ -61,7 +61,7 @@ class TestBlueprint(ComponentTestBase):
 
             blueprint_params = dict()
             blueprint_params['blueprint'] = {}
-            blueprint_params['blueprint']['blueprint_id'] = 'blu_name'
+            blueprint_params['blueprint']['id'] = 'blu_name'
             blueprint_params['blueprint']['blueprint_archive'] = self.archive
             self.resource_config['resource_config'] = blueprint_params
 

--- a/cloudify_types/cloudify_types/component/tests/test_deployment.py
+++ b/cloudify_types/cloudify_types/component/tests/test_deployment.py
@@ -323,7 +323,7 @@ class TestComponentPlugins(TestDeploymentBase):
                     timeout=MOCK_TIMEOUT)
 
                 self.assertIn('Failed to remove plugin "plugin_id"....',
-                              error.message)
+                              str(error))
 
             self.cfy_mock_client.plugins.delete.assert_called_with(
                 plugin_id='plugin_id')

--- a/cloudify_types/cloudify_types/component/tests/test_execute.py
+++ b/cloudify_types/cloudify_types/component/tests/test_execute.py
@@ -64,8 +64,7 @@ class TestExecute(ComponentTestBase):
                                       execute_start,
                                       deployment_id='dep_name',
                                       workflow_id='install')
-            self.assertIn('action "start" failed',
-                          error.message)
+            self.assertIn('action "start" failed', str(error))
 
     def test_execute_start_timeout(self):
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:
@@ -75,7 +74,7 @@ class TestExecute(ComponentTestBase):
                                       deployment_id='dep_name',
                                       workflow_id='install',
                                       timeout=MOCK_TIMEOUT)
-            self.assertIn('Execution timed out', error.message)
+            self.assertIn('Execution timed out', str(error))
 
     def test_execute_start_succeeds(self):
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:

--- a/cloudify_types/cloudify_types/component/tests/test_polling.py
+++ b/cloudify_types/cloudify_types/component/tests/test_polling.py
@@ -78,7 +78,7 @@ class TestPolling(ComponentTestBase):
         output = self.assertRaises(NonRecoverableError,
                                    is_all_executions_finished,
                                    self.cfy_mock_client)
-        self.assertIn('failed', output.message)
+        self.assertIn('failed', str(output))
 
     def test_dep_workflow_in_state_pollster_no_execution_given(self):
         self.assertRaises(NonRecoverableError,
@@ -154,7 +154,7 @@ class TestPolling(ComponentTestBase):
                                    'dep_name',
                                    'terminated',
                                    'exe_id')
-        self.assertIn('failed', output.message)
+        self.assertIn('failed', str(output))
 
     def test_component_logs_redirect_predefined_level(self):
         self.cfy_mock_client.events.set_existing_objects([{


### PR DESCRIPTION
When we scale a Component with uploading a blueprint, one
Component will finish uploading it's blueprint with the same name and fail the others.
So when we catch the error, we will cont as usual.