### PR TITLE
RD-748 Limit labels length

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -160,7 +160,8 @@ def _get_labels(request_dict):
         if ((not isinstance(key, text_type)) or
                 (not isinstance(value, text_type))):
             _raise_bad_labels_list()
-        rest_utils.validate_inputs({'key': key, 'value': value})
+        rest_utils.validate_inputs({'key': key, 'value': value},
+                                   len_input_value=56)
         labels_list.append((key.lower(), value.lower()))
 
     _test_unique_labels(labels_list)

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -139,7 +139,7 @@ def set_restart_task(delay=1, service_management='systemd'):
     subprocess.Popen(cmd, shell=True)
 
 
-def validate_inputs(input_dict):
+def validate_inputs(input_dict, len_input_value=256):
     for input_name, input_value in input_dict.items():
         prefix = 'The `{0}` argument'.format(input_name)
 
@@ -148,10 +148,10 @@ def validate_inputs(input_dict):
                 '{0} is empty'.format(prefix)
             )
 
-        if len(input_value) > 256:
+        if len(input_value) > len_input_value:
             raise manager_exceptions.BadParametersError(
-                '{0} is too long. Maximum allowed length is 256 '
-                'characters'.format(prefix)
+                '{0} is too long. Maximum allowed length is {1} '
+                'characters'.format(prefix, len_input_value)
             )
 
         # urllib.quote changes all chars except alphanumeric chars and _-.


### PR DESCRIPTION
Following a UI request, we would like to limit the labels' keys and values to a maximum length of 56 characters. 