### PR TITLE
CY-3420 Lightweight deployments delete

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -440,11 +440,12 @@ class ResourceManager(object):
                               in ExecutionState.END_STATES])))
         if not ignore_live_nodes:
             deplyment_id_filter = self.create_filters_dict(
-                deployment_id=deployment_id)
+                deployment_id=deployment_id,
+                state=lambda col: ~col.in_(['uninitialized', 'deleted'])
+            )
             node_instances = self.sm.list(
                 models.NodeInstance,
                 filters=deplyment_id_filter,
-                get_all_results=True
             )
             # validate either all nodes for this deployment are still
             # uninitialized or have been deleted
@@ -467,7 +468,7 @@ class ResourceManager(object):
         # Delete deployment data  DB (should only happen AFTER the workflow
         # finished successfully, hence the delete_db_mode flag)
         else:
-            return self.sm.delete(deployment)
+            return self.sm.delete(deployment, load_relationships=False)
 
     def _reset_operations(self, execution, from_states=None):
         """Force-resume the execution: restart failed operations.

--- a/rest-service/manager_rest/rest/resources_v1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v1/deployments.py
@@ -174,7 +174,9 @@ class DeploymentsId(SecuredResource):
                 deployment.id)
             if os.path.exists(deployment_folder):
                 shutil.rmtree(deployment_folder)
-        return deployment, 200
+        return {
+            'id': deployment.id
+        }, 200
 
 
 class DeploymentModifications(SecuredResource):

--- a/rest-service/manager_rest/storage/relationships.py
+++ b/rest-service/manager_rest/storage/relationships.py
@@ -40,7 +40,9 @@ def one_to_many_relationship(child_class,
                              foreign_key_column,
                              parent_class_primary_key='_storage_id',
                              backreference=None,
-                             cascade='all'):
+                             cascade='all',
+                             backref_kwargs=None,
+                             relationship_kwargs=None):
     """Return a one-to-many SQL relationship object
     Meant to be used from inside the *child* object
 
@@ -51,6 +53,10 @@ def one_to_many_relationship(child_class,
     :param backreference: The name to give to the reference to the child
     :param cascade: in what cases to cascade changes from parent to child
     """
+    if backref_kwargs is None:
+        backref_kwargs = {}
+    if relationship_kwargs is None:
+        relationship_kwargs = {}
     backreference = backreference or child_class.__tablename__
     parent_primary_key = getattr(parent_class, parent_class_primary_key)
     return db.relationship(
@@ -58,7 +64,8 @@ def one_to_many_relationship(child_class,
         primaryjoin=lambda: parent_primary_key == foreign_key_column,
         # The following line makes sure that when the *parent* is
         # deleted, all its connected children are deleted as well
-        backref=db.backref(backreference, cascade=cascade)
+        backref=db.backref(backreference, cascade=cascade, **backref_kwargs),
+        **relationship_kwargs
     )
 
 

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -238,7 +238,10 @@ class Execution(CreatedAtMixin, SQLResourceBase):
 
     @declared_attr
     def deployment(cls):
-        return one_to_many_relationship(cls, Deployment, cls._deployment_fk)
+        return one_to_many_relationship(
+            cls, Deployment, cls._deployment_fk,
+            backref_kwargs={'passive_deletes': True}
+        )
 
     deployment_id = association_proxy('deployment', 'id')
     blueprint_id = association_proxy('deployment', 'blueprint_id')
@@ -491,7 +494,10 @@ class Node(SQLResourceBase):
 
     @declared_attr
     def deployment(cls):
-        return one_to_many_relationship(cls, Deployment, cls._deployment_fk)
+        return one_to_many_relationship(
+            cls, Deployment, cls._deployment_fk,
+            backref_kwargs={'passive_deletes': True}
+        )
 
     deployment_id = association_proxy('deployment', 'id')
     blueprint_id = association_proxy('deployment', 'blueprint_id')

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -581,11 +581,12 @@ class SQLStorageManager(object):
         self._validate_unique_resource_id_per_tenant(instance)
         return instance
 
-    def delete(self, instance):
+    def delete(self, instance, load_relationships=True):
         """Delete the passed instance
         """
         current_app.logger.debug('Delete {0}'.format(instance))
-        self._load_relationships(instance)
+        if load_relationships:
+            self._load_relationships(instance)
         db.session.delete(instance)
         self._safe_commit()
         return instance


### PR DESCRIPTION
Deleting deployments can lead to fetching an unbounded amount of
items - executions and node instances - to delete it ORM-side, and to
return them as part of the response.

Instead of deleting them ORM-side, delete them DB-side: we already
have the CASCADE set up on the DB side, we just need to say
passive_deletes so that sqlalchemy knows not to touch the
relationship.

Instead of returning the whole deployment object, with embedded
relationships, just return a mock object with just the id.
We can't avoid returning _something_ because the 4.6 CLI expects us
to return a dict.
We'll only do it for deployments, because this is the most affected
endpoint, and other endpoints aren't having problems in practice
(and this is a 4.6 fix, on an as-needed basis)