### PR TITLE
inte-tests: log `docker run` command

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -46,8 +46,11 @@ def pytest_addoption(parser):
 # TODO fill this in as needed, when needed
 sources = [
     ('cloudify-cli/cloudify_cli', ['/opt/cfy']),
+    ('cloudify-premium/cloudify_premium', ['/opt/manager/env']),
     ('cloudify-common/cloudify', ['/opt/manager/env', '/opt/mgmtworker/env',
                                   '/opt/cfy']),
+    ('cloudify-common/cloudify_rest_client', [
+        '/opt/manager/env', '/opt/mgmtworker/env', '/opt/cfy']),
     ('cloudify-common/cloudify_rest_client', ['/opt/mgmtworker/env']),
     ('cloudify-common/dsl_parser', ['/opt/manager/env']),
     ('cloudify-common/script_runner', ['/opt/mgmtworker/env']),

--- a/tests/integration_tests/framework/docker.py
+++ b/tests/integration_tests/framework/docker.py
@@ -20,6 +20,7 @@ import sh
 import sys
 import yaml
 import shlex
+import logging
 import tempfile
 import subprocess
 from functools import partial
@@ -157,7 +158,9 @@ sanity:
         for src, dst in resource_mapping:
             command += ['-v', '{0}:{1}:ro'.format(src, dst)]
     command += [image]
+    logging.info('Starting container: %s', ' '.join(command))
     manager_id = subprocess.check_output(command).decode('utf-8').strip()
+    logging.info('Started container %s', manager_id)
     execute(manager_id, ['cfy_manager', 'wait-for-starter'])
     return manager_id
 


### PR DESCRIPTION
It's useful to log the `docker run` call because then developers can
copy it and use it for running their containers manually,
with all the mounts formatted in. I do it all the time.

With pytest, this log is not going to be shown by default,
but you can `--log-cli-level=info` (or pytest.ini).