### PR TITLE
deployment delete: return a rendered execution object

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -147,8 +147,10 @@ class ResourceManager(object):
 
         if execution.workflow_id == 'delete_deployment_environment' and \
                 status == ExecutionState.TERMINATED:
+            # render the execution here, because immediately afterwards
+            # we'll delete it, and then we won't be able to render it anymore
+            res = res.to_response()
             self.delete_deployment(execution.deployment)
-
         return res
 
     def start_queued_executions(self):


### PR DESCRIPTION
when running PATCH to update the delete-dep-env execution status,
which makes the deployment be actually deleted, that makes the
execution be deleted as well, and the request returns 500.

Instead, pre-render the execution to-be-returned ahead of time,
before we delete it.

It is a bit ugly to return a rendered dict from here, but we don't
really have a better way.

A long-term better way would be to not ad-hoc'ly get/render
attributes from the database in rendering, but only fetch them
once. But that's a framework-level question.