### PR TITLE
RD-507 Fix usage collector integration tests

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -115,6 +115,7 @@ def manager_container(request, resource_mapping):
     amqp_events_printer_thread = EventsPrinter(
         docker.get_manager_ip(container_id))
     amqp_events_printer_thread.start()
+    _disable_cron_jobs(container_id)
     try:
         yield container
     finally:
@@ -279,6 +280,11 @@ def {0}_plugin(rest_client, {0}_wagon):
 """.format(plugin_name), d)
     func = d['{0}_plugin'.format(plugin_name)]
     return pytest.fixture()(func)
+
+
+def _disable_cron_jobs(container_id):
+    if docker.file_exists(container_id, '/var/spool/cron/cfyuser'):
+        docker.execute(container_id, 'crontab -u cfyuser -r')
 
 
 cloudmock_wagon = _make_wagon_fixture('cloudmock')

--- a/tests/integration_tests/framework/constants.py
+++ b/tests/integration_tests/framework/constants.py
@@ -35,5 +35,5 @@ ADMIN_TOKEN_SCRIPT = '/opt/cloudify/mgmtworker/create-admin-token.py'
 INSERT_MOCK_LICENSE_QUERY = "INSERT INTO licenses(customer_id, " \
                             "expiration_date, license_edition, trial," \
                             " cloudify_version, capabilities, signature)" \
-                            " VALUES('mock_customer', '2050-01-01', 'Spire'," \
+                            " VALUES('MockCustomer', '2050-01-01', 'Spire'," \
                             " false, '4.6', '{mock}', 'mock_signature');"

--- a/tests/integration_tests/framework/docker.py
+++ b/tests/integration_tests/framework/docker.py
@@ -225,3 +225,12 @@ def get_manager_ip(container_id):
         '--format={{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}',
         container_id
     ]).decode('utf-8').strip()
+
+
+def file_exists(container_id, file_path):
+    try:
+        execute(container_id, 'test -e {0}'.format(file_path))
+    except subprocess.CalledProcessError:
+        return False
+
+    return True

--- a/tests/integration_tests/tests/agent_tests/test_usage_collector.py
+++ b/tests/integration_tests/tests/agent_tests/test_usage_collector.py
@@ -30,7 +30,7 @@ class TestUsageCollectorWithAgent(AgentTestCase, TestUsageCollectorBase):
         messages = [
             "Uptime script finished running",
             "Usage script finished running",
-            "'customer_id': 'MockCustomer'",
+            "'customer_id': 'mock_customer'",
             "'node_instances_count': 1",
             "'compute_count': 1",
             "'agents_count': 1",

--- a/tests/integration_tests/tests/agent_tests/test_usage_collector.py
+++ b/tests/integration_tests/tests/agent_tests/test_usage_collector.py
@@ -24,13 +24,16 @@ class TestUsageCollectorWithAgent(AgentTestCase, TestUsageCollectorBase):
     def setUp(self):
         super(AgentTestCase, self).setUp()
         self.clean_timestamps()
+
+    def tearDown(self):
+        super(AgentTestCase, self).tearDown()
         self.clean_usage_collector_log()
 
     def test_collector_scripts_with_agent(self):
         messages = [
             "Uptime script finished running",
             "Usage script finished running",
-            "'customer_id': 'mock_customer'",
+            "'customer_id': 'MockCustomer'",
             "'node_instances_count': 1",
             "'compute_count': 1",
             "'agents_count': 1",

--- a/tests/integration_tests/tests/agent_tests/test_usage_collector.py
+++ b/tests/integration_tests/tests/agent_tests/test_usage_collector.py
@@ -21,12 +21,16 @@ from integration_tests.tests.usage_collector_base import TestUsageCollectorBase
 
 @pytest.mark.usefixtures('allow_agent')
 class TestUsageCollectorWithAgent(AgentTestCase, TestUsageCollectorBase):
+    def setUp(self):
+        super(AgentTestCase, self).setUp()
+        self.clean_timestamps()
+        self.clean_usage_collector_log()
 
     def test_collector_scripts_with_agent(self):
         messages = [
             "Uptime script finished running",
             "Usage script finished running",
-            "'customer_id': 'mock_customer'",
+            "'customer_id': 'MockCustomer'",
             "'node_instances_count': 1",
             "'compute_count': 1",
             "'agents_count': 1",

--- a/tests/integration_tests/tests/agentless_tests/test_license.py
+++ b/tests/integration_tests/tests/agentless_tests/test_license.py
@@ -20,6 +20,7 @@ import requests
 
 from integration_tests import AgentlessTestCase
 from integration_tests.tests.utils import get_resource
+from integration_tests.framework.constants import INSERT_MOCK_LICENSE_QUERY
 from cloudify_rest_client.exceptions import (
     MissingCloudifyLicense,
     ExpiredCloudifyLicense,
@@ -36,6 +37,12 @@ class TestLicense(AgentlessTestCase):
     def setUp(self):
         super(TestLicense, self).setUp()
         run_postgresql_command(self.env.container_id, "DELETE FROM licenses")
+
+    def tearDown(self):
+        super(TestLicense, self).setUp()
+        run_postgresql_command(self.env.container_id, "DELETE FROM licenses")
+        run_postgresql_command(self.env.container_id,
+                               INSERT_MOCK_LICENSE_QUERY)
 
     def test_error_when_no_license_on_manager(self):
         """

