### PR TITLE
Plugins UNIQUE index: add distro_ver/distro_rel to the index

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/387fcd049efb_5_0_5_to_5_1.py
+++ b/resources/rest-service/cloudify/migrations/versions/387fcd049efb_5_0_5_to_5_1.py
@@ -317,7 +317,8 @@ def _create_unique_indexes():
     op.create_index('plugins_name_version__tenant_id_idx',
                     'plugins',
                     ['package_name', 'package_version', '_tenant_id',
-                     'distribution'],
+                     'distribution', 'distribution_release',
+                     'distribution_version'],
                     unique=True)
     op.create_index('secrets_id_tenant_id_idx',
                     'secrets',

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -99,6 +99,7 @@ class Plugin(SQLResourceBase):
         db.Index(
             'plugins_name_version__tenant_id_idx',
             'package_name', 'package_version', '_tenant_id', 'distribution',
+            'distribution_release', 'distribution_version',
             unique=True
         ),
     )


### PR DESCRIPTION
People do have indexes for eg. ubuntu trusty + ubuntu precise that
don't differ by anything else.
And indeed, even we do have them in tests, eg. test_snapshots.py,
test_4_4_snapshot_restore_with_bad_plugin_fails