### PR TITLE
Upload stuff to temporary directory

### DIFF
--- a/rest-service/manager_rest/upload_manager.py
+++ b/rest-service/manager_rest/upload_manager.py
@@ -61,7 +61,7 @@ class UploadedDataManager(object):
 
     def receive_uploaded_data(self, data_id=None, **kwargs):
         file_server_root = config.instance.file_server_root
-        resource_target_path = tempfile.mktemp(dir=file_server_root)
+        resource_target_path = tempfile.mktemp()
         try:
             additional_inputs = self._save_file_locally_and_extract_inputs(
                 resource_target_path,


### PR DESCRIPTION
Instead of using file_server_root as a base directory for resource upload,
use a tempdir.  This way partially uploaded stuff will not interfere with
the Cloudify operation (Syncthing for example).