### PR TITLE
Fix db cluster status check, allow more replicas

### DIFF
--- a/rest-service/manager_rest/cluster_status_manager.py
+++ b/rest-service/manager_rest/cluster_status_manager.py
@@ -384,7 +384,7 @@ def _get_db_cluster_status(db_service, expected_nodes_number):
     if not sync_replica:
         return ServiceStatus.FAIL
 
-    if (len(master_replications_state) != expected_nodes_number - 1 or
+    if (len(master_replications_state) < expected_nodes_number - 1 or
             not all_replicas_streaming):
         return ServiceStatus.DEGRADED
 


### PR DESCRIPTION
* There can be more replicas the master has than the
  number of db nodes in our db_nodes table.

* A customer can have an extra node replicating
  from the cluster. For example in geo repl use case.