### PR TITLE
Dep-update: when comparing groups, ignore members ordering

### DIFF
--- a/rest-service/manager_rest/deployment_update/step_extractor.py
+++ b/rest-service/manager_rest/deployment_update/step_extractor.py
@@ -519,8 +519,11 @@ class StepExtractor(object):
             for entity_name in new_entities:
                 with self.entity_id_builder.extend_id(entity_name):
                     if entity_name in old_entities:
-                        if old_entities[entity_name] != \
-                                new_entities[entity_name]:
+                        if self._has_changed(
+                            entities_name,
+                            old_entities[entity_name],
+                            new_entities[entity_name]
+                        ):
                             self._create_step(
                                 self.entity_id_segment_to_entity_type[
                                     entities_name],
@@ -533,6 +536,19 @@ class StepExtractor(object):
                                 entities_name],
                             supported
                         )
+    def _has_changed(self, entities_name, old, new):
+        """Is old different than new, if both are of kind entity_type?
+
+        Some entity kinds need a more complex comparison than just !=.
+        """
+        if entities_name == GROUPS:
+            # group's members is a list, but it should ignore order
+            old_clone = old.copy()
+            new_clone = new.copy()
+            old_members = set(old_clone.pop('members', ()))
+            new_members = set(new_clone.pop('members', ()))
+            return old_members != new_members or old_clone != new_clone
+        return old != new
 
     def _extract_steps(self, new, old):
         for entities_name, new_entities in new.items():

--- a/rest-service/manager_rest/test/endpoints/test_deployment_update_step_extraction.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_update_step_extraction.py
@@ -1972,6 +1972,17 @@ class StepExtractorTestCase(unittest.TestCase):
 
         self.assertEqual(expected_steps, steps)
 
+    def test_groups_member_order(self):
+        groups_old = {GROUPS: {'group1': {'members': ['a', 'b']}}}
+        groups_new = {GROUPS: {'group1': {'members': ['b', 'a']}}}
+
+        self.step_extractor.old_deployment_plan.update(groups_old)
+        self.step_extractor.new_deployment_plan.update(groups_new)
+
+        _, steps = self.step_extractor.extract_steps()
+
+        self.assertEqual([], steps)
+
     def test_cda_plugins_no_install(self):
 
         cda_plugins_new = {

--- a/rest-service/manager_rest/test/endpoints/test_deployment_update_step_extraction.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_update_step_extraction.py
@@ -1907,7 +1907,7 @@ class StepExtractorTestCase(unittest.TestCase):
 
     def test_groups_no_change(self):
 
-        groups_old = {GROUPS: {'group1': 'group1_value'}}
+        groups_old = {GROUPS: {'group1': {}}}
         groups_new = groups_old
 
         self.step_extractor.old_deployment_plan.update(groups_old)
@@ -1918,7 +1918,7 @@ class StepExtractorTestCase(unittest.TestCase):
 
     def test_groups_add_group(self):
 
-        groups_new = {GROUPS: {'group1': 'group1_value'}}
+        groups_new = {GROUPS: {'group1': {}}}
 
         self.step_extractor.new_deployment_plan.update(groups_new)
 
@@ -1936,7 +1936,7 @@ class StepExtractorTestCase(unittest.TestCase):
 
     def test_groups_remove_group(self):
 
-        groups_old = {GROUPS: {'group1': 'group1_value'}}
+        groups_old = {GROUPS: {'group1': {}}}
 
         self.step_extractor.old_deployment_plan.update(groups_old)
 
@@ -1954,8 +1954,8 @@ class StepExtractorTestCase(unittest.TestCase):
 
     def test_groups_modify_group(self):
 
-        groups_old = {GROUPS: {'group1': 'group1_value'}}
-        groups_new = {GROUPS: {'group1': 'group1_modified_value'}}
+        groups_old = {GROUPS: {'group1': {'members': []}}}
+        groups_new = {GROUPS: {'group1': {'members': ['a']}}}
 
         self.step_extractor.old_deployment_plan.update(groups_old)
         self.step_extractor.new_deployment_plan.update(groups_new)


### PR DESCRIPTION
Group members is a list, but there is no difference between a group
with members [a, b] and a group with members [b, a]. It is the same
group and should compare equal.