### PR TITLE
Keep db_nodes table when restoring a snapshot

### DIFF
--- a/tests/integration_tests/resources/scripts/reset_storage.py
+++ b/tests/integration_tests/resources/scripts/reset_storage.py
@@ -118,7 +118,7 @@ def reset_storage(script_config):
 
     # Rebuild the DB
     safe_drop_all(keep_tables=['roles', 'config', 'rabbitmq_brokers',
-                               'certificates', 'managers'])
+                               'certificates', 'managers', 'db_nodes'])
     upgrade(directory=migrations_dir)
 
     # Add default tenant, admin user and provider context

--- a/workflows/cloudify_system_workflows/snapshots/postgres.py
+++ b/workflows/cloudify_system_workflows/snapshots/postgres.py
@@ -47,7 +47,8 @@ class Postgres(object):
     _COMPOSER_DB_NAME = 'composer'
     _TABLES_TO_KEEP = ['alembic_version', 'provider_context', 'roles',
                        'licenses']
-    _CONFIG_TABLES = ['config', 'rabbitmq_brokers', 'certificates', 'managers']
+    _CONFIG_TABLES = ['config', 'rabbitmq_brokers', 'certificates', 'managers',
+                      'db_nodes']
     _TABLES_TO_EXCLUDE_ON_DUMP = _TABLES_TO_KEEP + ['snapshots'] + \
         _CONFIG_TABLES
     _TABLES_TO_RESTORE = ['users', 'tenants']


### PR DESCRIPTION
Don't take the db_nodes table from the snapshot.