### PR TITLE
CY-2468 Add deployment.external_resource property

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -996,6 +996,11 @@ data_types:
 
   cloudify.datatypes.ComponentDeployment:
     properties:
+      external_resource:
+        description: >
+          Use external deployment resource.
+        type: boolean
+        default: false
       id:
         description: >
           This is the deployment ID that the Component's node is connected to.


### PR DESCRIPTION
An `external_resource` property is added to the schema definition of
`cloudify.datatypes.ComponentDeployment`.