### PR TITLE
RD-827 Fix delete deployment with component fails

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2434,7 +2434,8 @@ class ResourceManager(object):
                 dependency_params = {
                     'dependency_creator': func_id,
                     'source_deployment': source_deployment.id,
-                    'target_deployment': target_deployment.id or ' ',
+                    'target_deployment': (target_deployment.id if
+                                          target_deployment else ' '),
                     'external_source': {
                         'deployment': source_deployment.id,
                         'tenant': source_deployment.tenant_name,

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -548,8 +548,7 @@ class RecursiveDeploymentDependencies(object):
 
 
 def update_inter_deployment_dependencies(sm):
-    dependencies_list = sm.list(models.InterDeploymentDependencies,
-                                filters={'target_deployment': None})
+    dependencies_list = sm.list(models.InterDeploymentDependencies)
     for dependency in dependencies_list:
         if (dependency.target_deployment_func and
                 not dependency.external_target):
@@ -557,15 +556,16 @@ def update_inter_deployment_dependencies(sm):
 
 
 def _update_dependency_target_deployment(sm, dependency):
-    target_deployment = get_deployment_from_target_func(
+    eval_target_deployment = _get_deployment_from_target_func(
         sm, dependency.target_deployment_func, dependency.source_deployment_id)
-    if target_deployment:
-        dependency.target_deployment = target_deployment
+    if (eval_target_deployment and
+            eval_target_deployment != dependency.target_deployment):
+        dependency.target_deployment = eval_target_deployment
 
         # check for cyclic dependencies
         dep_graph = RecursiveDeploymentDependencies(sm)
         source_id = str(dependency.source_deployment_id)
-        target_id = str(target_deployment.id)
+        target_id = str(eval_target_deployment.id)
         dep_graph.create_dependencies_graph()
         dep_graph.assert_no_cyclic_dependencies(source_id, target_id)
 
@@ -581,7 +581,7 @@ def _evaluate_target_func(target_dep_func, source_dep_id):
     return target_dep_func
 
 
-def get_deployment_from_target_func(sm, target_dep_func, source_dep_id):
+def _get_deployment_from_target_func(sm, target_dep_func, source_dep_id):
     target_dep_id = _evaluate_target_func(target_dep_func, source_dep_id)
     if target_dep_id:
         return sm.get(models.Deployment, target_dep_id, fail_silently=True)

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -584,11 +584,6 @@ def _evaluate_target_func(target_dep_func, source_dep_id):
 def get_deployment_from_target_func(sm, target_dep_func, source_dep_id):
     target_dep_id = _evaluate_target_func(target_dep_func, source_dep_id)
     if target_dep_id:
-        target_deployment = sm.get(models.Deployment, target_dep_id,
-                                   fail_silently=True)
-        if not target_deployment:
-            current_app.logger.info('Deployment %s does not exist',
-                                    target_dep_id)
-        return target_deployment
+        return sm.get(models.Deployment, target_dep_id, fail_silently=True)
 
     return None

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -521,15 +521,19 @@ class SQLStorageManager(object):
             query = query.with_for_update()
         result = query.first()
 
-        if not result and not fail_silently:
+        if not result:
             if filters and set(filters.keys()) != {'id'}:
                 filters_message = ' (filters: {0})'.format(filters)
             else:
                 filters_message = ''
-            raise manager_exceptions.NotFoundError(
-                'Requested `{0}` with ID `{1}` was not found{2}'
-                .format(model_class.__name__, element_id, filters_message)
-            )
+            err_msg = 'Requested `{0}` with ID `{1}` was not found{2}'.format(
+                model_class.__name__, element_id, filters_message)
+
+            if fail_silently:
+                current_app.logger.debug(err_msg)
+            else:
+                raise manager_exceptions.NotFoundError(err_msg)
+
         current_app.logger.debug('Returning {0}'.format(result))
         return result
 


### PR DESCRIPTION
At the end of any execution that ended in status `canceled`, `failed`, or `terminated`, the manager goes through the inter_deployment_dependencies table and evaluates each target_deployment_func to a deployment ID, and the corresponding deployment is being retrieved from the DB. The error occurs when this deployment doesn’t exist in the DB, either because it was deleted or because it wasn’t created yet. 

To solve this issue, this PR:
1. Fails silently in case the relevant deployment doesn't exist. 
2. Updates the inter deployment dependencies only when the execution ended in state `terminated`. 

Moreover, this PR adds a logging message to `storage_manager.get()` in case `fail_silently=True`. This way we will know if an element was supposed to be retrieved from the DB.