### PR TITLE
Use fixture `allow_agent` in agent tests

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_agent_install_from_plugin.py
+++ b/tests/integration_tests/tests/agent_tests/test_agent_install_from_plugin.py
@@ -22,6 +22,7 @@ from integration_tests.tests.utils import get_resource as resource
 
 
 @pytest.mark.usefixtures('dockercompute_plugin')
+@pytest.mark.usefixtures('allow_agent')
 class TestWorkflow(AgentTestWithPlugins):
     def test_agent_install_from_plugin(self):
         deployment_id = 'd{0}'.format(uuid.uuid4())

--- a/tests/integration_tests/tests/agent_tests/test_list_agents.py
+++ b/tests/integration_tests/tests/agent_tests/test_list_agents.py
@@ -20,6 +20,7 @@ from integration_tests.tests.utils import (get_resource as resource,
                                            create_rest_client)
 
 
+@pytest.mark.usefixtures('allow_agent')
 class TestListAgents(AgentTestCase):
 
     def test_list_agents(self):


### PR DESCRIPTION
The fixture should be used to run tests that use dockercompute plugin.