--- a/tests/integration_tests/tests/agentless_tests/test_usage_collector.py
+++ b/tests/integration_tests/tests/agentless_tests/test_usage_collector.py
@@ -26,6 +26,9 @@ class TestUsageCollector(AgentlessTestCase, TestUsageCollectorBase):
     def setUp(self):
         super(AgentlessTestCase, self).setUp()
         self.clean_timestamps()
+
+    def tearDown(self):
+        super(AgentlessTestCase, self).tearDown()
         self.clean_usage_collector_log()
 
     def test_collector_scripts(self):

--- a/tests/integration_tests/tests/agentless_tests/test_usage_collector.py
+++ b/tests/integration_tests/tests/agentless_tests/test_usage_collector.py
@@ -23,12 +23,16 @@ from integration_tests.tests.usage_collector_base import TestUsageCollectorBase
 @pytest.mark.usefixtures('cloudmock_plugin')
 @pytest.mark.usefixtures('testmockoperations_plugin')
 class TestUsageCollector(AgentlessTestCase, TestUsageCollectorBase):
+    def setUp(self):
+        super(AgentlessTestCase, self).setUp()
+        self.clean_timestamps()
+        self.clean_usage_collector_log()
 
     def test_collector_scripts(self):
         messages = [
             "Uptime script finished running",
             "Usage script finished running",
-            "'customer_id': 'mock_customer'",
+            "'customer_id': 'MockCustomer'",
             "'node_instances_count': 1",
             "'compute_count': 1",
             "'agents_count': 0",
@@ -58,4 +62,3 @@ class TestUsageCollector(AgentlessTestCase, TestUsageCollectorBase):
         ]
         self.run_collector_scripts_and_assert(messages)
         self.delete_deployment(deployment.id, validate=True)
-        self.clean_timestamps()

--- a/tests/integration_tests/tests/usage_collector_base.py
+++ b/tests/integration_tests/tests/usage_collector_base.py
@@ -36,9 +36,6 @@ class TestUsageCollectorBase(BaseTestCase):
         self.undeploy_application(deployment.id)
 
     def run_collector_scripts_and_assert(self, messages):
