### PR TITLE
mgmtworker: don't break on bytecompile errors

### DIFF
--- a/packaging/cloudify-mgmtworker.spec
+++ b/packaging/cloudify-mgmtworker.spec
@@ -1,3 +1,4 @@
+%global _python_bytecompile_errors_terminate_build 0
 %define __jar_repack %{nil}
 %define PIP_INSTALL /opt/mgmtworker/env/bin/pip install -c "${RPM_SOURCE_DIR}/packaging/mgmtworker/constraints.txt"
 


### PR DESCRIPTION
it now has py3-only modules in in

this can be reverted after mgmtworker is ported to py3