### PR TITLE
CY-3536 Move deployment workdir

### DIFF
--- a/workflows/cloudify_system_workflows/deployment_environment.py
+++ b/workflows/cloudify_system_workflows/deployment_environment.py
@@ -117,5 +117,5 @@ def _delete_deployment_workdir(ctx):
 
 
 def _workdir(deployment_id, tenant):
-    base_workdir = os.environ['AGENT_WORK_DIR']
-    return os.path.join(base_workdir, 'deployments', tenant, deployment_id)
+    return os.path.join('/opt', 'manager', 'resources', 'deployments',
+                        tenant, deployment_id)


### PR DESCRIPTION
It should be under the replicated /opt/manager/resources/deployments