### PR TITLE
write_ca_cert: cert contents is unicode

### DIFF
--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -589,7 +589,7 @@ class _WithCACert(object):
         if not self.ca_cert_content:
             return
 
-        with tempfile.NamedTemporaryFile(delete=False) as f:
+        with tempfile.NamedTemporaryFile(delete=False, mode='w') as f:
             f.write(self.ca_cert_content)
         return f.name
 


### PR DESCRIPTION
this is unicode, so use tempfile's unicode api, as opposed to the
default bytes api