### PR TITLE
Handling labels tenant

### DIFF
--- a/rest-service/manager_rest/storage/models_base.py
+++ b/rest-service/manager_rest/storage/models_base.py
@@ -244,6 +244,10 @@ class SQLModelBase(db.Model):
         _repr = ' '.join('{0}=`{1}`'.format(k, v) for k, v in id_dict.items())
         return '<{0} {1}>'.format(class_name, _repr)
 
+    @classproperty
+    def is_label(cls):
+        return hasattr(cls, 'labeled_model')
+
 
 def is_orm_attribute(item):
     if isinstance(item, AssociationProxyInstance):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -377,6 +377,8 @@ class _Label(CreatedAtMixin, SQLModelBase):
     key = db.Column(db.Text, nullable=False, index=True)
     value = db.Column(db.Text, nullable=False)
 
+    labeled_model = None
+
     @declared_attr
     def _creator_id(cls):
         return foreign_key(User.id)
@@ -385,6 +387,14 @@ class _Label(CreatedAtMixin, SQLModelBase):
     def creator(cls):
         return one_to_many_relationship(cls, User, cls._creator_id, 'id')
 
+    @declared_attr
+    def visibility(cls):
+        return cls.labeled_model.visibility
+
+    @declared_attr
+    def _tenant_id(cls):
+        return cls.labeled_model._tenant_id
+
 
 class DeploymentLabel(_Label):
     __tablename__ = 'deployments_labels'
@@ -392,6 +402,7 @@ class DeploymentLabel(_Label):
         db.UniqueConstraint(
             'key', 'value', '_deployment_fk'),
     )
+    labeled_model = Deployment
 
     _deployment_fk = foreign_key(Deployment._storage_id)
 

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -204,7 +204,7 @@ class SQLStorageManager(object):
         ancestor who has such a relationship)
         """
         # Users/Groups etc. don't have tenants
-        if not model_class.is_resource:
+        if not (model_class.is_resource or model_class.is_label):
             return query
 
         # not used from a request handler - no relevant user
@@ -230,9 +230,12 @@ class SQLStorageManager(object):
             tenant_ids = [current_tenant.id] if current_tenant else []
 
         # Match any of the applicable tenant ids or if it's a global resource
+        model = (model_class.labeled_model if model_class.is_label
+                 else model_class)
+
         tenant_filter = sql_or(
-            model_class.visibility == VisibilityState.GLOBAL,
-            model_class._tenant_id.in_(tenant_ids)
+            model.visibility == VisibilityState.GLOBAL,
+            model._tenant_id.in_(tenant_ids)
         )
         return query.filter(tenant_filter)
 

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -230,12 +230,9 @@ class SQLStorageManager(object):
             tenant_ids = [current_tenant.id] if current_tenant else []
 
         # Match any of the applicable tenant ids or if it's a global resource
-        model = (model_class.labeled_model if model_class.is_label
-                 else model_class)
-
         tenant_filter = sql_or(
-            model.visibility == VisibilityState.GLOBAL,
-            model._tenant_id.in_(tenant_ids)
+            model_class.visibility == VisibilityState.GLOBAL,
+            model_class._tenant_id.in_(tenant_ids)
         )
         return query.filter(tenant_filter)
 


### PR DESCRIPTION
When listing the existing deployments' labels' keys, we have a problem identifying in which tenant these deployments are.
This can be solved by declaring the labeled object's model (using the labeled_model attribute) in the different labels models and filtering the tenant using it.