### PR TITLE
TestManagerStatus: increase service wait time

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_manager_status.py
+++ b/tests/integration_tests/tests/agentless_tests/test_manager_status.py
@@ -110,7 +110,7 @@ class TestManagerStatus(AgentlessTestCase):
                 SERVICES[service]
             )
         )
-        time.sleep(2)
+        time.sleep(5)
         status = self.client.manager.get_status()
         self.assertEqual(status['status'], ServiceStatus.HEALTHY)
         self.assertEqual(status['services'][service]['status'],


### PR DESCRIPTION
2 seconds is not enough of a wait because dependent services might
need more time to start. For example, stop/starting rabbitmq will
also lead to its dependent services (amqp-postgres) to stop/start,
and that takes a bit longer than 2 seconds. It seems 5 seconds is
enough.