### PR TITLE
test_amqp_queues_list: re-fetch queues/exchanges for assertions

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_agent_install_workflow.py
+++ b/tests/integration_tests/tests/agent_tests/test_agent_install_workflow.py
@@ -76,6 +76,10 @@ class TestWorkflow(AgentTestWithPlugins):
 
         self.undeploy_application(deployment_id)
 
+        main_queues = self._get_queues()
+        main_exchanges = self._get_exchanges()
+        tenant_queues = self._get_queues(vhost)
+        agent_exchanges = self._get_exchanges(vhost) - tenant_exchanges
         # after uninstalling the agent, there's still no new queues on
         # the / vhost
         assert self._get_queues() == main_queues


### PR DESCRIPTION
we are going to be asserting on queues/exchanges after uninstalling
the agent, so we must fetch the list of queues/exchanges after
uninstalling the agent.

We used to uninstall the agent, and then assert on the list of
exchanges that we fetched while the agent was still installed.

I think it was a pre-merge cleanup gone wrong.