### PR TITLE
inte-tests setup.py: use find_packages

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,17 +13,14 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='cloudify-integration-tests',
     version='5.0.5',
     author='Cloudify',
     author_email='cosmo-admin@cloudify.co',
-    packages=[
-        'integration_tests',
-        'integration_tests_plugins',
-    ],
+    packages=find_packages(),
     description='Cloudify Integration Tests',
     zip_safe=False,
     install_requires=[

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cloudify-integration-tests',
-    version='5.0.5',
+    version='5.2.0.dev1',
     author='Cloudify',
     author_email='cosmo-admin@cloudify.co',
     packages=find_packages(),


### PR DESCRIPTION
instead of providing the list of packages. The problem is, the
list of packages was provided wrong anyway, because it didn't
include sub-packages.