### PR TITLE
CY-1959 Add GET /operations/id

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/operations.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/operations.py
@@ -53,6 +53,11 @@ class Operations(SecuredResource):
 class OperationsId(SecuredResource):
     @authorize('operations')
     @marshal_with(models.Operation)
+    def get(self, operation_id, **kwargs):
+        return get_storage_manager().get(models.Operation, operation_id)
+
+    @authorize('operations')
+    @marshal_with(models.Operation)
     def put(self, operation_id, **kwargs):
         params = get_json_and_verify_params({
             'name': {'type': unicode, 'required': True},


### PR DESCRIPTION
Allowing getting a single operation per id so that dispatch.py can
examine operation state to decide whether it's running a resume or not