### PR TITLE
CY-2123 Update the execution token for resumed execution

### DIFF
--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -45,10 +45,12 @@ def execute_workflow(name,
                      wait_after_fail=600,
                      execution_creator=None,
                      scheduled_time=None,
-                     resume=False):
+                     resume=False,
+                     execution_token=None):
 
     execution_parameters = execution_parameters or {}
     task_name = workflow['operation']
+    execution_token = execution_token or generate_execution_token(execution_id)
 
     context = {
         'type': 'workflow',
@@ -64,7 +66,7 @@ def execute_workflow(name,
         'is_system_workflow': False,
         'wait_after_fail': wait_after_fail,
         'resume': resume,
-        'execution_token': generate_execution_token(execution_id),
+        'execution_token': execution_token,
         'plugin': {}
     }
 


### PR DESCRIPTION
* We create a new execution token when we resumed execution.

* Before the resumed operation had the old token in the context
  and the quthentication failed.

* Now we update the context of the operations with the new execution
  token.