### PR TITLE
inte-tests: add plugin state checks to the plugin update tests

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_plugin_update.py
+++ b/tests/integration_tests/tests/agent_tests/test_plugin_update.py
@@ -72,6 +72,7 @@ def uploads_mock_plugins(f):
     return wrapper
 
 
+@pytest.mark.usefixtures('allow_agent')
 class TestPluginUpdate(AgentTestWithPlugins):
     versions = ['1.0', '2.0']
     dsl_resources_path = resource(os.path.join('dsl', 'agent_tests'))

--- a/tests/integration_tests/tests/agent_tests/test_plugin_update.py
+++ b/tests/integration_tests/tests/agent_tests/test_plugin_update.py
@@ -346,6 +346,18 @@ class TestPluginUpdate(AgentTestWithPlugins):
     def _assert_on_values(self, version):
         self._assert_cda_values(version)
         self._assert_host_values(version)
+        plugins = self.client.plugins.list(package_name='version_aware')
+        if not plugins:
+            return
+        target_plugin = next(p for p in plugins
+                             if p.package_version == version)
+        other_plugins = [p for p in plugins if p.package_version != version]
+
+        assert all(pstate['state'] == 'installed'
+                   for pstate in target_plugin.installation_state)
+        for other_plugin in other_plugins:
+            assert all(pstate['state'] != 'installed'
+                       for pstate in other_plugin.installation_state)
 
     def _upload_blueprints_and_deploy_base(self):
         self.deploy_application(


### PR DESCRIPTION
Next to testing that the right version of the plugin was used,
also fetch the plugins and assert on its stored state.