### PR TITLE
5.1 migration: keep_old_dependencies: use server_default

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/387fcd049efb_5_0_5_to_5_1.py
+++ b/resources/rest-service/cloudify/migrations/versions/387fcd049efb_5_0_5_to_5_1.py
@@ -13,7 +13,7 @@ Create Date: 2020-03-30 06:27:26.747213
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy import orm
+from sqlalchemy import orm, sql
 from manager_rest import storage
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.declarative import declarative_base
@@ -277,7 +277,7 @@ def _create_inter_deployment_dependencies_table():
                   sa.Column('keep_old_deployment_dependencies',
                             sa.Boolean(),
                             nullable=False,
-                            default=False))
+                            server_default=sql.expression.true()))
 
 
 def _drop_inter_deployment_dependencies_table():


### PR DESCRIPTION
`default` is the python-side default, used when creating ORM
objects on the python side. In the migrations, we don't create
any ORM objects, so `default` is useless entirely there.

Instead, `server_default` is what makes sqlalchemy make an actual
default on the DB side:
```
keep_old_deployment_dependencies | boolean                     | not null default true
```