### PR TITLE
CY-2314 Add abort_started param for scale workflow

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -797,6 +797,11 @@ workflows:
             occurs during the workflow, otherwise the rollback will be
             triggered.
         default: true
+      abort_started:
+        description: >
+          Remove any started deployment modifications created prior to the
+          scaling workflow.
+        default: false
         type: boolean
 
   install_new_agents:


### PR DESCRIPTION
The `abort_started` flag (default `False`) enables roll back of any
started deployment modifications.