### PR TITLE
CY-2125 Fix internal request check

### DIFF
--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -60,7 +60,9 @@ def is_sanity_mode():
 def is_internal_request():
     remote_addr = _get_remote_addr()
     http_hosts = [_get_host(), constants.LOCAL_ADDRESS]
-    return all([remote_addr, http_hosts, remote_addr in http_hosts])
+
+    # cloudify-rest is the host for the auth request for the file-server
+    return remote_addr in http_hosts or 'cloudify-rest' in _get_host()
 
 
 def _get_host():


### PR DESCRIPTION
* When the mgmtworker sends a request: host=172.17.0.2,
  remote_addr=172.17.0.2 and the is_internal_request function passes.

* When nginx sends the internal auth request, host=cloudify-rest
  so it used to fail.