### PR TITLE
Handling labels tenant and visibility

### DIFF
--- a/rest-service/manager_rest/storage/models_base.py
+++ b/rest-service/manager_rest/storage/models_base.py
@@ -122,6 +122,8 @@ class SQLModelBase(db.Model):
     # management table (User, Tenant, etc.), as they are handled differently
     is_resource = False
 
+    is_label = False
+
     # Can this resource be attached to tenants
     top_level_tenant = False
 

--- a/rest-service/manager_rest/storage/models_base.py
+++ b/rest-service/manager_rest/storage/models_base.py
@@ -122,8 +122,6 @@ class SQLModelBase(db.Model):
     # management table (User, Tenant, etc.), as they are handled differently
     is_resource = False
 
-    is_label = False
-
     # Can this resource be attached to tenants
     top_level_tenant = False
 
@@ -245,6 +243,10 @@ class SQLModelBase(db.Model):
         class_name = self.__class__.__name__
         _repr = ' '.join('{0}=`{1}`'.format(k, v) for k, v in id_dict.items())
         return '<{0} {1}>'.format(class_name, _repr)
+
+    @classproperty
+    def is_label(cls):
+        return hasattr(cls, 'labeled_model')
 
 
 def is_orm_attribute(item):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -372,6 +372,7 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
 class _Label(CreatedAtMixin, SQLModelBase):
     """An abstract class for the different labels models."""
     __abstract__ = True
+    is_label = True
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     key = db.Column(db.Text, nullable=False, index=True)
@@ -392,6 +393,7 @@ class DeploymentLabel(_Label):
         db.UniqueConstraint(
             'key', 'value', '_deployment_fk'),
     )
+    labeled_model = Deployment
 
     _deployment_fk = foreign_key(Deployment._storage_id)
 

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -372,7 +372,6 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
 class _Label(CreatedAtMixin, SQLModelBase):
     """An abstract class for the different labels models."""
     __abstract__ = True
-    is_label = True
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     key = db.Column(db.Text, nullable=False, index=True)

--- a/rest-service/manager_rest/storage/resource_models_base.py
+++ b/rest-service/manager_rest/storage/resource_models_base.py
@@ -36,6 +36,8 @@ class SQLResourceBase(SQLModelBase):
     # table models (users, tenants, etc.)
     is_resource = True
 
+    is_label = False
+
     # Indicates whether the `id` column in this class should be unique
     is_id_unique = True
 

--- a/rest-service/manager_rest/storage/resource_models_base.py
+++ b/rest-service/manager_rest/storage/resource_models_base.py
@@ -36,8 +36,6 @@ class SQLResourceBase(SQLModelBase):
     # table models (users, tenants, etc.)
     is_resource = True
 
-    is_label = False
-
     # Indicates whether the `id` column in this class should be unique
     is_id_unique = True
 

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -204,7 +204,7 @@ class SQLStorageManager(object):
         ancestor who has such a relationship)
         """
         # Users/Groups etc. don't have tenants
-        if not model_class.is_resource:
+        if not (model_class.is_resource or model_class.is_label):
             return query
 
         # not used from a request handler - no relevant user
@@ -230,9 +230,12 @@ class SQLStorageManager(object):
             tenant_ids = [current_tenant.id] if current_tenant else []
 
         # Match any of the applicable tenant ids or if it's a global resource
+        model = (model_class.labeled_model if model_class.is_label
+                 else model_class)
+
         tenant_filter = sql_or(
-            model_class.visibility == VisibilityState.GLOBAL,
-            model_class._tenant_id.in_(tenant_ids)
+            model.visibility == VisibilityState.GLOBAL,
+            model._tenant_id.in_(tenant_ids)
         )
         return query.filter(tenant_filter)
 

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -74,7 +74,7 @@ class SQLStorageManager(object):
                 )
             raise exception_to_raise
 
-    def _get_base_query(self, model_class, include, joins):
+    def _get_base_query(self, model_class, include, joins, distinct=None):
         """Create the initial query from the model class and included columns
 
         :param model_class: SQL DB table class
@@ -91,11 +91,14 @@ class SQLStorageManager(object):
             # If all columns should be returned, query directly from the model
             query = model_class.query
 
+        if distinct:
+            query = query.distinct(*distinct)
+
         query = query.outerjoin(*joins)
         return query
 
     @staticmethod
-    def _sort_query(query, model_class, sort=None):
+    def _sort_query(query, model_class, sort=None, distinct=None):
         """Add sorting clauses to the query
 
         :param query: Base SQL query
@@ -103,7 +106,9 @@ class SQLStorageManager(object):
         sort by, and values are the order (asc/desc)
         :return: An SQLAlchemy AppenderQuery object
         """
-        if sort:
+        if sort or distinct:
+            if distinct:
+                query = query.order_by(*distinct)
             for column, order in sort.items():
                 if order == 'desc':
                     column = column.desc()
@@ -284,7 +289,8 @@ class SQLStorageManager(object):
                                          include,
                                          filters,
                                          substr_filters,
