### PR TITLE
CY-2314 Add abort_started param for scale workflow

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -579,6 +579,12 @@ workflows:
       ignore_failure:
         default: false
         type: boolean
+      abort_started:
+        description: >
+          Remove any started deployment modifications created prior to the
+          scaling workflow.
+        default: false
+        type: boolean
 
   install_new_agents:
     mapping: default_workflows.cloudify.plugins.workflows.install_new_agents


### PR DESCRIPTION
The `abort_started` flag (default `False`) enables roll back of any
started deployment modifications.