### PR TITLE
CY-3161 - Move stage service restart after DB restore to allow WidgetBackends table refresh

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -147,6 +147,7 @@ class SnapshotRestore(object):
                 self._possibly_update_encryption_key()
                 self._generate_new_rest_token()
                 self._restart_rest_service()
+                self._restart_stage_service()
                 self._restore_plugins(existing_plugins)
                 self._restore_credentials(postgres)
                 self._restore_agents()
@@ -220,6 +221,13 @@ class SnapshotRestore(object):
             'cloudify-restservice'
         )
         self._wait_for_rest_to_restart()
+
+    def _restart_stage_service(self):
+        utils.run_service(
+            self._service_management,
+            'restart',
+            'cloudify-stage'
+        )
 
     def _wait_for_rest_to_restart(self, timeout=60):
         deadline = time.time() + timeout

--- a/workflows/cloudify_system_workflows/snapshots/utils.py
+++ b/workflows/cloudify_system_workflows/snapshots/utils.py
@@ -153,13 +153,6 @@ def restore_stage_files(archive_root, service_management, override=False):
     finally:
         shutil.rmtree(stage_tempdir)
 
-    run_service(
-        service_management,
-        'restart',
-        'cloudify-stage',
-        ignore_failures=True
-    )
-
 
 def copy_composer_files(archive_root):
     """Copy Cloudify Composer files into the snapshot"""


### PR DESCRIPTION
It turned out during investigation that stage service restart was already done, but before stage DB migration, so I just moved it a bit further in the flow.

### Changes
* Removed stage service restart just after stage files restore
* Added stage service restart just after rest service restart (which is after stage DB restore) to allow WidgetBackends table refresh