### PR TITLE
RD-664 Allow using alembic directly to migrate

### DIFF
--- a/resources/rest-service/cloudify/migrations/alembic.ini
+++ b/resources/rest-service/cloudify/migrations/alembic.ini
@@ -1,0 +1,2 @@
+[alembic]
+script_location=.

--- a/resources/rest-service/cloudify/migrations/env.py
+++ b/resources/rest-service/cloudify/migrations/env.py
@@ -18,9 +18,6 @@ logger = logging.getLogger('alembic.env')
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-config.set_main_option('sqlalchemy.url',
-                       current_app.config.get('SQLALCHEMY_DATABASE_URI'))
-target_metadata = current_app.extensions['migrate'].db.metadata
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:
@@ -40,8 +37,7 @@ def run_migrations_offline():
     script output.
 
     """
-    url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url)
+    context.configure(dialect_name='postgresql')
 
     with context.begin_transaction():
         context.run_migrations()
@@ -54,6 +50,10 @@ def run_migrations_online():
     and associate a connection with the context.
 
     """
+
+    config.set_main_option('sqlalchemy.url',
+                           current_app.config.get('SQLALCHEMY_DATABASE_URI'))
+    target_metadata = current_app.extensions['migrate'].db.metadata
 
     # this callback is used to prevent an auto-migration from being generated
     # when there are no changes to the schema

--- a/resources/rest-service/cloudify/migrations/versions/3483e421713d_rename_availability_to_visibility.py
+++ b/resources/rest-service/cloudify/migrations/versions/3483e421713d_rename_availability_to_visibility.py
@@ -27,7 +27,7 @@ def upgrade():
     # to visibility
     visibility_enum = postgresql.ENUM(*visibility_states,
                                       name='visibility_states')
