### PR TITLE
RD-79 Get rid of remote Prometheus calls

### DIFF
--- a/rest-service/manager_rest/cluster_status_manager.py
+++ b/rest-service/manager_rest/cluster_status_manager.py
@@ -126,8 +126,8 @@ def get_cluster_status(detailed=False):
 
 
 def _add_monitoring_data(cluster_nodes):
-    # We are taking a step towards using federated data from the local
-    # Prometheus only.
+    # Get all the data in one fell swoop (thanks to the underlying Prometheus
+    # federation).
     query_string = ' or '.join(QUERY_STRINGS.values())
     global_results = prometheus_query(
         query_string=query_string,

--- a/rest-service/manager_rest/cluster_status_manager.py
+++ b/rest-service/manager_rest/cluster_status_manager.py
@@ -1,5 +1,3 @@
-import threading
-import queue
 from datetime import datetime
 
 from flask import current_app
@@ -326,7 +324,7 @@ def _host_matches(struct, node_private_ip):
 
 
 def _strip_keys(struct, keys):
-    """Return copy of struct but without the keys listed"""
+    """Return copy of struct but without the keys listed."""
     if not isinstance(keys, list):
         keys = [keys]
     return {k: v for k, v in struct.items() if k not in keys}

--- a/rest-service/manager_rest/prometheus_client.py
+++ b/rest-service/manager_rest/prometheus_client.py
@@ -1,10 +1,9 @@
 import requests
-QUERY_URL_TEMPLATE = 'https://{address}:8009/monitoring/api/v1/query'
+LOCAL_QUERY_URL = 'http://127.0.0.1:9090/monitoring/api/v1/query'
 
 
-def query(address, query_string, logger, auth=None, ca_path=None,
-          timeout=None):
-    query_url = QUERY_URL_TEMPLATE.format(address=address)
+def query(query_string, logger, timeout=None):
+    query_url = LOCAL_QUERY_URL
     url_with_query_string = (
         query_url + '?query=' + requests.utils.quote(query_string)
     )
@@ -12,15 +11,11 @@ def query(address, query_string, logger, auth=None, ca_path=None,
     try:
         r = requests.get(query_url,
                          params=params,
-                         auth=auth,
-                         verify=ca_path if ca_path else True,
                          timeout=timeout)
     except Exception as err:
         logger.error(
-            "Error retrieving prometheus results from '%s' with ca '%s': "
-            "(%s) %s",
+            "Error retrieving prometheus results from '%s': (%s) %s",
             url_with_query_string,
-            ca_path,
             type(err),
             err,
         )
@@ -30,10 +25,9 @@ def query(address, query_string, logger, auth=None, ca_path=None,
 
         if not result:
             logger.error(
-                "Could not get prometheus results from '%s' with ca '%s'. "
+                "Could not get prometheus results from '%s'. "
                 'Response code %s.',
                 url_with_query_string,
-                ca_path,
                 r.status_code,
             )
     return result


### PR DESCRIPTION
Start using federated Prometheus data recorded on each manager node to
determine Cloudify cluster status.