### PR TITLE
CY-2534 Mgmtworker: install cloudify-agent with fabric

### DIFF
--- a/packaging/mgmtworker/requirements.txt
+++ b/packaging/mgmtworker/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common==master
-git+https://github.com/cloudify-cosmo/cloudify-agent@master#egg=cloudify-agent[celery,kerberos]==master
+git+https://github.com/cloudify-cosmo/cloudify-agent@master#egg=cloudify-agent[celery,kerberos,fabric]==master
 
 # For dealing with the binary leftovers of psycopg2 in the 2.7.x version
 psycopg2==2.7.4 --no-binary psycopg2


### PR DESCRIPTION
Fabric is now an optional dependency, so let's install
it in the mgmtworker