### PR TITLE
RD-178 kill-cancel: cope with malformed agents

### DIFF
--- a/mgmtworker/mgmtworker/worker.py
+++ b/mgmtworker/mgmtworker/worker.py
@@ -223,7 +223,11 @@ class MgmtworkerServiceTaskConsumer(ServiceTaskConsumer):
             _get_all_results=True)
         for instance in node_instances:
             if self._is_agent(instance):
-                yield instance.runtime_properties['cloudify_agent']['queue']
+                try:
+                    yield instance.runtime_properties[
+                        'cloudify_agent']['queue']
+                except KeyError:
+                    pass
 
     def _is_agent(self, node_instance):
         """Does the node_instance have an agent?"""


### PR DESCRIPTION
If the agent doesn't have a queue property, we want to just ignore
it (we can't do anything anyway) instead of dying.

This can happen for agents who weren't installed properly
(which, btw, is one of the reasons you might want to kill-cancel
in the first place)