### PR TITLE
Kill-cancel: bypass maintenance

### DIFF
--- a/mgmtworker/mgmtworker/worker.py
+++ b/mgmtworker/mgmtworker/worker.py
@@ -136,6 +136,8 @@ class MgmtworkerServiceTaskConsumer(ServiceTaskConsumer):
                 self.tenant_name = tenant['name']
                 self.rest_token = rest_token
                 self.execution_token = execution_token
+                # always bypass - this is a kill, as forceful as we can get
+                self.bypass_maintenance = True
 
         with current_workflow_ctx.push(CancelCloudifyContext()):
             self._workflow_registry.cancel(execution_id)


### PR DESCRIPTION
When kill-cancelling, always bypass maintenance. Killing stuff
is as forceful as we can get, so we need to bypass everything.

And it's useful, because you mostly only kill things when trying
to recover a manager that is in an invalid state; and recovering
managers is what maintenance mode is for