### PR TITLE
CY-3237 Mgmtworker: retry connection

### DIFF
--- a/mgmtworker/mgmtworker/worker.py
+++ b/mgmtworker/mgmtworker/worker.py
@@ -17,6 +17,7 @@
 import os
 import sys
 import json
+import time
 import shutil
 import logging
 import argparse
@@ -263,9 +264,14 @@ def main():
     setup_agent_logger('mgmtworker')
     agent_worker.logger = logger
 
-    prepare_broker_config()
-    worker = make_amqp_worker(args)
-    worker.consume()
+    while True:
+        prepare_broker_config()
+        worker = make_amqp_worker(args)
+        try:
+            worker.consume()
+        except Exception:
+            logger.exception('Error while reading from rabbitmq')
+        time.sleep(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Relying on systemd to restart when the connection is lost is
not enough:
it will restart us indeed, but only once the process really exits.
However, it might take a very long time for the process to exit,
because all the threads need to finish first.

Example: we start handling an operation that takes 2 hours,
and immediately we lose connection to rabbitmq. The process will
only be restarted once all its threads are done, so we will stay
up for 2 hours more, with no rabbitmq connection, and so no other
workflows will be handled during that time.

Instead, stop relying on external restarts, and reconnect immediately.
Just a `while True` is fine - sigint still stops us, and we don't
need any other stop conditions.

Also, preparing the config is retried as well, in case some new
rabbitmq brokers were added.

The amqp_client has its own backoff, but add 1 second between
anyway, in case we get no brokers and go into a very fast retry loop.