### PR TITLE
Add rest_host to the kill-cancel context

### DIFF
--- a/mgmtworker/mgmtworker/worker.py
+++ b/mgmtworker/mgmtworker/worker.py
@@ -117,13 +117,14 @@ class MgmtworkerServiceTaskConsumer(ServiceTaskConsumer):
         super(MgmtworkerServiceTaskConsumer, self).__init__(*args, **kwargs)
 
     def cancel_workflow_task(self, execution_id, rest_token, tenant,
-                             execution_token):
+                             execution_token, rest_host):
         logger.info('Cancelling workflow {0}'.format(execution_id))
 
         class CancelCloudifyContext(object):
             """A CloudifyContext that has just enough data to cancel workflows
             """
             def __init__(self):
+                self.rest_host = rest_host
                 self.tenant_name = tenant['name']
                 self.rest_token = rest_token
                 self.execution_token = execution_token

--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -237,10 +237,13 @@ def _get_time_to_live(scheduled_time):
 
 
 def cancel_execution(execution_id):
+    sm = get_storage_manager()
+    managers = sm.list(models.Manager)
     message = {
         'service_task': {
             'task_name': 'cancel-workflow',
             'kwargs': {
+                'rest_host': [manager.private_ip for manager in managers],
                 'execution_id': execution_id,
                 'rest_token': current_user.get_auth_token(),
                 'tenant': _get_tenant_dict(),

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -43,6 +43,7 @@ sources = [
     ('cloudify-common/cloudify', ['/opt/manager/env', '/opt/mgmtworker/env']),
     ('cloudify-common/dsl_parser', ['/opt/manager/env']),
     ('cloudify-common/script_runner', ['/opt/mgmtworker/env']),
+    ('cloudify-manager/mgmtworker/mgmtworker', ['/opt/mgmtworker/env']),
     ('cloudify-manager/rest-service/manager_rest', ['/opt/manager/env']),
     ('cloudify-manager/rest-service/manager_rest', ['/opt/manager/env']),
     ('cloudify-manager-install/cfy_manager', ['/opt/cloudify/cfy_manager'])


### PR DESCRIPTION
kill-canceling has been broken for quite a while, but this fixes it.
Now that we have integration-tests that can actually be run, it was very easy to fix!

The relevant test is `integration_tests/tests/agentless_tests/test_resume.py -k test_resume_cancelled_resumable`