### PR TITLE
5.0.5 -> 5.1 migration downgrade: drop plugins_states [ci skip]

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/387fcd049efb_5_0_5_to_5_1.py
+++ b/resources/rest-service/cloudify/migrations/versions/387fcd049efb_5_0_5_to_5_1.py
@@ -117,6 +117,7 @@ def upgrade():
 
 
 def downgrade():
+    op.drop_table('plugins_states')
     _remove_monitoring_credentials_columns()
     _drop_usage_collector_table()
     _drop_inter_deployment_dependencies_table()


### PR DESCRIPTION
it was added in the upgrade, needs to be dropped in the downgrade.
Whoops.