-        docker.execute(self.env.container_id, 'mkdir -p {0}'.format(LOG_PATH))
-        docker.execute(self.env.container_id, 'echo > {0}'.format(
-            join(LOG_PATH, LOG_FILE)))
         for script in COLLECTOR_SCRIPTS:
             docker.execute(self.env.container_id, '{0} {1}.py'.format(
                 MANAGER_PYTHON,
@@ -60,11 +57,11 @@ class TestUsageCollectorBase(BaseTestCase):
     def clean_usage_collector_log(self):
         # We need to clean the usage_collector log before each test, because
         # each test uses it for asserting different values.
+        old_usage_log = join(LOG_PATH, self._testMethodName)
         test_usage_log = join(LOG_PATH, LOG_FILE)
-        complete_usage_log = join(LOG_PATH, 'complete_usage_collector.log')
-
-        docker.execute(self.env.container_id, 'cat {0} >> {1}'.format(
-            test_usage_log, complete_usage_log))
 
         docker.execute(self.env.container_id,
-                       'cp /dev/null {0}'.format(test_usage_log))
+                       'mv {0} {1}'.format(test_usage_log, old_usage_log))
+
+        docker.execute(self.env.container_id,
+                       'touch {0}'.format(test_usage_log))

--- a/tests/integration_tests/tests/usage_collector_base.py
+++ b/tests/integration_tests/tests/usage_collector_base.py
@@ -60,5 +60,11 @@ class TestUsageCollectorBase(BaseTestCase):
     def clean_usage_collector_log(self):
         # We need to clean the usage_collector log before each test, because
         # each test uses it for asserting different values.
-        command = 'cp /dev/null {0}'.format(join(LOG_PATH, LOG_FILE))
-        docker.execute(self.env.container_id, command)
+        test_usage_log = join(LOG_PATH, LOG_FILE)
+        complete_usage_log = join(LOG_PATH, 'complete_usage_collector.log')
+
+        docker.execute(self.env.container_id, 'cat {0} >> {1}'.format(
+            test_usage_log, complete_usage_log))
+
+        docker.execute(self.env.container_id,
+                       'cp /dev/null {0}'.format(test_usage_log))

--- a/tests/integration_tests/tests/usage_collector_base.py
+++ b/tests/integration_tests/tests/usage_collector_base.py
@@ -60,8 +60,5 @@ class TestUsageCollectorBase(BaseTestCase):
         old_usage_log = join(LOG_PATH, self._testMethodName)
         test_usage_log = join(LOG_PATH, LOG_FILE)
 
-        docker.execute(self.env.container_id,
-                       'mv {0} {1}'.format(test_usage_log, old_usage_log))
-
-        docker.execute(self.env.container_id,
-                       'touch {0}'.format(test_usage_log))
+        self.execute_on_manager(['mv', test_usage_log, old_usage_log])
+        self.execute_on_manager(['touch', test_usage_log])

--- a/tests/integration_tests/tests/usage_collector_base.py
+++ b/tests/integration_tests/tests/usage_collector_base.py
@@ -14,6 +14,8 @@
 #    * limitations under the License.
 
 from os.path import join
+
+from integration_tests import BaseTestCase
 from integration_tests.framework import docker
 from integration_tests.tests.constants import MANAGER_PYTHON
 from integration_tests.tests.utils import (assert_messages_in_log,
@@ -26,13 +28,12 @@ LOG_PATH = '/var/log/cloudify/usage_collector'
 LOG_FILE = 'usage_collector.log'
 
 
-class TestUsageCollectorBase(object):
+class TestUsageCollectorBase(BaseTestCase):
     def run_scripts_with_deployment(self, yaml_path, messages):
         deployment, _ = self.deploy_application(resource(yaml_path),
                                                 timeout_seconds=120)
         self.run_collector_scripts_and_assert(messages)
         self.undeploy_application(deployment.id)
-        self.clean_timestamps()
 
     def run_collector_scripts_and_assert(self, messages):
         docker.execute(self.env.container_id, 'mkdir -p {0}'.format(LOG_PATH))
@@ -49,9 +50,15 @@ class TestUsageCollectorBase(object):
                                join(LOG_PATH, LOG_FILE))
 
     def clean_timestamps(self):
-        # this is necessary for forcing the collector scripts to actually run
+        # This is necessary for forcing the collector scripts to actually run
         # in subsequent tests, despite not enough time passing since last run
         run_postgresql_command(
             self.env.container_id,
-            "UPDATE usage_collector SET hourly_timestamp=0, daily_timestamp=0 "
-            "WHERE id=0")
+            "UPDATE usage_collector SET hourly_timestamp=NULL, "
+            "daily_timestamp=NULL")
+
+    def clean_usage_collector_log(self):
+        # We need to clean the usage_collector log before each test, because
+        # each test uses it for asserting different values.
+        command = 'cp /dev/null {0}'.format(join(LOG_PATH, LOG_FILE))
+        docker.execute(self.env.container_id, command)


### PR DESCRIPTION
This PR fixes the usage_collector integration tests by:
1. Disabling the `cron` jobs on the manager container. This way, the usage_collector cron jobs won't be activated during the tests. And besides, it doesn't make sense for a cron job to work during tests, it's better to activate the scripts manually. 

2. Changing the `customer_id`  in the container license to `MockCustomer`. Until now, if `test_license.py` ran before the usage_collector tests, the customer_id would have changed from `mock_customer` to `MockCustomer` as defined in the test's licenses. This is prevented by changing the `customer_id` in the container license to `MockCustomer`. Moreover, to keep the correct license on the container, we "reset" the license at the end of each license test. 

3. Cleaning the usage_collector log at the end of each test. The usage_collector tests use the log file for the assertion, therefore we need to clean it at the end of each test. We do so by moving the log file at the end of each test to a file with the test's name. 