### PR TITLE
Filter out non-local services from federated results

### DIFF
--- a/rest-service/manager_rest/cluster_status_manager.py
+++ b/rest-service/manager_rest/cluster_status_manager.py
@@ -201,7 +201,7 @@ def _add_monitoring_data(cluster_nodes):
     for address, results in status_getter.get(cluster_nodes).items():
         results = [
             metric for metric in results
-            if 'federate' not in metric.get('metric', {}).get('job', '')
+            if 'cloudify' not in metric.get('metric', {}).get('monitor', '')
         ]
         service_results, metric_results = _parse_prometheus_results(results)
 


### PR DESCRIPTION
Now a slightly different approach to filtering-out Prometheus
federated results should be taken.