### PR TITLE
RD-599 Snapshot-restore support for permissions

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/5ce2b0cbb6f3_5_1_to_5_1_1.py
+++ b/resources/rest-service/cloudify/migrations/versions/5ce2b0cbb6f3_5_1_to_5_1_1.py
@@ -135,7 +135,7 @@ def _create_maintenance_mode_table():
         sa.Column('status', sa.Text(), nullable=False),
         sa.Column('activation_requested_at', UTCDateTime(), nullable=False),
         sa.Column('activated_at', UTCDateTime(), nullable=True),
-        sa.Column('_requested_by', sa.Integer(), nullable=False),
+        sa.Column('_requested_by', sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(
             ['_requested_by'],
             ['users.id'],

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -726,7 +726,7 @@ class MaintenanceMode(SQLModelBase):
 
     @declared_attr
     def _requested_by(cls):
-        return foreign_key(User.id)
+        return foreign_key(User.id, nullable=True)
 
     @declared_attr
     def requested_by(cls):

--- a/workflows/cloudify_system_workflows/snapshots/fix_snapshot_ssh_db.py
+++ b/workflows/cloudify_system_workflows/snapshots/fix_snapshot_ssh_db.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 import os
 import argparse
 
-from manager_rest import flask_utils
+from manager_rest import flask_utils, config
 from manager_rest.storage.models import Deployment
 from manager_rest.storage import get_storage_manager
 
@@ -146,6 +146,7 @@ def main(original_string, secret_name):
 
 def setup_flask_app(tenant_name):
     app = flask_utils.setup_flask_app()
+    config.instance.load_configuration()
     flask_utils.set_admin_current_user(app)
     tenant = flask_utils.get_tenant_by_name(tenant_name)
     flask_utils.set_tenant_in_app(tenant)

--- a/workflows/cloudify_system_workflows/snapshots/postgres.py
+++ b/workflows/cloudify_system_workflows/snapshots/postgres.py
@@ -221,6 +221,27 @@ class Postgres(object):
                                       self.current_execution_date,
                                       self.hashed_execution_token)
 
+    def dump_permissions_table(self, tempdir):
+        # store the permissions table separately from config tables,
+        # because it can be also present in the snapshot, and we're only
+        # going to restore it if it's missing
+        pg_dump_bin = os.path.join(self._bin_dir, 'pg_dump')
+        path = os.path.join(tempdir, 'permissions.dump')
+        command = [pg_dump_bin,
+                   '-a',
+                   '--host', self._host,
+                   '--port', self._port,
+                   '-U', self._username,
+                   self._db_name,
+                   '-f', path,
+                   '-t', 'permissions']
+
+        run_shell(command)
+        return path
+
+    def restore_permissions_table(self, permissions_path):
+        self._restore_dump(permissions_path, self._db_name)
+
     def dump_config_tables(self, tempdir):
         pg_dump_bin = os.path.join(self._bin_dir, 'pg_dump')
         path = os.path.join(tempdir, 'config.dump')


### PR DESCRIPTION
In snapshot-restore, keep the permissions table data around in a file, similar to what we do
with other config tables.

However for this one, only restore it if it's not in the snapshot. We do want to allow the user to keep their permissions :)