### PR TITLE
integration-tests jenkinsfile: add a BRANCH param [ci skip]

### DIFF
--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -3,6 +3,7 @@ pipeline {
         node 'docker'
     }
     parameters {
+        string(name: 'BRANCH', defaultValue: 'master')
         string(name: 'IMAGE_BUILD_NUMBER')
         booleanParam(name: 'FETCH_IMAGE', defaultValue: false)
         text(name: 'PYTEST_ARGS', defaultValue: """-sv \\


### PR DESCRIPTION
not used here, but it's going to be used on jenkins.
That part of the build is not under source control, unfortunately, but well, downloading
a jenkinsfile from source control needs to know which branch to use. And declaring the
branch param makes it appear in jenkins's UI.