### PR TITLE
RD-544 Even more than one system service is fine

### DIFF
--- a/rest-service/manager_rest/cluster_status_manager.py
+++ b/rest-service/manager_rest/cluster_status_manager.py
@@ -403,7 +403,7 @@ def _parse_prometheus_results(prometheus_results):
         # Technically the second element in the tuple is the metric value, but
         # we only use it to indicate health currently
         timestamp, healthy = result.get('value', [0, ''])
-        healthy = healthy == '1'
+        healthy = bool(int(healthy)) if healthy else False
 
         process_manager = metric.get('process_manager')
 


### PR DESCRIPTION
With the recent transition to recording rules, status reporter can have
the same system service process reported more than once (because of the
`sum by` aggregation used in recording rules).  While this might be a
little bit controversial and could mean some mis-configuration, it is
perfectly safe to assume values `>= 1` mean process is running (just
as `== 1` indicated it when simple queries were used).