### PR TITLE
CY-3455 execute_workflow: also pass through plugin source

### DIFF
--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -86,7 +86,8 @@ def execute_workflow(name,
             'package_name': plugin.get('package_name'),
             'package_version': plugin.get('package_version'),
             'visibility': plugin.get('visibility'),
-            'tenant_name': plugin.get('tenant_name')
+            'tenant_name': plugin.get('tenant_name'),
+            'source': plugin.get('source')
         }
 
     return _execute_task(execution_id=execution_id,


### PR DESCRIPTION
If the plugin needs to be installed, because the workflow function
comes from a plugin, we need to pass through _all_ the information
required to install it. Which also includes the source field, in case
it's a source plugin.