### PR TITLE
CY-2304 Remove SecuredResourceReadonlyMode decorator and use SecuredResource instead

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/status.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/status.py
@@ -23,9 +23,9 @@ from cloudify.cluster_status import ServiceStatus, NodeServiceStatus
 
 from manager_rest.rest import responses
 from manager_rest.utils import get_amqp_client
+from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
 from manager_rest.rest.rest_decorators import marshal_with
-from manager_rest.security import SecuredResourceReadonlyMode
 from manager_rest.rest.rest_utils import verify_and_convert_bool
 from manager_rest.cluster_status_manager import get_syncthing_status
 from manager_rest.rest.resources_v1.status import (
@@ -62,7 +62,7 @@ OPTIONAL_SERVICES = {
 }
 
 
-class Status(SecuredResourceReadonlyMode):
+class Status(SecuredResource):
 
     @swagger.operation(
         responseClass=responses.Status,

--- a/rest-service/manager_rest/security/__init__.py
+++ b/rest-service/manager_rest/security/__init__.py
@@ -20,7 +20,6 @@ from .secured_resource import (  # NOQA
     MissingPremiumFeatureResource,
     premium_only,
     allow_on_community,
-    SecuredResourceReadonlyMode,
     SecuredResourceBannedSnapshotRestore,
     authenticate
 )

--- a/rest-service/manager_rest/security/authentication.py
+++ b/rest-service/manager_rest/security/authentication.py
@@ -57,7 +57,7 @@ class Authentication(object):
         user.failed_logins_counter += 1
         user_datastore.commit()
 
-    def authenticate(self, request, readonly=False):
+    def authenticate(self, request):
         user = self._internal_auth(request)
         is_bootstrap_admin = user and user.is_bootstrap_admin
         if self.external_auth_configured \
@@ -78,7 +78,6 @@ class Authentication(object):
             # (User + Password), otherwise the counter will be reset on
             # every UI refresh (every 4 sec) and accounts won't be locked.
             user.failed_logins_counter = 0
-        if not readonly:
             user.last_login_at = datetime.now()
         user_datastore.commit()
         return user

--- a/rest-service/manager_rest/security/secured_resource.py
+++ b/rest-service/manager_rest/security/secured_resource.py
@@ -28,7 +28,7 @@ from manager_rest.rest.rest_decorators import (
 from .authentication import authenticator
 
 
-def authenticate(func, readonly=False):
+def authenticate(func):
     def _extend_response_headers(response, extra_headers):
         response = jsonify(response)
         response.headers.extend(extra_headers)
@@ -51,7 +51,7 @@ def authenticate(func, readonly=False):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        auth_response = authenticator.authenticate(request, readonly)
+        auth_response = authenticator.authenticate(request)
         auth_headers = getattr(auth_response, 'response_headers', {})
         if isinstance(auth_response, Response):
             return auth_response
@@ -73,10 +73,6 @@ def authenticate(func, readonly=False):
                     extra_headers=auth_response.response_headers)
         return response
     return wrapper
-
-
-def authenticate_readonly_mode(func):
-    return authenticate(func, True)
 
 
 def _abort_on_premium_missing(func):
@@ -126,16 +122,6 @@ class SecuredResourceBannedSnapshotRestore(Resource):
     So we will block access to that resource.
     """
     method_decorators = [prevent_running_in_snapshot_restore, authenticate]
-
-
-class SecuredResourceReadonlyMode(Resource):
-    """
-    In case of readonly access to the DB with write access for the failed
-    counter login mechanism, only this kind of secured resource will allow
-    access to the endpoints needed in that scenario by not writing to a
-    readonly column.
-    """
-    method_decorators = [authenticate_readonly_mode]
 
 
 class MissingPremiumFeatureResource(Resource):

--- a/rest-service/manager_rest/test/endpoints/test_status.py
+++ b/rest-service/manager_rest/test/endpoints/test_status.py
@@ -43,15 +43,8 @@ class StatusV1TestCase(base_test.BaseServerTestCase):
 class StatusTestCase(base_test.BaseServerTestCase):
 
     def test_get_status(self):
-        self._assert_last_login_time_value(None)
         result = self.client.manager.get_status()
 
         # There is no systemd in unit tests so the status response is FAIL
         self.assertEqual(result['status'], ServiceStatus.FAIL)
         self.assertEqual(type(result['services']), dict)
-        self._assert_last_login_time_value(None)
-
-    def _assert_last_login_time_value(self, value):
-        login_time_before = self.sm.get(management_models.User,
-                                        current_user.id).last_login_at
-        self.assertEqual(login_time_before, value)


### PR DESCRIPTION
* The SecuredResourceReadonlyMode decorator was created for a use case
  when we have 2 Cloudify sites (geo-replication) and the standby manager
  has only read access to the DB.

* We still wanted the cluster-status to work on the read-only one so
  we created this decorator and it is currently in use only in
  2 apis (/status and /brokers).

* This use case is not relevant anymore, therefore I remove all
  occurrences of SecuredResourceReadonlyMode.