### PR TITLE
REST unittests: allow 200 in delete

### DIFF
--- a/rest-service/manager_rest/test/mocks.py
+++ b/rest-service/manager_rest/test/mocks.py
@@ -14,6 +14,7 @@
 #  * limitations under the License.
 
 import types
+import numbers
 from datetime import datetime
 
 from functools import wraps
@@ -135,7 +136,9 @@ class MockHTTPClient(HTTPClient):
         else:
             raise NotImplementedError()
 
-        if response.status_code != expected_status_code:
+        if isinstance(expected_status_code, numbers.Number):
+            expected_status_code = [expected_status_code]
+        if response.status_code not in expected_status_code:
             response.content = response.data
             self._raise_client_error(MockClientResponse(response), request_url)
 


### PR DESCRIPTION
This replicates the back-compat change we did
in cloudify-cosmo/cloudify-common#562