### PR TITLE
CY-2725 Filtering events delete by timestamp range (#2175)

### DIFF
--- a/rest-service/manager_rest/rest/resources_v2/events.py
+++ b/rest-service/manager_rest/rest/resources_v2/events.py
@@ -16,6 +16,9 @@
 
 from flask_restful_swagger import swagger
 from sqlalchemy import bindparam
+from datetime import datetime
+import errno
+import os
 
 from manager_rest import manager_exceptions
 from manager_rest.rest import (
@@ -34,7 +37,6 @@ from manager_rest.security.authorization import authorize
 
 
 class Events(resources_v1.Events):
-
     """Events resource.
 
     Through the events endpoint a user can retrieve both events and logs as
@@ -158,31 +160,32 @@ class Events(resources_v1.Events):
             'deployment_id': filters['deployment_id'][0],
             'tenant_id': self.current_tenant.id
         }
+        do_store_before = 'store_before' in filters and \
+                          filters['store_before'][0].upper() == 'TRUE'
 
-        delete_event_query = (
-            db.session.query(Event)
-            .filter(
-                Event._execution_fk.in_(executions_query),
-                Event._tenant_id == bindparam('tenant_id')
-            )
-            .params(**params)
-        )
-        total = delete_event_query.delete(synchronize_session=False)
+        delete_event_query = Events._apply_range_filters(
+            Events._build_delete_subquery(
+                Event, executions_query, params),
+            Event, range_filters)
+        if do_store_before:
+            self._store_log_entries('events', filters['deployment_id'][0],
+                                    delete_event_query.order_by(
+                                        'reported_timestamp'))
+        total = delete_event_query.delete(
+            synchronize_session=False)
 
         if 'cloudify_log' in filters['type']:
-            delete_log_query = (
-                db.session.query(Log)
-                .filter(
-                    Log._execution_fk.in_(executions_query),
-                    Log._tenant_id == bindparam('tenant_id')
-                )
-                .params(**params)
-            )
+            delete_log_query = Events._apply_range_filters(
+                Events._build_delete_subquery(
+                    Log, executions_query, params),
+                Log, range_filters)
+            if do_store_before:
+                self._store_log_entries('logs', filters['deployment_id'][0],
+                                        delete_log_query.order_by(
+                                            'reported_timestamp'))
             total += delete_log_query.delete('fetch')
 
-        metadata = {
-            'pagination': dict(pagination, total=total)
-        }
+        metadata = {'pagination': dict(pagination, total=total)}
 
         # Commit bulk row deletions to database
         db.session.commit()
@@ -190,3 +193,42 @@ class Events(resources_v1.Events):
         # We don't really want to return all of the deleted events,
         # so it's a bit of a hack to return the deleted element count.
         return ListResult([total], metadata)
+
+    @staticmethod
+    def _store_log_entries(table_name, deployment_id, select_query):
+        output_directory = Events._create_logs_output_directory()
+        output_filename = "{0}_{1}_{2}.log".format(
+            table_name, deployment_id,
+            datetime.utcnow().strftime('%Y%m%dT%H%M%S')
+        )
+        output_filename = os.path.join(output_directory, output_filename)
+        with open(output_filename, 'a') as output_file:
+            for event in select_query.all():
+                output_file.write(Events._map_event_to_log_entry(event))
+
+    @staticmethod
+    def _map_event_to_log_entry(event):
+        return '{0}  {1}\n'.format(
+            event.reported_timestamp,
+            {k: v for k, v in event.to_response().items()
+             if k != 'reported_timestamp'})
+
+    @staticmethod
+    def _create_logs_output_directory():
+        output_directory = os.path.join(os.sep, 'opt', 'manager', 'logs')
+        try:
+            os.makedirs(output_directory)
+        except OSError as ex:
+            # be happy if someone already created the path
+            if ex.errno != errno.EEXIST:
+                raise
+        return output_directory
+
+    @staticmethod
+    def _build_delete_subquery(model, execution_query, params):
+        """Build delete subquery."""
+        query = db.session.query(model).filter(
+            model._execution_fk.in_(execution_query),
+            model._tenant_id == bindparam('tenant_id'),
+        )
+        return query.params(**params)

--- a/rest-service/manager_rest/test/endpoints/test_events_v2.py
+++ b/rest-service/manager_rest/test/endpoints/test_events_v2.py
@@ -12,6 +12,8 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
+from mock import patch
+
 from manager_rest.test.attribute import attr
 
 from manager_rest.test import base_test
@@ -43,4 +45,27 @@ class EventsTest(base_test.BaseServerTestCase):
     def test_delete_events(self):
         response = self.client.events.delete(
             '<deployment_id>', include_logs=True)
+        self.assertEqual(response.items, [0])
+
+    @attr(client_min_version=3,
+          client_max_version=base_test.LATEST_API_VERSION)
+    def test_delete_events_timestamp_range(self):
+        response = self.client.events.delete(
+            '<deployment_id>', include_logs=True,
+            from_datetime='2020-01-01', to_datetime='2020-02-02')
+        self.assertEqual(response.items, [0])
+
+    @attr(client_min_version=3,
+          client_max_version=base_test.LATEST_API_VERSION)
+    @patch('manager_rest.rest.resources_v2.events.Events._store_log_entries')
+    def test_delete_events_store_before(self, store_log_entries):
+        response = self.client.events.delete(
+            '<deployment_id>', include_logs=False,
+            store_before='true')
+        self.assertEqual(store_log_entries.call_count, 1)
+        self.assertEqual(response.items, [0])
+        response = self.client.events.delete(
+            '<deployment_id>', include_logs=True,
+            store_before='true')
+        self.assertEqual(store_log_entries.call_count, 3)
         self.assertEqual(response.items, [0])


### PR DESCRIPTION
Added ability to remove events for specified timestamp range.

This patch is accompanied by the other one in cloudify-cli.

* Add simple test_delte_events_timestamp_range

* Save deleted logs to a file

Store deleted logs in /opt/manager/logs/<FILENAME>.log

* Add test_delete_events_store_before

* Resolve reviewer's remarks