### PR TITLE
RD-666 Load permissions from the file during migrations

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/5ce2b0cbb6f3_5_1_to_5_1_1.py
+++ b/resources/rest-service/cloudify/migrations/versions/5ce2b0cbb6f3_5_1_to_5_1_1.py
@@ -170,7 +170,7 @@ def _load_permissions(permissions_table):
                 .from_select(
                     ['name', 'role_id'],
                     select([
-                        op.inline_literal(permission),
+                        op.inline_literal(permission).label('name'),
                         roles_table.c.id
                     ])
                     .where(roles_table.c.name == op.inline_literal(role))


### PR DESCRIPTION
When migrating the db on a machine that already has the auth.conf
file, load permissions from that file. And insert them.