### PR TITLE
Downgrade migrations: use compatible .where() syntax

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/387fcd049efb_5_0_5_to_5_1.py
+++ b/resources/rest-service/cloudify/migrations/versions/387fcd049efb_5_0_5_to_5_1.py
@@ -98,32 +98,32 @@ def downgrade():
         config_table
         .delete()
         .where(
-            config_table.c.name == op.inline_literal('blueprint_folder_max_size_mb'),  # NOQA
-            config_table.c.scope == op.inline_literal('rest')
+            (config_table.c.name == op.inline_literal('blueprint_folder_max_size_mb')) & # NOQA
+            (config_table.c.scope == op.inline_literal('rest'))
         )
     )
     op.execute(
         config_table
         .delete()
         .where(
-            config_table.c.name == op.inline_literal('blueprint_folder_max_files'),  # NOQA
-            config_table.c.scope == op.inline_literal('rest')
+            (config_table.c.name == op.inline_literal('blueprint_folder_max_files')) &  # NOQA
+            (config_table.c.scope == op.inline_literal('rest'))
         )
     )
     op.execute(
         config_table
         .delete()
         .where(
-            config_table.c.name == op.inline_literal('service_management'),
-            config_table.c.scope == op.inline_literal('rest')
+            (config_table.c.name == op.inline_literal('service_management')) &
+            (config_table.c.scope == op.inline_literal('rest'))
         )
     )
     op.execute(
         config_table
         .delete()
         .where(
-            config_table.c.name == op.inline_literal('monitoring_timeout'),
-            config_table.c.scope == op.inline_literal('rest')
+            (config_table.c.name == op.inline_literal('monitoring_timeout')) &
+            (config_table.c.scope == op.inline_literal('rest'))
         )
     )
 

--- a/resources/rest-service/cloudify/migrations/versions/62a8d746d13b_5_0_to_5_0_5.py
+++ b/resources/rest-service/cloudify/migrations/versions/62a8d746d13b_5_0_to_5_0_5.py
@@ -670,8 +670,8 @@ def downgrade():
         config_table
         .delete()
         .where(
-            config_table.c.name == op.inline_literal('ldap_ca_path'),
-            config_table.c.scope == op.inline_literal('rest')
+            (config_table.c.name == op.inline_literal('ldap_ca_path')) &
+            (config_table.c.scope == op.inline_literal('rest'))
         )
     )
     op.drop_constraint(


### PR DESCRIPTION
With modern versions of sqlalchemy, .where() takes one argument,
and that needs to be and'ed, not multiple arguments.