### PR TITLE
CY-2139 Fix cluster-status when one manager is down

### DIFF
--- a/rest-service/manager_rest/cluster_status_manager.py
+++ b/rest-service/manager_rest/cluster_status_manager.py
@@ -235,8 +235,10 @@ def _handle_missing_non_manager_report(service_type,
         node_status = ServiceStatus.FAIL
 
         if missing_node.is_external:
-            service_statuses = [node[SERVICES][service_key][STATUS]
-                                for name, node in managers.items()]
+            service_statuses = [
+                node[SERVICES].get(service_key, {}).get(STATUS)
+                for name, node in managers.items()
+            ]
             # The service is healthy if one of the managers is able
             # to connect
             if NodeServiceStatus.ACTIVE in service_statuses:


### PR DESCRIPTION
* When one manager is down, there is no updated status report,
  so there is no info on it's services.

* Added defaults for this case when one manager is down and
  there is no info on the rabbit or db services.