### PR TITLE
RD-655 Use `workflow_parameters` in components

### DIFF
--- a/cloudify_types/cloudify_types/component/component.py
+++ b/cloudify_types/cloudify_types/component/component.py
@@ -474,6 +474,7 @@ class Component(object):
             dict(
                  deployment_id=self.deployment_id,
                  workflow_id=self.workflow_id,
+                 parameters=ctx.workflow_parameters,
                  **execution_args
              ))
 


### PR DESCRIPTION
Retrieve a `workflow_parameters` from the Cloudify context and use it to
run executions from the Components.