### PR TITLE
CY-2222: no starting status reporter in ip-setter

### DIFF
--- a/packaging/ip_setter/files/opt/cloudify/manager-ip-setter/manager-ip-setter.sh
+++ b/packaging/ip_setter/files/opt/cloudify/manager-ip-setter/manager-ip-setter.sh
@@ -28,7 +28,7 @@ function set_manager_ip() {
   cfy_manager create-internal-certs --manager-hostname $(hostname -s)
 
   echo "Updating status reporter initial IP..."
-  cfy_manager status-reporter configure --managers-ip ${ip}
+  cfy_manager status-reporter configure --managers-ip ${ip} --no-start
 
   echo "Done!"
 

--- a/packaging/ip_setter/files/opt/cloudify/manager-ip-setter/manager-ip-setter.sh
+++ b/packaging/ip_setter/files/opt/cloudify/manager-ip-setter/manager-ip-setter.sh
@@ -28,7 +28,7 @@ function set_manager_ip() {
   cfy_manager create-internal-certs --manager-hostname $(hostname -s)
 
   echo "Updating status reporter initial IP..."
-  cfy_manager status-reporter configure --managers-ip ${ip} --no-start
+  cfy_manager status-reporter configure --managers-ip ${ip} --no-restart
 
   echo "Done!"
 


### PR DESCRIPTION
Starting it makes a dependency loop with the ipsetter as well
(ipsetter runs before status-reporter, so when in the ipsetter script we
attempt to do this, status-reporter can't start, because ipsetter didn't exit yet,
because it's waiting for the status-reporter to restart)