### PR TITLE
CY-1731 Fix role assignment

### DIFF
--- a/rest-service/manager_rest/storage/storage_utils.py
+++ b/rest-service/manager_rest/storage/storage_utils.py
@@ -84,11 +84,10 @@ def create_status_reporter_user_and_assign_role(username, password, role):
 
     default_tenant = Tenant.query.filter_by(
         id=constants.DEFAULT_TENANT_ID).first()
-    user_role = user_datastore.find_role(constants.DEFAULT_TENANT_ROLE)
     user_tenant_association = UserTenantAssoc(
         user=user,
         tenant=default_tenant,
-        role=user_role,
+        role=role,
     )
     user.tenant_associations.append(user_tenant_association)
     user_datastore.commit()

--- a/rest-service/manager_rest/storage/storage_utils.py
+++ b/rest-service/manager_rest/storage/storage_utils.py
@@ -84,10 +84,11 @@ def create_status_reporter_user_and_assign_role(username, password, role):
 
     default_tenant = Tenant.query.filter_by(
         id=constants.DEFAULT_TENANT_ID).first()
+    reporter_role = user_datastore.find_role(role)
     user_tenant_association = UserTenantAssoc(
         user=user,
         tenant=default_tenant,
-        role=role,
+        role=reporter_role,
     )
     user.tenant_associations.append(user_tenant_association)
     user_datastore.commit()


### PR DESCRIPTION
Previously the status reporters would have a `user` role inside the default tenant (by mistake), now they have a single role which has very limited permissions.