-    visibility_enum.create(op.get_bind())
+    op.execute(postgresql.base.CreateEnumType(visibility_enum))
     for table_name in resource_tables:
         op.alter_column(table_name,
                         'resource_availability',
@@ -45,7 +45,7 @@ def downgrade():
     # to resource_availability
     resource_availability = postgresql.ENUM(*visibility_states,
                                             name='resource_availability')
-    resource_availability.create(op.get_bind())
+    op.execute(postgresql.base.CreateEnumType(resource_availability))
     for table_name in resource_tables:
         op.alter_column(table_name,
                         'visibility',

--- a/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
+++ b/resources/rest-service/cloudify/migrations/versions/406821843b55_add_role_column_to_users_tenants_table.py
@@ -43,7 +43,7 @@ def update_system_role(from_role_id, to_role_id):
     """
     op.execute(
         users_roles.update()
-        .where(users_roles.c.role_id == from_role_id)
+        .where(users_roles.c.role_id == op.inline_literal(from_role_id))
         .values(role_id=to_role_id)
     )
 
@@ -52,7 +52,8 @@ def _get_role_id(role_name):
     """
     Return a SELECT statement that retrieves a role ID from a role name
     """
-    return sa.select([roles.c.id]).where(roles.c.name == role_name)
+    return sa.select([roles.c.id]).where(
+        roles.c.name == op.inline_literal(role_name))
 
 
 def upgrade():

--- a/resources/rest-service/cloudify/migrations/versions/423a1643f365_4_6_to_5_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/423a1643f365_4_6_to_5_0.py
@@ -13,9 +13,7 @@ Create Date: 2019-02-21 13:00:46.042338
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy import orm
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.ext.declarative import declarative_base
 
 from manager_rest.storage.models import User
 from manager_rest.storage.models_base import JSONString, UTCDateTime
@@ -29,241 +27,239 @@ branch_labels = None
 depends_on = None
 
 
-Base = declarative_base()
-
 LOG_LEVELS_ENUM = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
-
-
-class Config(Base):
-    __tablename__ = 'config'
-
-    name = sa.Column(sa.Text, primary_key=True)
-    value = sa.Column(JSONString(), nullable=False)
-    schema = sa.Column(JSONString(), nullable=True)
-    is_editable = sa.Column(sa.Boolean, default=True)
-    updated_at = sa.Column(UTCDateTime())
-    scope = sa.Column(sa.Text, primary_key=True)
-    _updater_id = sa.Column(
-        sa.Integer,
-        sa.ForeignKey(User.id, ondelete='SET NULL'),
-        nullable=True,
-        index=False,
-        primary_key=False,
-    )
 
 
 def upgrade():
     op.add_column('executions', sa.Column('token',
                                           sa.String(length=100),
                                           nullable=True))
-
-    bind = op.get_bind()
-    session = orm.Session(bind=bind)
-    Config.__table__.create(bind)
-
-    session.add_all([
-        Config(
-            name='rest_service_log_path',
-            value='/var/log/cloudify/rest/cloudify-rest-service.log',
-            scope='rest',
-            schema=None,
-            is_editable=False
-        ),
-        Config(
-            name='rest_service_log_level',
-            value='INFO',
-            scope='rest',
-            schema={'type': 'string', 'enum': LOG_LEVELS_ENUM},
-            is_editable=True
-        ),
-        Config(
-            name='ldap_server',
-            value=None,
-            scope='rest',
-            schema={'type': 'string'},
-            is_editable=True
-        ),
-        Config(
-            name='ldap_username',
-            value=None,
-            scope='rest',
-            schema={'type': 'string'},
-            is_editable=True
-        ),
-        Config(
-            name='ldap_password',
-            value=None,
-            scope='rest',
-            schema={'type': 'string'},
-            is_editable=True
-        ),
-        Config(
-            name='ldap_domain',
-            value=None,
-            scope='rest',
-            schema={'type': 'string'},
-            is_editable=True
-        ),
-        Config(
-            name='ldap_is_active_directory',
-            value=None,
-            scope='rest',
-            schema={'type': 'boolean'},
-            is_editable=True
-        ),
-        Config(
-            name='ldap_dn_extra',
-            value=None,
-            scope='rest',
-            schema=None,
-            is_editable=True
-        ),
-        Config(
-            name='ldap_timeout',
-            value=5.0,
-            scope='rest',
-            schema={'type': 'number'},
-            is_editable=True
-        ),
-        Config(
-            name='ldap_nested_levels',
-            value=1,
-            scope='rest',
-            schema={'type': 'number', 'minimum': 1},
-            is_editable=True
-        ),
-        Config(
-            name='file_server_root',
-            value='/opt/manager/resources',
-            scope='rest',
-            schema=None,
-            is_editable=False
-        ),
-        Config(
-            name='file_server_url',
-            value='http://127.0.0.1:53333/resources',
-            scope='rest',
-            schema=None,
-            is_editable=False
-        ),
-        Config(
-            name='insecure_endpoints_disabled',
-            value=True,
-            scope='rest',
-            schema={'type': 'boolean'},
-            is_editable=False
-        ),
-        Config(
-            name='maintenance_folder',
-            value='/opt/manager/maintenance',
-            scope='rest',
-            schema=None,
-            is_editable=False
-        ),
-        Config(
-            name='min_available_memory_mb',
-            value=100,
-            scope='rest',
-            schema={'type': 'number', 'minimum': 0},
-            is_editable=True
-        ),
-        Config(
-            name='failed_logins_before_account_lock',
-            value=4,
-            scope='rest',
-            schema={'type': 'number', 'minimum': 1},
-            is_editable=True
-        ),
-        Config(
-            name='account_lock_period',
-            value=-1,
-            scope='rest',
-            schema={'type': 'number', 'minimum': -1},
-            is_editable=True
-        ),
-        Config(
-            name='public_ip',
-            value=None,
-            scope='rest',
-            schema=None,
-            is_editable=False
-        ),
-        Config(
-            name='default_page_size',
-            value=1000,
-            scope='rest',
-            schema={'type': 'number', 'minimum': 1},
-            is_editable=True
-        ),
-
-        Config(
-            name='max_workers',
-            value=5,
-            scope='mgmtworker',
-            schema={'type': 'number', 'minimum': 1},
-            is_editable=True
-        ),
-        Config(
-            name='min_workers',
-            value=2,
-            scope='mgmtworker',
-            schema={'type': 'number', 'minimum': 1},
-            is_editable=True
-        ),
-        Config(
-            name='broker_port',
-            value=5671,
-            scope='agent',
-            schema={'type': 'number', 'minimum': 1, 'maximum': 65535},
-            is_editable=True
-        ),
-        Config(
-            name='min_workers',
-            value=2,
-            scope='agent',
-            schema={'type': 'number', 'minimum': 1},
-            is_editable=True
-        ),
-        Config(
-            name='max_workers',
-            value=5,
-            scope='agent',
-            schema={'type': 'number', 'minimum': 1},
-            is_editable=True
-        ),
-        Config(
-            name='heartbeat',
-            value=30,
-            scope='agent',
-            schema={'type': 'number', 'minimum': 0},
-            is_editable=True
-        ),
-        Config(
-            name='log_level',
-            value='info',
-            scope='agent',
-            schema={'type': 'string', 'enum': LOG_LEVELS_ENUM}
-        ),
-        Config(
-            name='task_retries',
-            value=60,
-            scope='workflow',
-            schema={'type': 'number', 'minimum': -1},
-        ),
-        Config(
-            name='task_retry_interval',
-            value=15,
-            scope='workflow',
-            schema={'type': 'number', 'minimum': 0},
-        ),
-        Config(
-            name='subgraph_retries',
-            value=0,
-            scope='workflow',
-            schema={'type': 'number', 'minimum': -1},
+    config_table = op.create_table(
+        'config',
+        sa.Column('name', sa.Text, primary_key=True),
+        sa.Column('value', JSONString(), nullable=False),
+        sa.Column('schema', JSONString(), nullable=True),
+        sa.Column('is_editable', sa.Boolean, default=True),
+        sa.Column('updated_at', UTCDateTime()),
+        sa.Column('scope', sa.Text, primary_key=True),
+        sa.Column(
+            '_updater_id',
+            sa.Integer,
+            sa.ForeignKey(User.id, ondelete='SET NULL'),
+            nullable=True,
+            index=False,
+            primary_key=False,
         )
-    ])
-    session.commit()
+    )
+    op.bulk_insert(
+        config_table,
+        [
+            dict(
+                name='rest_service_log_path',
+                value='/var/log/cloudify/rest/cloudify-rest-service.log',
+                scope='rest',
+                schema=None,
+                is_editable=False
+            ),
+            dict(
+                name='rest_service_log_level',
+                value='INFO',
+                scope='rest',
+                schema={'type': 'string', 'enum': LOG_LEVELS_ENUM},
+                is_editable=True
+            ),
+            dict(
+                name='ldap_server',
+                value=None,
+                scope='rest',
+                schema={'type': 'string'},
+                is_editable=True
+            ),
+            dict(
+                name='ldap_username',
+                value=None,
+                scope='rest',
+                schema={'type': 'string'},
+                is_editable=True
+            ),
+            dict(
+                name='ldap_password',
+                value=None,
+                scope='rest',
+                schema={'type': 'string'},
+                is_editable=True
+            ),
+            dict(
+                name='ldap_domain',
+                value=None,
+                scope='rest',
+                schema={'type': 'string'},
+                is_editable=True
+            ),
+            dict(
+                name='ldap_is_active_directory',
+                value=None,
+                scope='rest',
+                schema={'type': 'boolean'},
+                is_editable=True
+            ),
+            dict(
+                name='ldap_dn_extra',
+                value=None,
+                scope='rest',
+                schema=None,
+                is_editable=True
+            ),
+            dict(
+                name='ldap_timeout',
+                value=5.0,
+                scope='rest',
+                schema={'type': 'number'},
+                is_editable=True
+            ),
+            dict(
+                name='ldap_nested_levels',
+                value=1,
+                scope='rest',
+                schema={'type': 'number', 'minimum': 1},
+                is_editable=True
+            ),
+            dict(
+                name='file_server_root',
+                value='/opt/manager/resources',
+                scope='rest',
+                schema=None,
+                is_editable=False
+            ),
+            dict(
+                name='file_server_url',
+                value='http://127.0.0.1:53333/resources',
+                scope='rest',
+                schema=None,
+                is_editable=False
+            ),
+            dict(
+                name='insecure_endpoints_disabled',
+                value=True,
+                scope='rest',
+                schema={'type': 'boolean'},
+                is_editable=False
+            ),
+            dict(
+                name='maintenance_folder',
+                value='/opt/manager/maintenance',
+                scope='rest',
+                schema=None,
+                is_editable=False
+            ),
+            dict(
+                name='min_available_memory_mb',
+                value=100,
+                scope='rest',
+                schema={'type': 'number', 'minimum': 0},
+                is_editable=True
+            ),
+            dict(
+                name='failed_logins_before_account_lock',
+                value=4,
+                scope='rest',
+                schema={'type': 'number', 'minimum': 1},
+                is_editable=True
+            ),
+            dict(
+                name='account_lock_period',
+                value=-1,
+                scope='rest',
+                schema={'type': 'number', 'minimum': -1},
+                is_editable=True
+            ),
+            dict(
+                name='public_ip',
+                value=None,
+                scope='rest',
+                schema=None,
+                is_editable=False
+            ),
+            dict(
+                name='default_page_size',
+                value=1000,
+                scope='rest',
+                schema={'type': 'number', 'minimum': 1},
+                is_editable=True
+            ),
+
+            dict(
+                name='max_workers',
+                value=5,
+                scope='mgmtworker',
+                schema={'type': 'number', 'minimum': 1},
+                is_editable=True
+            ),
+            dict(
+                name='min_workers',
+                value=2,
+                scope='mgmtworker',
+                schema={'type': 'number', 'minimum': 1},
+                is_editable=True
+            ),
+            dict(
+                name='broker_port',
+                value=5671,
+                scope='agent',
+                schema={'type': 'number', 'minimum': 1, 'maximum': 65535},
+                is_editable=True
+            ),
+            dict(
+                name='min_workers',
+                value=2,
+                scope='agent',
+                schema={'type': 'number', 'minimum': 1},
+                is_editable=True
+            ),
+            dict(
+                name='max_workers',
+                value=5,
+                scope='agent',
+                schema={'type': 'number', 'minimum': 1},
+                is_editable=True
+            ),
+            dict(
+                name='heartbeat',
+                value=30,
+                scope='agent',
+                schema={'type': 'number', 'minimum': 0},
+                is_editable=True
+            ),
+            dict(
+                name='log_level',
+                value='info',
+                scope='agent',
+                schema={'type': 'string', 'enum': LOG_LEVELS_ENUM},
+                is_editable=True
+            ),
+            dict(
+                name='task_retries',
+                value=60,
+                scope='workflow',
+                schema={'type': 'number', 'minimum': -1},
+                is_editable=True
+            ),
+            dict(
+                name='task_retry_interval',
+                value=15,
+                scope='workflow',
+                schema={'type': 'number', 'minimum': 0},
+                is_editable=True
+            ),
+            dict(
+                name='subgraph_retries',
+                value=0,
+                scope='workflow',
+                schema={'type': 'number', 'minimum': -1},
+                is_editable=True
+            )
+        ]
+    )
 
     op.create_table(
         'certificates',

--- a/resources/rest-service/cloudify/migrations/versions/4dfd8797fdfa_4_2.py
+++ b/resources/rest-service/cloudify/migrations/versions/4dfd8797fdfa_4_2.py
@@ -26,7 +26,7 @@ def upgrade():
     # Adding the enum resource_availability to postgres
     resource_availability = postgresql.ENUM('private', 'tenant', 'global',
                                             name='resource_availability')
-    resource_availability.create(op.get_bind())
+    op.execute(postgresql.base.CreateEnumType(resource_availability))
 
     # Update the resource_availability according to private_resource
     update_query = """UPDATE {0}

--- a/resources/rest-service/cloudify/migrations/versions/7aae863786af_add_role_column_groups_tenants_table.py
+++ b/resources/rest-service/cloudify/migrations/versions/7aae863786af_add_role_column_groups_tenants_table.py
@@ -50,7 +50,7 @@ def upgrade():
         groups_tenants.update()
         .values(role_id=(
             sa.select([roles.c.id])
-            .where(roles.c.name == 'user')
+            .where(roles.c.name == op.inline_literal('user'))
         ))
     )
     op.alter_column('groups_tenants', 'role_id', nullable=False)


### PR DESCRIPTION
This allows using alembic directly, eg.:
```bash
cd /opt/manager/resources/cloudify/migrations/
/opt/manager/env/bin/alembic upgrade head
```
instead of having to go through flask-migrate.

Also, `alembic upgrade --sql head > file.sql` now works too!

The changes are about replacing ORM usage in the migrations, with
sql/expression-layer stuff instead, so eg. instead of `session.add(obj)`,
to insert things in the migration, we use `op.bulk_insert()` with a
list of dicts, etc.

