### PR TITLE
RD-695 Create filters endpoint

### DIFF
--- a/amqp-postgres/test-requirements.txt
+++ b/amqp-postgres/test-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common[dispatcher]==master
+git+https://github.com/cloudify-cosmo/cloudify-common@RD-377-filters#egg=cloudify-common[dispatcher]==RD-377-filters
 -e ../rest-service
 mock
 pytest

--- a/rest-service/dev-requirements.txt
+++ b/rest-service/dev-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common[dispatcher]==master
+git+https://github.com/cloudify-cosmo/cloudify-common@RD-377-filters#egg=cloudify-common[dispatcher]==RD-377-filters
 
 # For dealing with the binary leftovers of psycopg2 in the 2.7.x version
 psycopg2==2.7.4 --no-binary psycopg2

--- a/rest-service/manager_rest/rest/endpoint_mapper.py
+++ b/rest-service/manager_rest/rest/endpoint_mapper.py
@@ -132,6 +132,8 @@ def setup_resources(api):
         'PermissionsRole': 'permissions/<string:role_name>',
         'PermissionsRoleId':
             'permissions/<string:role_name>/<string:permission_name>',
+        'Filters': 'filters',
+        'FiltersId': 'filters/<string:filter_id>',
     }
 
     # Set version endpoint as a non versioned endpoint

--- a/rest-service/manager_rest/rest/resources_v3_1/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/__init__.py
@@ -101,3 +101,8 @@ from .permissions import (  # NOQA
     PermissionsRole,
     PermissionsRoleId
 )
+
+from .filters import (                           # NOQA
+    Filters,
+    FiltersId,
+)

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -48,6 +48,7 @@ SHARED_RESOURCE_TYPE = 'cloudify.nodes.SharedResource'
 COMPONENT_TYPE = 'cloudify.nodes.Component'
 EXTERNAL_SOURCE = 'external_source'
 EXTERNAL_TARGET = 'external_target'
+LABEL_LEN = 56
 
 
 class DeploymentsId(resources_v1.DeploymentsId):
@@ -161,7 +162,7 @@ def _get_labels(request_dict):
                 (not isinstance(value, text_type))):
             _raise_bad_labels_list()
         rest_utils.validate_inputs({'key': key, 'value': value},
-                                   len_input_value=56)
+                                   len_input_value=LABEL_LEN)
         labels_list.append((key.lower(), value.lower()))
 
     _test_unique_labels(labels_list)

