### PR TITLE
CY-2314 Clean started (stalled) dep-modifications

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -579,6 +579,12 @@ workflows:
       ignore_failure:
         default: false
         type: boolean
+      abort_starting:
+        description: >
+          Remove any starting nodes and deployment modifications created prior
+          to the interrupted scaling workflow.
+        default: false
+        type: boolean
 
   install_new_agents:
     mapping: default_workflows.cloudify.plugins.workflows.install_new_agents

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1176,6 +1176,8 @@ class ResourceManager(object):
 
         deployment_id_filter = self.create_filters_dict(
             deployment_id=deployment_id)
+        if context.get('abort_starting', False):
+            self.abort_started_modifications(deployment_id)
         existing_modifications = self.sm.list(
             models.DeploymentModification,
             include=['id', 'status'],
@@ -1279,6 +1281,18 @@ class ResourceManager(object):
         self._create_deployment_node_instances(deployment_id,
                                                added_node_instances)
         return modification
+
+    def abort_started_modifications(self, deployment_id):
+        started_deployment_filter = self.create_filters_dict(
+            deployment_id=deployment_id,
+            status=DeploymentModificationState.STARTED)
+
+        started_modifications = self.sm.list(
+            models.DeploymentModification,
+            filters=started_deployment_filter
+        )
+        for m in started_modifications:
+            self.rollback_deployment_modification(m.id)
 
     def finish_deployment_modification(self, modification_id):
         modification = self.sm.get(


### PR DESCRIPTION
This patch adds ability to abort already started (but possibly stalled)
deployment modifications before starting a new modification.