### PR TITLE
CY-2609 verify_and_convert_bool: use bool literals

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v1/executions.py
@@ -89,16 +89,16 @@ class Executions(SecuredResource):
 
         allow_custom_parameters = verify_and_convert_bool(
             'allow_custom_parameters',
-            request_dict.get('allow_custom_parameters', 'false'))
+            request_dict.get('allow_custom_parameters', False))
         force = verify_and_convert_bool(
             'force',
-            request_dict.get('force', 'false'))
+            request_dict.get('force', False))
         dry_run = verify_and_convert_bool(
             'dry_run',
-            request_dict.get('dry_run', 'false'))
+            request_dict.get('dry_run', False))
         queue = verify_and_convert_bool(
             'queue',
-            request_dict.get('queue', 'false'))
+            request_dict.get('queue', False))
 
         deployment_id = request_dict['deployment_id']
         workflow_id = request_dict['workflow_id']

--- a/rest-service/manager_rest/rest/resources_v2/executions.py
+++ b/rest-service/manager_rest/rest/resources_v2/executions.py
@@ -60,7 +60,7 @@ class Executions(resources_v1.Executions):
         """
         is_include_system_workflows = rest_utils.verify_and_convert_bool(
             '_include_system_workflows',
-            request.args.get('_include_system_workflows', 'false'))
+            request.args.get('_include_system_workflows', False))
         get_all_results = rest_utils.verify_and_convert_bool(
             '_get_all_results',
             request.args.get('_get_all_results', False)

--- a/rest-service/manager_rest/rest/resources_v2/snapshots.py
+++ b/rest-service/manager_rest/rest/resources_v2/snapshots.py
@@ -98,19 +98,19 @@ class SnapshotsId(SecuredResource):
         request_dict = rest_utils.get_json_and_verify_params()
         include_credentials = rest_utils.verify_and_convert_bool(
             'include_credentials',
-            request_dict.get('include_credentials', 'true')
+            request_dict.get('include_credentials', True)
         )
         include_logs = rest_utils.verify_and_convert_bool(
             'include_logs',
-            request_dict.get('include_logs', 'true')
+            request_dict.get('include_logs', True)
         )
         include_events = rest_utils.verify_and_convert_bool(
             'include_events',
-            request_dict.get('include_events', 'true')
+            request_dict.get('include_events', True)
         )
         queue = rest_utils.verify_and_convert_bool(
             'queue',
-            request_dict.get('queue', 'false')
+            request_dict.get('queue', False)
         )
         execution = get_resource_manager().create_snapshot(
             snapshot_id,
@@ -236,16 +236,16 @@ class SnapshotsIdRestore(SecuredResource):
         )
         restore_certificates = rest_utils.verify_and_convert_bool(
             'restore_certificates',
-            request_dict.get('restore_certificates', 'false')
+            request_dict.get('restore_certificates', False)
         )
         no_reboot = rest_utils.verify_and_convert_bool(
             'no_reboot',
-            request_dict.get('no_reboot', 'false')
+            request_dict.get('no_reboot', False)
         )
         ignore_plugin_failure = \
             rest_utils.verify_and_convert_bool(
                 'ignore_plugin_failure',
-                request_dict.get('ignore_plugin_failure', 'false')
+                request_dict.get('ignore_plugin_failure', False)
             )
         if no_reboot and not restore_certificates:
             raise manager_exceptions.BadParametersError(

--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -158,32 +158,32 @@ class DeploymentUpdate(SecuredResource):
     def _parse_args(deployment_id, request_json, using_post_request=False):
         skip_install = verify_and_convert_bool(
             'skip_install',
-            request_json.get('skip_install', 'false'))
+            request_json.get('skip_install', False))
         skip_uninstall = verify_and_convert_bool(
             'skip_uninstall',
-            request_json.get('skip_uninstall', 'false'))
+            request_json.get('skip_uninstall', False))
         skip_reinstall = verify_and_convert_bool(
             'skip_reinstall',
             request_json.get('skip_reinstall', using_post_request))
         force = verify_and_convert_bool(
             'force',
-            request_json.get('force', 'false'))
+            request_json.get('force', False))
         ignore_failure = verify_and_convert_bool(
             'ignore_failure',
-            request_json.get('ignore_failure', 'false'))
+            request_json.get('ignore_failure', False))
         install_first = verify_and_convert_bool(
             'install_first',
             request_json.get('install_first', using_post_request))
         preview = not using_post_request and verify_and_convert_bool(
             'preview',
-            request_json.get('preview', 'false'))
+            request_json.get('preview', False))
         workflow_id = request_json.get('workflow_id', None)
         update_plugins = verify_and_convert_bool(
             'update_plugins',
-            request_json.get('update_plugins', 'true'))
+            request_json.get('update_plugins', True))
         runtime_only_evaluation = verify_and_convert_bool(
             'runtime_only_evaluation',
-            request_json.get('runtime_only_evaluation', 'false')
+            request_json.get('runtime_only_evaluation', False)
         )
         manager = get_deployment_updates_manager(preview)
         manager.validate_no_active_updates_per_deployment(deployment_id,

--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -202,11 +202,11 @@ class DeploymentUpdate(SecuredResource):
 
 class DeploymentUpdateId(SecuredResource):
     @swagger.operation(
-            responseClass=models.DeploymentUpdate,
-            nickname="DeploymentUpdate",
-            notes='Return a single deployment update',
-            parameters=create_filter_params_list_description(
-                models.DeploymentUpdate.response_fields, 'deployment update')
+        responseClass=models.DeploymentUpdate,
+        nickname="DeploymentUpdate",
+        notes='Return a single deployment update',
+        parameters=create_filter_params_list_description(
+            models.DeploymentUpdate.response_fields, 'deployment update')
     )
     @authorize('deployment_update_get')
     @rest_decorators.marshal_with(models.DeploymentUpdate)
@@ -219,13 +219,13 @@ class DeploymentUpdateId(SecuredResource):
 
 class DeploymentUpdates(SecuredResource):
     @swagger.operation(
-            responseClass='List[{0}]'.format(models.DeploymentUpdate.__name__),
-            nickname="listDeploymentUpdates",
-            notes='Returns a list of deployment updates',
-            parameters=create_filter_params_list_description(
-                    models.DeploymentUpdate.response_fields,
-                    'deployment updates'
-            )
+        responseClass='List[{0}]'.format(models.DeploymentUpdate.__name__),
+        nickname="listDeploymentUpdates",
+        notes='Returns a list of deployment updates',
+        parameters=create_filter_params_list_description(
+            models.DeploymentUpdate.response_fields,
+            'deployment updates'
+        )
     )
     @authorize('deployment_update_list')
     @rest_decorators.marshal_with(models.DeploymentUpdate)


### PR DESCRIPTION
verify_and_convert_bool has a isinstance(.., text_type) - while
data coming in from the request is indeed text (ie. unicode),
literals in our code aren't necessarily (bare strings in py2, being
bytes).

Instead, just pass bool literals. No reason to pass strings,
be it text or bytes.
