### PR TITLE
Set hostname to cloudify in IP setter

### DIFF
--- a/packaging/ip_setter/files/opt/cloudify/manager-ip-setter/manager-ip-setter.sh
+++ b/packaging/ip_setter/files/opt/cloudify/manager-ip-setter/manager-ip-setter.sh
@@ -25,7 +25,7 @@ function set_manager_ip() {
   /usr/bin/sed -ri "s/"'"'"manager_addresses"'"'"[^]]+]/"'"'"manager_addresses"'"'": \\["'"'"${ip}"'"'"]/" /etc/cloudify/ssl/certificate_metadata
 
   echo "Creating internal SSL certificates.."
-  cfy_manager create-internal-certs --manager-hostname $(hostname -s)
+  cfy_manager create-internal-certs --manager-hostname cloudify
 
   if [[ -d "/opt/status-reporter" ]]; then
     echo "Updating status reporter initial IP..."


### PR DESCRIPTION
This is to work around a problem with very long instance names on openstack, which 'hostname -s'
then truncates. If it happens to truncate ending with a hyphen then we generate an invalid DNS
SAN in a cert.
It is set to cloudify in case a generated VM has another hostname set, so that we don't put the
original VM's name in the certs when IP setter runs.