-                                         sort):
+                                         sort,
+                                         distinct):
         """Get a list of tables on which we need to join and the converted
         `include`, `filters` and `sort` arguments (converted to actual SQLA
         column/label objects instead of column names)
@@ -293,17 +299,19 @@ class SQLStorageManager(object):
         filters = filters or dict()
         substr_filters = substr_filters or dict()
         sort = sort or OrderedDict()
+        distinct = distinct or []
 
         all_columns = set(include) | set(filters.keys()) | set(sort.keys())
         joins = self._get_joins(model_class, all_columns)
 
-        include, filters, substr_filters, sort = \
+        include, filters, substr_filters, sort, distinct = \
             self._get_columns_from_field_names(model_class,
                                                include,
                                                filters,
                                                substr_filters,
-                                               sort)
-        return include, filters, substr_filters, sort, joins
+                                               sort,
+                                               distinct)
+        return include, filters, substr_filters, sort, joins, distinct
 
     def _get_query(self,
                    model_class,
@@ -311,7 +319,8 @@ class SQLStorageManager(object):
                    filters=None,
                    substr_filters=None,
                    sort=None,
-                   all_tenants=None):
+                   all_tenants=None,
+                   distinct=None):
         """Get an SQL query object based on the params passed
 
         :param model_class: SQL DB table class
@@ -326,20 +335,21 @@ class SQLStorageManager(object):
         :return: A sorted and filtered query with only the relevant
         columns
         """
-        include, filters, substr_filters, sort, joins = \
+        include, filters, substr_filters, sort, joins, distinct = \
             self._get_joins_and_converted_columns(model_class,
                                                   include,
                                                   filters,
                                                   substr_filters,
-                                                  sort)
+                                                  sort,
+                                                  distinct)
 
-        query = self._get_base_query(model_class, include, joins)
+        query = self._get_base_query(model_class, include, joins, distinct)
         query = self._filter_query(query,
                                    model_class,
                                    filters,
                                    substr_filters,
                                    all_tenants)
-        query = self._sort_query(query, model_class, sort)
+        query = self._sort_query(query, model_class, sort, distinct)
         return query
 
     def _get_columns_from_field_names(self,
@@ -347,7 +357,8 @@ class SQLStorageManager(object):
                                       include,
                                       filters,
                                       substr_filters,
-                                      sort):
+                                      sort,
+                                      distinct):
         """Go over the optional parameters (include, filters, sort), and
         replace column names with actual SQLA column objects
         """
@@ -358,8 +369,9 @@ class SQLStorageManager(object):
                           for c in substr_filters}
         sort = OrderedDict((self._get_column(model_class, c), sort[c])
                            for c in sort)
+        distinct = [self._get_column(model_class, c) for c in distinct]
 
-        return include, filters, substr_filters, sort
+        return include, filters, substr_filters, sort, distinct
 
     @staticmethod
     def _get_column(model_class, column_name):
@@ -379,7 +391,7 @@ class SQLStorageManager(object):
             return column.remote_attr.label(column_name)
 
     @staticmethod
-    def _paginate(query, pagination, get_all_results=False, distinct=False):
+    def _paginate(query, pagination, get_all_results=False):
         """Paginate the query by size and offset
 
         :param query: Current SQLAlchemy query object
@@ -398,9 +410,6 @@ class SQLStorageManager(object):
         else:
             size = config.instance.default_page_size
             offset = 0
-
-        if distinct:
-            query = query.distinct()
 
         total = query.order_by(None).count()  # Fastest way to count
         if get_all_results:
@@ -548,7 +557,7 @@ class SQLStorageManager(object):
              all_tenants=None,
              substr_filters=None,
              get_all_results=False,
-             distinct=False):
+             distinct=None):
         """Return a list of `model_class` results
 
         :param model_class: SQL DB table class
@@ -566,7 +575,8 @@ class SQLStorageManager(object):
         :param get_all_results: Get all the results without the limitation of
                                 size or pagination. Use it carefully to
                                 prevent consumption of too much memory
-        :param distinct: If True, distinct results will return
+        :param distinct: An optional list of columns names to get distinct
+                         results by.
         :return: A (possibly empty) list of `model_class` results
         """
         self._validate_available_memory()
@@ -583,12 +593,12 @@ class SQLStorageManager(object):
                                 filters,
                                 substr_filters,
                                 sort,
-                                all_tenants)
+                                all_tenants,
+                                distinct)
 
         results, total, size, offset = self._paginate(query,
                                                       pagination,
-                                                      get_all_results,
-                                                      distinct)
+                                                      get_all_results)
         pagination = {'total': total, 'size': size, 'offset': offset}
 
         current_app.logger.debug('Returning: {0}'.format(results))


### PR DESCRIPTION
When listing the existing deployments' labels' keys, we have a problem identifying in which tenant these deployments are. 
This can be solved by declaring the labeled object's model (using the `labeled_model` attribute) in the different labels models and filtering the tenant using it. 