### PR TITLE
CY-3435 get_all_results: omit the limit/offset clauses

### DIFF
--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -400,7 +400,11 @@ class SQLStorageManager(object):
             offset = 0
 
         total = query.order_by(None).count()  # Fastest way to count
-        results = query.limit(size).offset(offset).all()
+        if get_all_results:
+            results = query.all()
+        else:
+            results = query.limit(size).offset(offset).all()
+
         return results, total, size, offset
 
     @staticmethod

--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -13,6 +13,8 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
+import mock
+
 from cloudify.models_states import VisibilityState
 
 from manager_rest import utils
@@ -200,9 +202,12 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         self.assertFalse(hasattr(blueprint_restored, 'plan'))
         self.assertFalse(hasattr(blueprint_restored, 'main_file_name'))
 
+    @mock.patch('manager_rest.storage.storage_manager.'
+                'config.instance.default_page_size',
+                10)
     def test_all_results_query(self):
         now = utils.get_formatted_timestamp()
-        for i in range(1, 1002):
+        for i in range(20):
             secret = models.Secret(id='secret_{}'.format(i),
                                    value='value',
                                    created_at=now,
@@ -212,7 +217,13 @@ class StorageManagerTests(base_test.BaseServerTestCase):
 
         secret_list = self.sm.list(
             models.Secret,
-            include=['id', 'created_at'],
+            include=['id'],
+        )
+        self.assertEqual(10, len(secret_list))
+
+        secret_list = self.sm.list(
+            models.Secret,
+            include=['id'],
             get_all_results=True
         )
-        self.assertEqual(1000, len(secret_list))
+        self.assertEqual(20, len(secret_list))


### PR DESCRIPTION
In `_paginate`, make `get_all_results` just omit limit & offset.
Before, it was just doing nothing.

Also, the test was creating 1001 items, and then checking
that with `get_all_results` it returns 1000 (not all ie. 1001).
WHAT THE HELL.

Anyway, fixed the test, and also made it be 10 & 20 instead of 1001,
because inserting 1000 items via the storage managers takes on
the order of 10 seconds.