### PR TITLE
inte-tests: reset_storage.py: cope with the new permissions engine

### DIFF
--- a/tests/integration_tests/framework/constants.py
+++ b/tests/integration_tests/framework/constants.py
@@ -28,7 +28,6 @@ PLUGIN_STORAGE_DIR = '/tmp/integration-plugin-storage'
 DOCKER_COMPUTE_DIR = '/etc/cloudify/dockercompute'
 
 CONFIG_FILE_LOCATION = '/opt/manager/cloudify-rest.conf'
-AUTHORIZATION_FILE_LOCATION = '/opt/manager/authorization.conf'
 
 CLOUDIFY_USER = 'cfyuser'
 ADMIN_TOKEN_SCRIPT = '/opt/cloudify/mgmtworker/create-admin-token.py'

--- a/tests/integration_tests/framework/flask_utils.py
+++ b/tests/integration_tests/framework/flask_utils.py
@@ -52,7 +52,6 @@ def prepare_reset_storage_script(container_id):
             'config': {
                 '': constants.CONFIG_FILE_LOCATION,
                 'security': SECURITY_FILE_LOCATION,
-                'authorization': constants.AUTHORIZATION_FILE_LOCATION
             },
             'ip': get_manager_ip(container_id),
             'username': 'admin',

--- a/tests/integration_tests/resources/scripts/reset_storage.py
+++ b/tests/integration_tests/resources/scripts/reset_storage.py
@@ -79,8 +79,7 @@ def _add_defaults(app, amqp_manager, script_config):
     default_tenant = create_default_user_tenant_and_roles(
         admin_username=script_config['username'],
         admin_password=script_config['password'],
-        amqp_manager=amqp_manager,
-        authorization_file_path=script_config['config']['authorization']
+        amqp_manager=amqp_manager
     )
     for scope, configs in script_config['manager_config'].items():
         for name, value in configs.items():
@@ -111,7 +110,8 @@ def reset_storage(script_config):
     # Rebuild the DB
     safe_drop_all(keep_tables=['roles', 'config', 'rabbitmq_brokers',
                                'certificates', 'managers', 'db_nodes',
-                               'licenses', 'usage_collector'])
+                               'licenses', 'usage_collector',
+                               'permissions'])
     upgrade(directory=migrations_dir)
 
     # Add default tenant, admin user and provider context


### PR DESCRIPTION
It's now db-based and not file-based and so this script must
work like that as well.
Persist permissions between tests because that's what we've always
done.