### PR TITLE
RESTservice: use a request-local for the .parser_context

### DIFF
--- a/rest-service/manager_rest/app_context.py
+++ b/rest-service/manager_rest/app_context.py
@@ -13,7 +13,7 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from flask import current_app
+from flask import g
 
 from dsl_parser import constants
 from dsl_parser import utils as dsl_parser_utils
@@ -25,16 +25,16 @@ from manager_rest.storage.models import ProviderContext
 
 def get_parser_context(sm=None, resolver_parameters=None):
     sm = sm or get_storage_manager()
-    if not hasattr(current_app, 'parser_context'):
+    if not hasattr(g, 'parser_context'):
         update_parser_context(
             sm.get(ProviderContext, PROVIDER_CONTEXT_ID).context,
             resolver_parameters
         )
-    return current_app.parser_context
+    return g.parser_context
 
 
 def update_parser_context(context, resolver_parameters=None):
-    current_app.parser_context = _extract_parser_context(
+    g.parser_context = _extract_parser_context(
         context, resolver_parameters)
 
 

--- a/rest-service/manager_rest/test/infrastructure/test_parse_with_resolver.py
+++ b/rest-service/manager_rest/test/infrastructure/test_parse_with_resolver.py
@@ -109,28 +109,25 @@ class UploadBlueprintsWithImportResolverTests(BaseServerTestCase):
         self.assertEqual(create_import_resolver_inputs[0]['rules'],
                          resolver_section['rules'])
 
-        self.assertEqual(self.app.application.parser_context['resolver'],
-                         'mock expected import resolver')
-
     def test_resolver_update_in_app(self):
         # upload blueprint
         self.test_upload_blueprint_with_resolver()
-        # update current app
-        self.app.application.parser_context = {
-            'resolver': 'mock resolver',
-            'validate_version': True
-        }
+
         # upload blueprint again and check that
         # the expected resolver passed to the parser
         with mock.patch(
-                'dsl_parser.tasks.parse_dsl',
-                mock.MagicMock(return_value={})
+            'manager_rest.app_context.get_parser_context',
+            return_value={'resolver': 'mock', 'validate_version': True}
+        ), mock.patch(
+            'dsl_parser.tasks.parse_dsl',
+            return_value={}
         ) as mock_parse_dsl:
             self.put_file(*self.put_blueprint_args(blueprint_id='bp-2'))
-            mock_parse_dsl.assert_called_once_with(
-                mock.ANY, mock.ANY,
-                resolver='mock resolver',
-                validate_version=mock.ANY)
+
+        mock_parse_dsl.assert_called_once_with(
+            mock.ANY, mock.ANY,
+            resolver='mock',
+            validate_version=mock.ANY)
 
     def test_failed_to_initialize_resolver(self):
 


### PR DESCRIPTION
We can't just set the parser settings on the app, because that can
get persisted across requests, and then multiple requests will
wrongly use the same parser settings (eg. same plugin_mappings).

Instead, use a per-request variable.

It would be good to not use these context variables at all, but
just pass the arguments through instead, but for now...