### PR TITLE
CY-3320 Delete deployment after deleting dep env

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -144,7 +144,8 @@ class ResourceManager(object):
                 plugin_update.state = PluginsUpdateStates.FAILED
                 self.sm.update(plugin_update)
 
-        if execution.workflow_id == 'delete_deployment_environment':
+        if execution.workflow_id == 'delete_deployment_environment' and \
+                status == ExecutionState.TERMINATED:
             self.sm.delete(execution.deployment)
 
         return res

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -144,6 +144,9 @@ class ResourceManager(object):
                 plugin_update.state = PluginsUpdateStates.FAILED
                 self.sm.update(plugin_update)
 
+        if execution.workflow_id == 'delete_deployment_environment':
+            self.sm.delete(execution.deployment)
+
         return res
 
     def start_queued_executions(self):

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -42,7 +42,8 @@ from dsl_parser.constants import INTER_DEPLOYMENT_FUNCTIONS
 from manager_rest import premium_enabled
 from manager_rest.constants import (DEFAULT_TENANT_NAME,
                                     FILE_SERVER_BLUEPRINTS_FOLDER,
-                                    FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER)
+                                    FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER,
+                                    FILE_SERVER_DEPLOYMENTS_FOLDER)
 from manager_rest.dsl_functions import get_secret_method
 from manager_rest.utils import (send_event,
                                 is_create_global_permitted,
@@ -147,6 +148,13 @@ class ResourceManager(object):
         if execution.workflow_id == 'delete_deployment_environment' and \
                 status == ExecutionState.TERMINATED:
             self.sm.delete(execution.deployment)
+            deployment_folder = os.path.join(
+                config.instance.file_server_root,
+                FILE_SERVER_DEPLOYMENTS_FOLDER,
+                utils.current_tenant.name,
+                execution.deployment.id)
+            if os.path.exists(deployment_folder):
+                shutil.rmtree(deployment_folder)
 
         return res
 

--- a/rest-service/manager_rest/rest/resources_v1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v1/deployments.py
@@ -144,7 +144,7 @@ class DeploymentsId(SecuredResource):
         ])
 
         bypass_maintenance = is_bypass_maintenance_mode()
-        deployment = get_resource_manager().delete_deployment(
+        deployment = get_resource_manager().delete_deployment_environment(
             deployment_id,
             bypass_maintenance,
             args.force,

--- a/rest-service/manager_rest/rest/resources_v1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v1/deployments.py
@@ -14,18 +14,13 @@
 #  * limitations under the License.
 #
 
-import os
-import shutil
-
 from flask_restful_swagger import swagger
 from flask_restful.reqparse import Argument
 from flask_restful.inputs import boolean
 
-from manager_rest import config, utils
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
 from manager_rest.maintenance import is_bypass_maintenance_mode
-from manager_rest.constants import FILE_SERVER_DEPLOYMENTS_FOLDER
 from manager_rest.dsl_functions import evaluate_deployment_outputs
 from manager_rest.rest import (requests_schema,
                                responses)
@@ -142,35 +137,19 @@ class DeploymentsId(SecuredResource):
     @authorize('deployment_delete')
     @marshal_with(models.Deployment)
     def delete(self, deployment_id, **kwargs):
-        """
-        Delete deployment by id
-        """
-        args = get_args_and_verify_arguments(
-            [Argument('force', type=boolean,
-                      default=False),
-             Argument('delete_db_mode', type=boolean,
-                      default=False),
-             Argument('delete_logs', type=boolean,
-                      default=False)]
-        )
+        """Delete deployment by id"""
+        args = get_args_and_verify_arguments([
+            Argument('force', type=boolean, default=False),
+            Argument('delete_logs', type=boolean, default=False)
+        ])
 
         bypass_maintenance = is_bypass_maintenance_mode()
         deployment = get_resource_manager().delete_deployment(
             deployment_id,
             bypass_maintenance,
             args.force,
-            args.delete_db_mode,
             args.delete_logs)
 
-        if args.delete_db_mode:
-            # Delete deployment resources from file server
-            deployment_folder = os.path.join(
-                config.instance.file_server_root,
-                FILE_SERVER_DEPLOYMENTS_FOLDER,
-                utils.current_tenant.name,
-                deployment.id)
-            if os.path.exists(deployment_folder):
-                shutil.rmtree(deployment_folder)
         return deployment, 200
 
 

--- a/workflows/cloudify_system_workflows/deployment_environment.py
+++ b/workflows/cloudify_system_workflows/deployment_environment.py
@@ -65,7 +65,6 @@ def delete(ctx,
         ctx.send_event(
             "Deleting management workers' logs for deployment")
         _delete_logs(ctx)
-    _send_request_to_delete_deployment_from_db(ctx)
 
 
 def _send_request_to_delete_deployment_from_db(ctx):

--- a/workflows/cloudify_system_workflows/deployment_environment.py
+++ b/workflows/cloudify_system_workflows/deployment_environment.py
@@ -22,8 +22,6 @@ from retrying import retry
 
 from cloudify.decorators import workflow
 from cloudify.workflows import workflow_context
-from cloudify.workflows import tasks as workflow_tasks
-from cloudify.manager import get_rest_client
 
 
 @workflow
@@ -43,13 +41,6 @@ def delete(ctx, delete_logs, **_):
         ctx.logger.info("Deleting management workers' logs for deployment %s",
                         ctx.deployment.id)
         _delete_logs(ctx)
-
-
-def _send_request_to_delete_deployment_from_db(ctx):
-    client = get_rest_client()
-    client.deployments.delete(deployment_id=ctx.deployment.id,
-                              force=True,
-                              delete_db_mode=True)
 
 
 def _delete_logs(ctx):
@@ -79,14 +70,6 @@ def _delete_logs(ctx):
                 ctx.logger.exception(
                     'Failed removing rotated log file {0}.'.format(
                         rotated_log_file_path), exc_info=True)
-
-
-def _ignore_task_on_fail_and_send_event(task, ctx):
-    def failure_handler(tsk):
-        ctx.send_event('Ignoring task {0} failure'.format(tsk.name))
-        return workflow_tasks.HandlerResult.ignore()
-
-    task.on_failure = failure_handler
 
 
 def _retry_if_file_already_exists(exception):


### PR DESCRIPTION
Deleting the deployment from inside the workflow means that
the execution is deleted (via cascade from deployment) while it is
still running.
Deleting executions that are running leads them to fail.

This means deleting deployments from inside delete-dep-env
is racy, because if it just happens to poll the execution state
(to see if it was cancelled) after it was already deleted, it's
going to get a 404 and break.

Instead, delete the deployment after the delete-dep-env workflow
has finished.