### PR TITLE
amqp-postgres unittests: install common with extra dependencies

### DIFF
--- a/amqp-postgres/test-requirements.txt
+++ b/amqp-postgres/test-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common==master
+git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common[dispatcher]==master
 -e ../rest-service
 mock
 pytest


### PR DESCRIPTION
Similar to the restservice, we need the extra dependency in
amqp-postgres tests, because the tests use the same infra as
the restservice tests.
This dependency also pulls in networkx and pyyaml