### PR TITLE
RD-479 list key values

### DIFF
--- a/rest-service/manager_rest/rest/endpoint_mapper.py
+++ b/rest-service/manager_rest/rest/endpoint_mapper.py
@@ -128,7 +128,7 @@ def setup_resources(api):
         'SitesName': 'sites/<string:name>',
         'ClusterStatus': 'cluster-status',
         'DeploymentsLabels': 'labels/deployments',
-        'DeploymentsLabelsKey': 'labels/deployments/<string:key>'
+        'DeploymentsLabelsKey': 'labels/deployments/<string:key>',
     }
 
     # Set version endpoint as a non versioned endpoint

--- a/rest-service/manager_rest/rest/endpoint_mapper.py
+++ b/rest-service/manager_rest/rest/endpoint_mapper.py
@@ -128,6 +128,7 @@ def setup_resources(api):
         'SitesName': 'sites/<string:name>',
         'ClusterStatus': 'cluster-status',
         'DeploymentsLabels': 'labels/deployments',
+        'DeploymnetsLabelsKey': 'labels/deployments/<string:key>'
     }
 
     # Set version endpoint as a non versioned endpoint

--- a/rest-service/manager_rest/rest/endpoint_mapper.py
+++ b/rest-service/manager_rest/rest/endpoint_mapper.py
@@ -128,7 +128,7 @@ def setup_resources(api):
         'SitesName': 'sites/<string:name>',
         'ClusterStatus': 'cluster-status',
         'DeploymentsLabels': 'labels/deployments',
-        'DeploymnetsLabelsKey': 'labels/deployments/<string:key>'
+        'DeploymentsLabelsKey': 'labels/deployments/<string:key>'
     }
 
     # Set version endpoint as a non versioned endpoint

--- a/rest-service/manager_rest/rest/resources_v3_1/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/__init__.py
@@ -94,5 +94,5 @@ from .snapshots import ( # noqa
 
 from .labels import (                           # NOQA
     DeploymentsLabels,
-    DeploymentsLabelsKey
+    DeploymentsLabelsKey,
 )

--- a/rest-service/manager_rest/rest/resources_v3_1/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/__init__.py
@@ -94,5 +94,5 @@ from .snapshots import ( # noqa
 
 from .labels import (                           # NOQA
     DeploymentsLabels,
-    DeploymnetsLabelsKey
+    DeploymentsLabelsKey
 )

--- a/rest-service/manager_rest/rest/resources_v3_1/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/__init__.py
@@ -93,5 +93,6 @@ from .snapshots import ( # noqa
 )
 
 from .labels import (                           # NOQA
-    DeploymentsLabels
+    DeploymentsLabels,
+    DeploymnetsLabelsKey
 )

--- a/rest-service/manager_rest/rest/resources_v3_1/labels.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/labels.py
@@ -32,7 +32,7 @@ class DeploymentsLabels(SecuredResource):
 
 class DeploymentsLabelsKey(SecuredResource):
     @authorize('labels_list')
-    @rest_decorators.marshel_list_response
+    @rest_decorators.marshal_list_response
     @rest_decorators.paginate
     def get(self, key, pagination=None):
         """Get all deployments labels' keys in the current tenant"""

--- a/rest-service/manager_rest/rest/resources_v3_1/labels.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/labels.py
@@ -32,12 +32,12 @@ class DeploymentsLabels(SecuredResource):
 
 class DeploymnetsLabelsKey(SecuredResource):
 
-    @authorize('labels_keys_list')
+    @authorize('labels_list')
     def get(self, key):
         """Get the labels' values of the specified key"""
-        raw_labels_list = get_storage_manager().list(models.DeploymentLabel,
-                                                     filters={'key': key},
-                                                     include=['value'],
-                                                     get_all_results=True)
-        values_list = list(set(label.value for label in raw_labels_list))
+        results = db.session.query(
+            models.DeploymentLabel.value).filter(
+            models.DeploymentLabel.key == key).distinct().all()
+
+        values_list = [result.value for result in results]
         return {'metadata': {}, 'items': values_list}

--- a/rest-service/manager_rest/rest/resources_v3_1/labels.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/labels.py
@@ -28,3 +28,16 @@ class DeploymentsLabels(SecuredResource):
 
         results.items = [label.key for label in results]
         return results
+
+
+class DeploymnetsLabelsKey(SecuredResource):
+
+    @authorize('labels_keys_list')
+    def get(self, key):
+        """Get the labels' values of the specified key"""
+        raw_labels_list = get_storage_manager().list(models.DeploymentLabel,
+                                                     filters={'key': key},
+                                                     include=['value'],
+                                                     get_all_results=True)
+        values_list = list(set(label.value for label in raw_labels_list))
+        return {'metadata': {}, 'items': values_list}

--- a/rest-service/manager_rest/rest/resources_v3_1/labels.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/labels.py
@@ -1,5 +1,6 @@
 from flask import request
 
+from manager_rest.storage.models_base import db
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
 from manager_rest.storage import models, get_storage_manager
@@ -40,4 +41,4 @@ class DeploymnetsLabelsKey(SecuredResource):
             models.DeploymentLabel.key == key).distinct().all()
 
         values_list = [result.value for result in results]
-        return {'metadata': {}, 'items': values_list}
+        return {'metadata': {'total': len(values_list)}, 'items': values_list}

--- a/rest-service/manager_rest/rest/resources_v3_1/labels.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/labels.py
@@ -37,7 +37,7 @@ class DeploymentsLabelsKey(SecuredResource):
     @authorize('labels_list')
     def get(self, key):
         """Get the labels' values of the specified key"""
-        current_tenant = utils.current_tenant._get_current_object()
+        current_tenant = utils.current_tenant
         results = (db.session.query(models.DeploymentLabel.value)
                    .join(models.Deployment)
                    .filter(models.Deployment._tenant_id == current_tenant.id,


### PR DESCRIPTION
Implementing the `/labels/deployments/<key>` endpoint to list all values of a specific key in a tenant. 