### PR TITLE
CY-2276 Resume integration tests: download a resource

### DIFF
--- a/tests/integration_tests_plugins/cloudmock/cloudmock/tasks.py
+++ b/tests/integration_tests_plugins/cloudmock/cloudmock/tasks.py
@@ -51,6 +51,11 @@ def _resumable_task_base(ctx):
         ctx.logger.info('{0} WAITING'.format(ctx.operation.name))
         time.sleep(1)
     ctx.instance.runtime_properties['resumed'] = True
+
+    # fetch some file, any file, to see if downloading works aftter a resume
+    downloaded_data = ctx.download_resource('resumable_mgmtworker.yaml')
+    ctx.logger.info('Downloaded data: %s bytes', len(downloaded_data))
+
     ctx.instance.update(_merge_handler)
 
 


### PR DESCRIPTION
Add downloading a file to the resume test function, next to the
other things we do when running a resumable function.

This is because in the past, we noted how download resource doesn't
work after a resume (in some version of 4.x), so this is a regression
test.