### PR TITLE
amqp-postgres & mgmtworker: don't require rabbitmq

### DIFF
--- a/packaging/amqp-postgres/files/usr/lib/systemd/system/cloudify-amqp-postgres.service
+++ b/packaging/amqp-postgres/files/usr/lib/systemd/system/cloudify-amqp-postgres.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Cloudify AMQP PostgreSQL Broker Service
-Wants=postgresql-9.5.service cloudify-rabbitmq.service
 After=postgresql-9.5.service cloudify-rabbitmq.service
 
 [Service]

--- a/packaging/mgmtworker/files/usr/lib/systemd/system/cloudify-mgmtworker.service
+++ b/packaging/mgmtworker/files/usr/lib/systemd/system/cloudify-mgmtworker.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Cloudify Management Worker Service
-Wants=cloudify-rabbitmq.service
 After=cloudify-rabbitmq.service
 
 [Service]


### PR DESCRIPTION
that way, they are stopped when rabbitmq is stopped