### PR TITLE
CY-3420 Passive_deletes for executions

### DIFF
--- a/rest-service/manager_rest/storage/relationships.py
+++ b/rest-service/manager_rest/storage/relationships.py
@@ -42,7 +42,7 @@ def one_to_many_relationship(child_class,
                              parent_class,
                              foreign_key_column,
                              parent_class_primary_key='_storage_id',
-                             backreference=None,
+                             backref=None,
                              cascade='all',
                              **relationship_kwargs):
     """Return a one-to-many SQL relationship object
@@ -52,17 +52,16 @@ def one_to_many_relationship(child_class,
     :param child_class: Class of the child table
     :param foreign_key_column: The column of the foreign key
     :param parent_class_primary_key: The name of the parent's primary key
-    :param backreference: The name to give to the reference to the child
+    :param backref: A sqlalchemy backref for this relationship
     :param cascade: in what cases to cascade changes from parent to child
     """
-    backreference = backreference or child_class.__tablename__
+    if backref is None:
+        backref = db.backref(child_class.__tablename__, cascade=cascade)
     parent_primary_key = getattr(parent_class, parent_class_primary_key)
     return db.relationship(
         parent_class,
         primaryjoin=lambda: parent_primary_key == foreign_key_column,
-        # The following line makes sure that when the *parent* is
-        # deleted, all its connected children are deleted as well
-        backref=db.backref(backreference, cascade=cascade),
+        backref=backref,
         **relationship_kwargs
     )
 

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -377,7 +377,9 @@ class Execution(CreatedAtMixin, SQLResourceBase):
 
     @declared_attr
     def deployment(cls):
-        return one_to_many_relationship(cls, Deployment, cls._deployment_fk)
+        return one_to_many_relationship(
+            cls, Deployment, cls._deployment_fk,
+            backref=db.backref('executions', passive_deletes=True))
 
     deployment_id = association_proxy('deployment', 'id')
     blueprint_id = db.Column(db.Text, nullable=True)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -524,15 +524,15 @@ class PluginsUpdate(CreatedAtMixin, SQLResourceBase):
             cls,
             Blueprint,
             cls._original_blueprint_fk,
-            backreference='original_of_plugins_update')
+            backref=db.backref('original_of_plugins_update')
+        )
 
     @declared_attr
     def temp_blueprint(cls):
-        return one_to_many_relationship(cls,
-                                        Blueprint,
-                                        cls._temp_blueprint_fk,
-                                        backreference='temp_of_plugins_update',
-                                        cascade=False)
+        return one_to_many_relationship(
+            cls, Blueprint, cls._temp_blueprint_fk,
+            backref=db.backref('temp_of_plugins_update', cascade=False),
+            cascade=False)
 
     blueprint_id = association_proxy('blueprint', 'id')
     temp_blueprint_id = association_proxy('temp_blueprint', 'id')
@@ -577,19 +577,17 @@ class DeploymentUpdate(CreatedAtMixin, SQLResourceBase):
 
     @declared_attr
     def old_blueprint(cls):
-        return one_to_many_relationship(cls,
-                                        Blueprint,
-                                        cls._old_blueprint_fk,
-                                        backreference='update_from',
-                                        cascade=False)
+        return one_to_many_relationship(
+            cls, Blueprint, cls._old_blueprint_fk,
+            backref=db.backref('update_from', cascade=False),
+            cascade=False)
 
     @declared_attr
     def new_blueprint(cls):
-        return one_to_many_relationship(cls,
-                                        Blueprint,
-                                        cls._new_blueprint_fk,
-                                        backreference='update_to',
-                                        cascade=False)
+        return one_to_many_relationship(
+            cls, Blueprint, cls._new_blueprint_fk,
+            backref=db.backref('update_to', cascade=False),
+            cascade=False)
 
     deployment_id = association_proxy('deployment', 'id')
     execution_id = association_proxy('execution', 'id')
@@ -645,7 +643,7 @@ class DeploymentUpdateStep(SQLResourceBase):
         return one_to_many_relationship(cls,
                                         DeploymentUpdate,
                                         cls._deployment_update_fk,
-                                        backreference='steps')
+                                        backref=db.backref('steps'))
 
     deployment_update_id = association_proxy('deployment_update', 'id')
 
@@ -673,7 +671,7 @@ class DeploymentModification(CreatedAtMixin, SQLResourceBase):
         return one_to_many_relationship(cls,
                                         Deployment,
                                         cls._deployment_fk,
-                                        backreference='modifications')
+                                        backref=db.backref('modifications'))
 
     deployment_id = association_proxy('deployment', 'id')
 
@@ -916,7 +914,8 @@ class InterDeploymentDependencies(CreatedAtMixin, SQLResourceBase):
             cls,
             Deployment,
             cls._source_deployment,
-            backreference='source_of_dependency_in')
+            backref=db.backref('source_of_dependency_in')
+        )
 
     @declared_attr
     def target_deployment(cls):
@@ -924,7 +923,10 @@ class InterDeploymentDependencies(CreatedAtMixin, SQLResourceBase):
             cls,
             Deployment,
             cls._target_deployment,
-            backreference='target_of_dependency_in',
+            backref=db.backref(
+                'target_of_dependency_in',
+                cascade='save-update, merge, refresh-expire, expunge'
+            ),
             cascade='save-update, merge, refresh-expire, expunge')
 
     source_deployment_id = association_proxy('source_deployment', 'id')


### PR DESCRIPTION
When deleting a deployment, the DB itself must do the cascade to executions,
because doing it on the python side takes too long, and that times out the request.
(with enough executions, of course)

Also, refactor passing in the backref into relationships a bit, so that this level
of configurability is actually possible