### PR TITLE
RD-476 Create PATCH deployment-id endpoint

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1476,8 +1476,7 @@ class ResourceManager(object):
         self._create_deployment_initial_dependencies(
             deployment_plan, new_deployment)
 
-        if labels:
-            self._create_deployment_labels(new_deployment, labels)
+        self.create_deployment_labels(new_deployment, labels)
 
         try:
             self._create_deployment_environment(new_deployment,
@@ -2438,7 +2437,7 @@ class ResourceManager(object):
                 dep_graph.assert_no_cyclic_dependencies(source_id, target_id)
                 dep_graph.add_dependency_to_graph(source_id, target_id)
 
-    def _create_deployment_labels(self, deployment, labels_list):
+    def create_deployment_labels(self, deployment, labels_list):
         """
         Populate the deployments_labels table.
 
@@ -2446,6 +2445,9 @@ class ResourceManager(object):
         :param labels_list: A list of labels of the form:
                             [(key1, value1), (key2, value2)]
         """
+        if not labels_list:
+            return
+
         current_time = utils.get_formatted_timestamp()
         for key, value in labels_list:
             self.sm.put(

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2452,8 +2452,8 @@ class ResourceManager(object):
         for key, value in labels_list:
             self.sm.put(
                 models.DeploymentLabel(
-                    key=key.lower(),
-                    value=value.lower(),
+                    key=key,
+                    value=value,
                     created_at=current_time,
                     deployment=deployment,
                     creator=current_user

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -32,7 +32,8 @@ from manager_rest import utils, manager_exceptions
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
 from manager_rest.storage import models, get_storage_manager
-from manager_rest.manager_exceptions import BadParametersError
+from manager_rest.manager_exceptions import (BadParametersError,
+                                             IllegalActionError)
 from manager_rest.resource_manager import get_resource_manager
 from manager_rest.maintenance import is_bypass_maintenance_mode
 from manager_rest.dsl_functions import evaluate_deployment_capabilities
@@ -97,6 +98,59 @@ class DeploymentsId(resources_v1.DeploymentsId):
             labels=_get_labels(request_dict)
         )
         return deployment, 201
+
+    @authorize('deployment_create')
+    @rest_decorators.marshal_with(models.Deployment)
+    def patch(self, deployment_id):
+        """
+        Update a deployment
+
+        Currently, this function only updates the deployment's labels.
+        """
+        rest_utils.validate_inputs({'deployment_id': deployment_id})
+        if not request.json:
+            raise IllegalActionError('Update a deployment request must include'
+                                     ' at least one parameter to update')
+        sm = get_storage_manager()
+        deployment = sm.get(models.Deployment, deployment_id)
+
+        _update_labels(sm, deployment)
+
+        return deployment
+
+
+def _update_labels(sm, deployment):
+    """
+    Updating the deployment's labels.
+
+    This function replaces the existing deployment's lables with the new labels
+    that were passed in the request.
+    If a new label already exists, it won't be created again.
+    If an existing label is not in the new labels list, it will be deleted.
+    """
+    new_labels = _get_labels(request.json)
+    if new_labels is None:
+        return
+
+    rm = get_resource_manager()
+    new_labels_set = set(new_labels)
+    existing_labels = sm.list(
+        models.DeploymentLabel,
+        filters={'_deployment_fk': deployment._storage_id}
+    )
+    existing_labels_tup = set(
+        (label.key, label.value) for label in existing_labels)
+
+    labels_to_create = new_labels_set - existing_labels_tup
+    raw_labels_to_delete = existing_labels_tup - new_labels_set
+    labels_to_delete = [
+        label for label in existing_labels if
+        (label.key, label.value) in raw_labels_to_delete]
+
+    for label in labels_to_delete:
+        sm.delete(label)
+
+    rm.create_deployment_labels(deployment, labels_to_create)
 
 
 def _get_labels(request_dict):


### PR DESCRIPTION
We would like to create a `PATCH /deployments/DEPLOYMENT_ID` endpoint to patch existing deployments. Currently, this endpoint will be used to patch the deployment's labels. 