### PR TITLE
CY-2776 Make package_name a default plugin's title

### DIFF
--- a/rest-service/manager_rest/test/endpoints/test_plugins.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins.py
@@ -362,3 +362,16 @@ class PluginsTest(BaseServerTestCase):
         get_plugin_by_id_response = self.client.plugins.get(uploaded_plugin.id)
         self.assertIsNotNone(get_plugin_by_id_response)
         self.assertEqual(get_plugin_by_id_response.title, 'test')
+
+    @attr(client_min_version=3.1,
+          client_max_version=base_test.LATEST_API_VERSION)
+    def test_plugin_upload_check_default_title(self):
+        tmp_file_path = self.create_wheel(
+            TEST_PACKAGE_NAME,
+            TEST_PACKAGE_VERSION)
+        yaml_path = self.get_full_path(TEST_PACKAGE_YAML_FILE)
+        zip_path = self.zip_files([tmp_file_path, yaml_path])
+        uploaded_plugin = self.client.plugins.upload(zip_path)
+        get_plugin_by_id_response = self.client.plugins.get(uploaded_plugin.id)
+        self.assertIsNotNone(get_plugin_by_id_response)
+        self.assertEqual(get_plugin_by_id_response.title, TEST_PACKAGE_NAME)

--- a/rest-service/manager_rest/test/endpoints/test_plugins.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins.py
@@ -366,12 +366,11 @@ class PluginsTest(BaseServerTestCase):
     @attr(client_min_version=3.1,
           client_max_version=base_test.LATEST_API_VERSION)
     def test_plugin_upload_check_default_title(self):
-        tmp_file_path = self.create_wheel(
-            TEST_PACKAGE_NAME,
-            TEST_PACKAGE_VERSION)
-        yaml_path = self.get_full_path(TEST_PACKAGE_YAML_FILE)
-        zip_path = self.zip_files([tmp_file_path, yaml_path])
-        uploaded_plugin = self.client.plugins.upload(zip_path)
-        get_plugin_by_id_response = self.client.plugins.get(uploaded_plugin.id)
+        uploaded_plugin = self.upload_plugin(TEST_PACKAGE_NAME,
+                                             TEST_PACKAGE_VERSION).json
+        plugin_id = uploaded_plugin.get('id')
+        self.assertIsNotNone(plugin_id)
+        self.assertEqual(uploaded_plugin.get('title'), TEST_PACKAGE_NAME)
+        get_plugin_by_id_response = self.client.plugins.get(plugin_id)
         self.assertIsNotNone(get_plugin_by_id_response)
         self.assertEqual(get_plugin_by_id_response.title, TEST_PACKAGE_NAME)

--- a/rest-service/manager_rest/upload_manager.py
+++ b/rest-service/manager_rest/upload_manager.py
@@ -758,7 +758,7 @@ class UploadedPluginsManager(UploadedDataManager):
 
         return Plugin(
             id=plugin_id,
-            title=plugin_title,
+            title=plugin_title or plugin.get('package_name'),
             package_name=plugin.get('package_name'),
             package_version=plugin.get('package_version'),
             archive_name=plugin.get('archive_name'),


### PR DESCRIPTION
Recently added plugin's `title` field should by default be equal to `package_name`.