### PR TITLE
CY-2049 Correctly store runtime_only_functions on the deployment

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1328,6 +1328,7 @@ class ResourceManager(object):
             deployment_id,
             deployment_plan
         )
+        new_deployment.runtime_only_evaluation = runtime_only_evaluation
         new_deployment.blueprint = blueprint
         new_deployment.visibility = visibility
 


### PR DESCRIPTION
This makes it so that values are no longer rendered-in when
the deployment is updated