### PR TITLE
CY-3539 Error logging: make auth error logs DEBUG

### DIFF
--- a/rest-service/manager_rest/app_logging.py
+++ b/rest-service/manager_rest/app_logging.py
@@ -1,5 +1,6 @@
 import sys
 import logging
+import warnings
 
 from flask import current_app, request
 from logging.handlers import WatchedFileHandler
@@ -75,6 +76,10 @@ def log_response(response):
 
 
 def raise_unauthorized_user_error(extra_info=None):
+    warnings.warn(
+        'raise_unauthorized_user_error is deprecated, raise an '
+        'UnauthorizedError directly instead',
+        DeprecationWarning)
     error = 'User unauthorized'
     if extra_info:
         error += ': {0}'.format(extra_info)

--- a/rest-service/manager_rest/manager_exceptions.py
+++ b/rest-service/manager_rest/manager_exceptions.py
@@ -146,10 +146,13 @@ class NoTokenGeneratorError(ManagerException):
 class UnauthorizedError(ManagerException):
     UNAUTHORIZED_ERROR_CODE = 'unauthorized_error'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, extra_info, *args, **kwargs):
+        message = 'User unauthorized'
+        if extra_info:
+            message = '{0}: {1}'.format(message, extra_info)
         super(UnauthorizedError, self).__init__(
             401, UnauthorizedError.UNAUTHORIZED_ERROR_CODE,
-            *args, **kwargs)
+            message, *args, **kwargs)
 
 
 class ForbiddenError(ManagerException):

--- a/rest-service/manager_rest/manager_exceptions.py
+++ b/rest-service/manager_rest/manager_exceptions.py
@@ -155,6 +155,13 @@ class UnauthorizedError(ManagerException):
             message, *args, **kwargs)
 
 
+class NoAuthProvided(UnauthorizedError):
+    """Not authorized, because authentication was not provided."""
+    def __init__(self, *args, **kwargs):
+        super(NoAuthProvided, self).__init__(
+            'No authentication info provided', *args, **kwargs)
+
+
 class ForbiddenError(ManagerException):
     FORBIDDEN_ERROR_CODE = 'forbidden_error'
 

--- a/rest-service/manager_rest/security/authentication.py
+++ b/rest-service/manager_rest/security/authentication.py
@@ -29,7 +29,7 @@ from manager_rest.execution_token import (
     current_execution,
     get_execution_token_from_request
 )
-from manager_rest.manager_exceptions import UnauthorizedError
+from manager_rest.manager_exceptions import UnauthorizedError, NoAuthProvided
 
 
 Authorization = namedtuple('Authorization', 'username password')
@@ -74,7 +74,7 @@ class Authentication(object):
                 return response
             user = response
         if not user:
-            raise UnauthorizedError('No authentication info provided')
+            raise NoAuthProvided()
         self.logger.debug('Authenticated user: {0}'.format(user))
 
         if request.authorization:
@@ -168,7 +168,7 @@ class Authentication(object):
                 'Authentication token is invalid:\n{0}'.format(error)
             )
         elif not user:
-            raise UnauthorizedError('No authentication info provided')
+            raise NoAuthProvided()
         else:
             self._verify_token(token=data[1], user=user)
 

--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -50,7 +50,7 @@ app_errors = Blueprint('app_errors', __name__)
 
 @app_errors.app_errorhandler(manager_exceptions.ManagerException)
 def manager_exception(error):
-    if isinstance(error, manager_exceptions.UnauthorizedError):
+    if isinstance(error, manager_exceptions.NoAuthProvided):
         current_app.logger.debug(error)
     else:
         current_app.logger.error(error)

--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -50,7 +50,10 @@ app_errors = Blueprint('app_errors', __name__)
 
 @app_errors.app_errorhandler(manager_exceptions.ManagerException)
 def manager_exception(error):
-    current_app.logger.error(error)
+    if isinstance(error, manager_exceptions.UnauthorizedError):
+        current_app.logger.debug(error)
+    else:
+        current_app.logger.error(error)
     return jsonify(
         message=str(error),
         error_code=error.error_code,


### PR DESCRIPTION
All kinds of bad auth can flood the logs with useless logs.
The big offender is the status checkers, as even the built-in one
generates one log every 15 seconds, and of course there can be
user-specific ones on top of that.

These logs are also useless for detecting attacks, as they don't
include any kind of identification with them (eg. an IP). Nginx logs
serve better for that.

Hide the auth logs by default, by making them debug-level.