--- a/rest-service/manager_rest/rest/resources_v3_1/filters.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/filters.py
@@ -122,7 +122,7 @@ def _parse_labels_filter(labels_filter, sign):
              stripped of whitespaces
     """
     label_key, raw_label_value = labels_filter.split(sign)
-    label_value = filters.get_label_value(raw_label_value)
+    label_value = filters.get_label_value(raw_label_value.strip())
     if isinstance(label_value, list):
         value_msg_prefix = 'One of the filter values'
         label_values_list = label_value
@@ -135,7 +135,7 @@ def _parse_labels_filter(labels_filter, sign):
                 {'filter key': label_key.strip()}, len_input_value=LABEL_LEN)
             rest_utils.validate_inputs(
                 {'filter value': value.strip()}, len_input_value=LABEL_LEN,
-                prefix=value_msg_prefix)
+                err_prefix=value_msg_prefix)
         except manager_exceptions.BadParametersError as e:
             err_msg = 'The filter rule {0} is invalid. '.format(labels_filter)
             raise manager_exceptions.BadParametersError(err_msg + str(e))

--- a/rest-service/manager_rest/rest/resources_v3_1/filters.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/filters.py
@@ -1,0 +1,147 @@
+import re
+import json
+from flask import request
+
+from cloudify.models_states import VisibilityState
+
+from manager_rest import manager_exceptions
+from manager_rest.security import SecuredResource
+from manager_rest.utils import get_formatted_timestamp
+from manager_rest.rest import rest_decorators, rest_utils
+from manager_rest.security.authorization import authorize
+from manager_rest.storage import models, get_storage_manager, filters
+
+from .deployments import LABEL_LEN
+
+
+class Filters(SecuredResource):
+    @authorize('filters_list')
+    @rest_decorators.marshal_with(models.Filter)
+    @rest_decorators.paginate
+    @rest_decorators.sortable(models.Filter)
+    @rest_decorators.all_tenants
+    @rest_decorators.search('id')
+    def get(self, _include=None, pagination=None, sort=None,
+            all_tenants=None, search=None):
+        """List filters"""
+
+        get_all_results = rest_utils.verify_and_convert_bool(
+            '_get_all_results',
+            request.args.get('_get_all_results', False)
+        )
+        result = get_storage_manager().list(
+            models.Filter,
+            include=_include,
+            substr_filters=search,
+            pagination=pagination,
+            sort=sort,
+            all_tenants=all_tenants,
+            get_all_results=get_all_results
+        )
+
+        return result
+
+
+class FiltersId(SecuredResource):
+    @authorize('filters_create')
+    @rest_decorators.marshal_with(models.Filter)
+    def put(self, filter_id):
+        """Create a filter
+
+        Currently, this function only supports the creation of a labels filter
+        """
+        rest_utils.validate_inputs({'filter_id': filter_id})
+        request_dict = rest_utils.get_json_and_verify_params(
+            {'filter_rules': {'type': list}})
+        labels_filters = request_dict['filter_rules']
+        parsed_labels_filters = _parse_labels_filters(labels_filters)
+        visibility = rest_utils.get_visibility_parameter(
+            optional=True, valid_values=VisibilityState.STATES)
+
+        new_filter = models.Filter(
+            id=filter_id,
+            value=json.dumps({'labels': parsed_labels_filters}),
+            created_at=get_formatted_timestamp(),
+            visibility=visibility
+        )
+
+        return get_storage_manager().put(new_filter)
+
+
+def _parse_labels_filters(labels_filters_list):
+    """Validate and parse a list of labels filters
+
+    :param labels_filters_list: A list of labels filters. Labels filters must
+           be one of: <key>=<value>, <key>=[<value1>,<value2>,...],
+           <key>!=<value>, <key>!=[<value1>,<value2>,...], <key> is null,
+           <key> is not null
+
+    :return The labels filters list with the labels' keys and values in
+            lowercase and stripped of whitespaces
+    """
+    parsed_filter = None
+    parsed_labels_filters = []
+    for labels_filter in labels_filters_list:
+        try:
+            if '!=' in labels_filter:
+                parsed_filter = _parse_labels_filter(labels_filter, '!=')
+
+            elif '=' in labels_filter:
+                parsed_filter = _parse_labels_filter(labels_filter, '=')
+
+            elif 'null' in labels_filter:
+                match_null = re.match(r'(\S+) is null', labels_filter)
+                match_not_null = re.match(r'(\S+) is not null', labels_filter)
+                if match_null:
+                    parsed_filter = match_null.group(1).lower() + ' is null'
+                elif match_not_null:
+                    parsed_filter = (match_not_null.group(1).lower() +
+                                     ' is not null')
+                else:
+                    filters.raise_bad_labels_filter(labels_filter)
+
+            else:
+                filters.raise_bad_labels_filter(labels_filter)
+
+        except ValueError:
+            filters.raise_bad_labels_filter(labels_filter)
+
+        if parsed_filter:
+            parsed_labels_filters.append(parsed_filter)
+
+    return parsed_labels_filters
+
+
+def _parse_labels_filter(labels_filter, sign):
+    """Validate and parse a labels filter
+
+    :param labels_filter: One of <key>=<value>, <key>=[<value1>,<value2>,...],
+           <key>!=<value>, <key>!=[<value1>,<value2>,...]
+    :param sign: Either '=' or '!='
+    :return: The labels_filter, with its key and value(s) in lowercase and
+             stripped of whitespaces
+    """
+    label_key, raw_label_value = labels_filter.split(sign)
+    label_value = filters.get_label_value(raw_label_value)
+    if isinstance(label_value, list):
+        value_msg_prefix = 'One of the filter values'
+        label_values_list = label_value
+    else:
+        value_msg_prefix = None
+        label_values_list = [label_value]
+    for value in label_values_list:
+        try:
+            rest_utils.validate_inputs(
+                {'filter key': label_key.strip()}, len_input_value=LABEL_LEN)
+            rest_utils.validate_inputs(
+                {'filter value': value.strip()}, len_input_value=LABEL_LEN,
+                prefix=value_msg_prefix)
+        except manager_exceptions.BadParametersError as e:
+            err_msg = 'The filter rule {0} is invalid. '.format(labels_filter)
+            raise manager_exceptions.BadParametersError(err_msg + str(e))
+
+    parsed_values_list = [value.strip().lower() for value in label_values_list]
+    parsed_value = (('[' + ','.join(parsed_values_list) + ']')
+                    if isinstance(label_value, list) else
+                    parsed_values_list[0])
+    return label_key.strip().lower() + sign + parsed_value

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -139,9 +139,9 @@ def set_restart_task(delay=1, service_management='systemd'):
     subprocess.Popen(cmd, shell=True)
 
 
-def validate_inputs(input_dict, len_input_value=256):
+def validate_inputs(input_dict, len_input_value=256, prefix=None):
     for input_name, input_value in input_dict.items():
-        prefix = 'The `{0}` argument'.format(input_name)
+        prefix = prefix or 'The `{0}` argument'.format(input_name)
 
         if not input_value:
             raise manager_exceptions.BadParametersError(

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -139,9 +139,9 @@ def set_restart_task(delay=1, service_management='systemd'):
     subprocess.Popen(cmd, shell=True)
 
 
-def validate_inputs(input_dict, len_input_value=256, prefix=None):
+def validate_inputs(input_dict, len_input_value=256, err_prefix=None):
     for input_name, input_value in input_dict.items():
-        prefix = prefix or 'The `{0}` argument'.format(input_name)
+        prefix = err_prefix or 'The `{0}` argument'.format(input_name)
 
         if not input_value:
             raise manager_exceptions.BadParametersError(

--- a/rest-service/manager_rest/storage/filters.py
+++ b/rest-service/manager_rest/storage/filters.py
@@ -10,7 +10,7 @@ def add_labels_filters_to_query(query, labels_model, labels_filters):
         try:
             if '!=' in labels_filter:
                 label_key, raw_label_value = labels_filter.split('!=')
-                label_value = _get_label_value(raw_label_value)
+                label_value = get_label_value(raw_label_value)
                 if isinstance(label_value, list):
                     query = query.filter(key_not_equal_list_values(
                         labels_model, label_key, label_value))
@@ -20,7 +20,7 @@ def add_labels_filters_to_query(query, labels_model, labels_filters):
 
             elif '=' in labels_filter:
                 label_key, raw_label_value = labels_filter.split('=')
-                label_value = _get_label_value(raw_label_value)
+                label_value = get_label_value(raw_label_value)
                 if isinstance(label_value, list):
                     query = query.filter(key_equal_list_values(
                         labels_model, label_key, label_value))
@@ -38,18 +38,18 @@ def add_labels_filters_to_query(query, labels_model, labels_filters):
                     query = query.filter(
                         key_exist(labels_model, match_not_null.group(1)))
                 else:
-                    _raise_bad_labels_filter(labels_filter)
+                    raise_bad_labels_filter(labels_filter)
 
             else:
-                _raise_bad_labels_filter(labels_filter)
+                raise_bad_labels_filter(labels_filter)
 
         except ValueError:
-            _raise_bad_labels_filter(labels_filter)
+            raise_bad_labels_filter(labels_filter)
 
     return query
 
 
-def _raise_bad_labels_filter(labels_filter_value):
+def raise_bad_labels_filter(labels_filter_value):
     raise manager_exceptions.BadParametersError(
         'The labels filter `{0}` is not in the right '
         'format. It must be one of: <key>=<value>, '
@@ -59,7 +59,7 @@ def _raise_bad_labels_filter(labels_filter_value):
     )
 
 
-def _get_label_value(raw_label_value):
+def get_label_value(raw_label_value):
     # This means `]` and `,` are not allowed in the labels
     match_list = re.match(r'^\[([^]]+)\]$', raw_label_value)
     if match_list:

--- a/rest-service/manager_rest/storage/models.py
+++ b/rest-service/manager_rest/storage/models.py
@@ -54,4 +54,5 @@ from .resource_models import (Blueprint,
                               PluginsUpdate,
                               InterDeploymentDependencies,
                               _PluginState,
-                              DeploymentLabel)
+                              DeploymentLabel,
+                              Filter)

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -201,6 +201,7 @@ class BaseServerTestCase(unittest.TestCase):
                         client.inter_deployment_dependencies.api = \
                             mock_http_client
                         client.deployments_labels.api = mock_http_client
+                        client.filters.api = mock_http_client
 
         return client
 

--- a/rest-service/manager_rest/test/endpoints/test_filters.py
+++ b/rest-service/manager_rest/test/endpoints/test_filters.py
@@ -1,8 +1,15 @@
+from cloudify_rest_client.constants import VisibilityState
+from cloudify_rest_client.exceptions import CloudifyClientError
+
 from manager_rest.test import base_test
+from manager_rest.test.attribute import attr
 from manager_rest.storage.models_base import db
 from manager_rest.manager_exceptions import BadParametersError
+from manager_rest.rest.resources_v3_1.deployments import LABEL_LEN
 from manager_rest.storage.filters import add_labels_filters_to_query
 from manager_rest.storage.resource_models import Deployment, DeploymentLabel
+
+FILTER_ID = 'filter'
 
 
 class FiltersFunctionalityTest(base_test.BaseServerTestCase):
@@ -44,3 +51,59 @@ class FiltersFunctionalityTest(base_test.BaseServerTestCase):
         deployments = query.all()
 
         assert deployments_ids_set == set(dep.id for dep in deployments)
+
+
+@attr(client_min_version=3.1, client_max_version=base_test.LATEST_API_VERSION)
+class FiltersTestCase(base_test.BaseServerTestCase):
+    LEGAL_RULES = ['a=b', 'c!=d', 'e=[f,g]', 'h!=[i,j]',
+                   'k is null', 'l is not null']
+
+    def create_filter(self, filter_name, filter_rules,
+                      visibility=VisibilityState.TENANT):
+        return self.client.filters.create(filter_name, filter_rules,
+                                          visibility)
+
+    def list_filters(self, **kwargs):
+        return self.client.filters.list(**kwargs)
+
+    def test_create_legal_filter(self):
+        new_filter = self.create_filter(FILTER_ID, self.LEGAL_RULES)
+        self.assertEqual(new_filter.labels_filter, self.LEGAL_RULES)
+
+    def test_list_filters(self):
+        for i in range(3):
+            self.create_filter('{0}{1}'.format(FILTER_ID, i),
+                               ['a{0}=b{0}'.format(i)])
+        filters_list = self.list_filters()
+
+        self.assertEqual(len(filters_list.items), 3)
+        for i in range(3):
+            self.assertEqual(filters_list.items[i].labels_filter,
+                             ['a{0}=b{0}'.format(i)])
+
+    def test_filter_create_lowercase(self):
+        legal_rules_uppercase = (
+                [rule.upper() for rule in self.LEGAL_RULES[:4]] +
+                ['K is null', 'L is not null'])
+        new_filter = self.create_filter(FILTER_ID, legal_rules_uppercase)
+        self.assertEqual(new_filter.labels_filter, self.LEGAL_RULES)
+
+    def test_filter_create_strip(self):
+        legal_rules_whitespace = ['a = b', 'c != d', 'e= [f , g]',
+                                  'h !=[ i,j ]', 'k is null', 'l is not null']
+        new_filter = self.create_filter(FILTER_ID, legal_rules_whitespace)
+        self.assertEqual(new_filter.labels_filter, self.LEGAL_RULES)
+
+    def test_filter_create_fails(self):
+        err_rules = [
+            (['a={0}'.format('b'*(LABEL_LEN+1))], '.*too long.*'),
+            (['a= '], '.*is empty.*'),
+            (['a!=b]'], '.*illegal characters.*'),
+            (['a'], '.*not in the right format.*'),
+            (['a null'], '.*not in the right format.*'),
+            (['a=b=c'], '.*not in the right format.*'),
+        ]
+
+        for err_rule, err_msg in err_rules:
+            with self.assertRaisesRegex(CloudifyClientError, err_msg):
+                self.create_filter(FILTER_ID, err_rule)


### PR DESCRIPTION
This PR:
1. Creates a `/filters` endpoint (RD-696). [This is the complement PR is cloudify-manager-install](https://github.com/cloudify-cosmo/cloudify-manager-install/pull/1046).
2. Creates the `GET /filters` endpoint to list all filters (RD-697).
3. Creates the `PUT /filters/<filter_id>` endpoint to create a new filter (RD-699).