### PR TITLE
inte-tests: daemonize the script when installing an agent

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_resume.py
+++ b/tests/integration_tests/tests/agent_tests/test_resume.py
@@ -28,6 +28,7 @@ AFTER_MESSAGE = 'AFTER SLEEP'
 
 
 @pytest.mark.usefixtures('cloudmock_plugin')
+@pytest.mark.usefixtures('allow_agent')
 class TestResumeMgmtworker(AgentTestCase):
     def _start_execution(self, deployment, operation, wait_seconds=20):
         return self.execute_workflow(

--- a/tests/integration_tests/tests/agent_tests/test_resume.py
+++ b/tests/integration_tests/tests/agent_tests/test_resume.py
@@ -18,7 +18,6 @@ import uuid
 import pytest
 
 from integration_tests import AgentTestCase
-from integration_tests.framework import docker
 from integration_tests.tests.utils import get_resource as resource
 
 
@@ -41,30 +40,6 @@ class TestResumeMgmtworker(AgentTestCase):
                             'wait_seconds': wait_seconds
                         }})
 
-    def _detach_agents(self):
-        """Detach agents from the mgmtworker.
-
-        On systemd, agents spawned by the mgmtworker still belong to the
-        mgmtworker cgroup, and are also killed when the mgmtworker stops.
-        Detach them from that cgroup by attaching them to another one
-        so that they can stay up when we stop the mgmtworker.
-
-        To do that, figure out the agent PIDs, and put them into
-        the other-cgroup-dir/tasks file.
-        """
-        if self.get_service_management_command() != 'systemctl':
-            return
-        agent_pids = docker.execute(self.env.container_id, [
-            'pgrep', '-f', 'agent_host'
-        ]).splitlines()
-        for pid in agent_pids:
-            if not pid:
-                continue
-            docker.execute(self.env.container_id, [
-                'bash', '-c',
-                'echo {0} > /sys/fs/cgroup/systemd/tasks'.format(pid)
-            ])
-
     def _stop_mgmtworker(self):
         self.logger.info('Stopping mgmtworker')
         service_command = self.get_service_management_command()
@@ -85,7 +60,6 @@ class TestResumeMgmtworker(AgentTestCase):
         dsl_path = resource('dsl/resumable_agent.yaml')
         deployment, execution_id = self.deploy_application(
             dsl_path, deployment_id=deployment_id)
-        self._detach_agents()
 
         execution = self._start_execution(deployment, 'interface1.op1')
 
@@ -94,7 +68,6 @@ class TestResumeMgmtworker(AgentTestCase):
         instance = self.client.node_instances.list(
             node_id='agent_host', deployment_id=deployment.id)[0]
         self.assertFalse(instance.runtime_properties['resumed'])
-
         # restart mgmtworker
         self._stop_mgmtworker()
         self._start_mgmtworker()
@@ -111,7 +84,6 @@ class TestResumeMgmtworker(AgentTestCase):
         dsl_path = resource('dsl/resumable_agent.yaml')
         deployment, execution_id = self.deploy_application(
             dsl_path, deployment_id=deployment_id)
-        self._detach_agents()
 
         execution = self._start_execution(
             deployment, 'interface1.op1', wait_seconds=10)


### PR DESCRIPTION
Detaching from the parent process so that the agent is not
killed when the mgmtworker dies

Also, the ad-hoc detach in test_resume.py is now unnecessary