### PR TITLE
CY-1988 Set sqlalchemy pool size to 1

### DIFF
--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -138,6 +138,7 @@ class CloudifyFlaskApp(Flask):
         Set SQLAlchemy specific configurations, init the db object and create
         the tables if necessary
         """
+        self.config['SQLALCHEMY_POOL_SIZE'] = 1
         self.config['SQLALCHEMY_DATABASE_URI'] = config.instance.db_url
         self.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
         db.init_app(self)  # Prepare the app for use with flask-sqlalchemy


### PR DESCRIPTION
We're not using more than 1 connection per worker, so a pool
larger than 1 connection is just a waste of resources