### PR TITLE
Make status reporter create cfyuser group

### DIFF
--- a/packaging/cloudify-status-reporter.spec
+++ b/packaging/cloudify-status-reporter.spec
@@ -50,6 +50,7 @@ cp -R ${RPM_SOURCE_DIR}/packaging/status-reporter/files/* %{buildroot}
 
 %pre
 
+groupadd -fr cfyuser
 getent passwd cfyreporter >/dev/null || useradd -r -d /etc/cloudify -s /sbin/nologin cfyreporter
 
 %files


### PR DESCRIPTION
As it now requires it, it has been failing on broker and DB which don't have it.