### PR TITLE
snap-res: narrow down the executions list request

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -707,6 +707,8 @@ class SnapshotRestore(object):
     def _wait_for_plugin_executions(self, client):
         while True:
             executions = client.executions.list(
+                include=['id', 'workflow_id', 'status'],
+                workflow_id='install_plugin',
                 include_system_workflows=True,
                 _all_tenants=True,
                 _get_all_results=True

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -707,7 +707,7 @@ class SnapshotRestore(object):
     def _wait_for_plugin_executions(self, client):
         while True:
             executions = client.executions.list(
-                include=['id', 'workflow_id', 'status'],
+                _include=['id', 'workflow_id', 'status'],
                 workflow_id='install_plugin',
                 include_system_workflows=True,
                 _all_tenants=True,


### PR DESCRIPTION
The request looking for plugin install executions, currently lists
all executions ever, which is way too expensive. Instead,
only look for install_plugin executions, and only fetch a few
columns from it, to reduce the response size even more