### PR TITLE
CY-2314 Clean started (stalled) dep-modifications

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -797,6 +797,11 @@ workflows:
             occurs during the workflow, otherwise the rollback will be
             triggered.
         default: true
+      abort_starting:
+        description: >
+          Remove any starting nodes and deployment modifications created prior
+          to the interrupted scaling workflow.
+        default: false
         type: boolean
 
   install_new_agents:


### PR DESCRIPTION
This patch adds ability to abort already started (but possibly stalled)
deployment modifications before starting a new modification.