### PR TITLE
CY-2592 Add unique indexes to SQL database

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -59,6 +59,13 @@ class CreatedAtMixin(object):
 
 class Blueprint(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'blueprints'
+    __table_args__ = (
+        db.Index(
+            'blueprints_id__tenant_id_idx',
+            'id', '_tenant_id',
+            unique=True
+        ),
+    )
 
     skipped_fields = dict(
         SQLResourceBase.skipped_fields,
@@ -74,6 +81,13 @@ class Blueprint(CreatedAtMixin, SQLResourceBase):
 
 class Snapshot(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'snapshots'
+    __table_args__ = (
+        db.Index(
+            'snapshots_id__tenant_id_idx',
+            'id', '_tenant_id',
+            unique=True
+        ),
+    )
 
     status = db.Column(db.Enum(*SnapshotState.STATES, name='snapshot_status'))
     error = db.Column(db.Text)
@@ -81,6 +95,13 @@ class Snapshot(CreatedAtMixin, SQLResourceBase):
 
 class Plugin(SQLResourceBase):
     __tablename__ = 'plugins'
+    __table_args__ = (
+        db.Index(
+            'plugins_name_version__tenant_id_idx',
+            'package_name', 'package_version', '_tenant_id',
+            unique=True
+        ),
+    )
 
     archive_name = db.Column(db.Text, nullable=False, index=True)
     distribution = db.Column(db.Text)
@@ -144,6 +165,13 @@ class Plugin(SQLResourceBase):
 
 class Secret(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'secrets'
+    __table_args__ = (
+        db.Index(
+            'secrets_id_tenant_id_idx',
+            'id', '_tenant_id',
+            unique=True
+        ),
+    )
 
     value = db.Column(db.Text)
     updated_at = db.Column(UTCDateTime)
@@ -162,6 +190,13 @@ class Secret(CreatedAtMixin, SQLResourceBase):
 
 class Site(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'sites'
+    __table_args__ = (
+        db.Index(
+            'site_name__tenant_id_idx',
+            'name', '_tenant_id',
+            unique=True
+        ),
+    )
 
     name = db.Column(db.Text, nullable=False)
     latitude = db.Column(db.Float, nullable=True)
@@ -192,8 +227,13 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'deployments'
     __table_args__ = (
         db.Index(
-            'deployments__sife_fk_visibility_idx',
+            'deployments__site_fk_visibility_idx',
             '_blueprint_fk', '_site_fk', 'visibility', '_tenant_id'
+        ),
+        db.Index(
+            'deployments_id__tenant_id_idx',
+            'id', '_tenant_id',
+            unique=True
         ),
     )
     skipped_fields = dict(
@@ -762,7 +802,8 @@ class TasksGraph(SQLResourceBase):
     __table_args__ = (
         db.Index(
             'tasks_graphs__execution_fk_name_visibility_idx',
-            '_execution_fk', 'name', 'visibility'
+            '_execution_fk', 'name', 'visibility',
+            unique=True
         ),
     )
 


### PR DESCRIPTION
So far there were hardly any constraints for plugins stored in database.
All validation was handled in Python code.

This patch adds a constraint (and an index as well) for `package_name`
and `package_version` in `plugins` table to be unique.