### PR TITLE
RD-78 Derive Prometheus alerts `for` param from config

### DIFF
--- a/mgmtworker/setup.py
+++ b/mgmtworker/setup.py
@@ -19,6 +19,7 @@ install_requires = [
     'cloudify-common==5.1.1.dev1',
     'cloudify-agent==5.1.1.dev1',
     'packaging==17.1',
+    'pyyaml==5.3.1',
 ]
 
 

--- a/mgmtworker/setup.py
+++ b/mgmtworker/setup.py
@@ -19,7 +19,6 @@ install_requires = [
     'cloudify-common==5.1.1.dev1',
     'cloudify-agent==5.1.1.dev1',
     'packaging==17.1',
-    'pyyaml==5.3.1',
 ]
 
 


### PR DESCRIPTION
Prometheus alerts parameter defining how long should alert be pending
is delivered from Prometheus `global.scrape_interval` parameter.  `for`
value is smaller of the two: 15s or `scrape_interval`.