### PR TITLE
CY-1890 Fix allowed specific endpoints check in maintenance mode or with no license

### DIFF
--- a/rest-service/manager_rest/constants.py
+++ b/rest-service/manager_rest/constants.py
@@ -54,7 +54,8 @@ SECURITY_FILE_LOCATION = '/opt/manager/rest-security.conf'
 
 LOCAL_ADDRESS = '127.0.0.1'
 ALLOWED_ENDPOINTS = ['status', 'version', 'license', 'maintenance']
-ALLOWED_MAINTENANCE_ENDPOINTS = ALLOWED_ENDPOINTS + ['snapshots']
+ALLOWED_MAINTENANCE_ENDPOINTS = ALLOWED_ENDPOINTS + ['snapshots',
+                                                     'snapshot-status']
 ALLOWED_LICENSE_ENDPOINTS = ALLOWED_ENDPOINTS + [
     'tokens', 'config', 'cluster', 'tenants', 'brokers', 'managers'
 ]

--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -42,10 +42,13 @@ from manager_rest import constants, config, manager_exceptions
 
 
 def check_allowed_endpoint(allowed_endpoints):
-    for endpoint in allowed_endpoints:
-        if endpoint in request.endpoint:
-            return True
-    return False
+    # Getting the resource from the endpoint, for example 'status' or 'sites'
+    # from 'v3.1/status' and 'v3.1/sites/<string:name>'. GET /version url
+    # is the only one that excludes the api version
+    endpoint_parts = request.endpoint.split('/')
+    request_endpoint = endpoint_parts[1] if len(endpoint_parts) > 1 else \
+        endpoint_parts[0]
+    return request_endpoint in allowed_endpoints
 
 
 def is_sanity_mode():

--- a/tests/integration_tests/tests/agentless_tests/test_license.py
+++ b/tests/integration_tests/tests/agentless_tests/test_license.py
@@ -46,6 +46,15 @@ class TestLicense(AgentlessTestCase):
         self.assertRaises(MissingCloudifyLicense,
                           self.client.blueprints.list)
 
+    def test_error_when_no_license_substring_endpoint(self):
+        """
+        Restricted endpoint that partly contains allowed endpoint should not
+        be allowed. For example: `snapshot-status` is not allowed even
+        though `status` is allowed
+        """
+        self.assertRaises(MissingCloudifyLicense,
+                          self.client.snapshots.get_status)
+
     def test_no_error_when_using_allowed_endpoints(self):
         """
         The following endpoints are allowed even when there is no Cloudify


### PR DESCRIPTION

* This check used to approve endpoints that included allowed endpoints.
  For example, the 'status' endpoint is allowed, so this check approved
  also the new (not merged yet) 'cluster-status' endpoint.