### PR TITLE
CY-3577 cfy plugins update

### DIFF
--- a/rest-service/manager_rest/shell/update_plugin_imports.py
+++ b/rest-service/manager_rest/shell/update_plugin_imports.py
@@ -367,6 +367,10 @@ def scan_blueprint(blueprint: models.Blueprint,
                          suggested_is_pinned=is_pinned_version)
             continue
         plugin_in_plan = find_plugin_in_a_plan(blueprint.plan, plugin_name)
+        if not plugin_in_plan:
+            update_stats(suggested_import_from=import_from,
+                         suggested_is_pinned=is_pinned_version)
+            continue
         suggested_version = suggest_version(
             plugin_name, plugin_in_plan[PLUGIN_PACKAGE_VERSION]
         )


### PR DESCRIPTION
In case a plugin is declared in a blueprint but not used in a plan,
just skip it.