### PR TITLE
Don't fail to add cfyuser in status reporter

### DIFF
--- a/packaging/cloudify-status-reporter.spec
+++ b/packaging/cloudify-status-reporter.spec
@@ -51,7 +51,7 @@ cp -R ${RPM_SOURCE_DIR}/packaging/status-reporter/files/* %{buildroot}
 %pre
 
 groupadd -fr cfyuser
-getent passwd cfyuser >/dev/null || useradd -r -d /etc/cloudify -s /sbin/nologin cfyuser
+getent passwd cfyuser >/dev/null || useradd -r -g cfyuser -d /etc/cloudify -s /sbin/nologin cfyuser
 getent passwd cfyreporter >/dev/null || useradd -r -d /etc/cloudify -s /sbin/nologin cfyreporter
 
 %files


### PR DESCRIPTION
Trying to add with the group already existing fails silently, thanks yum.