### PR TITLE
RD-1007 Fix issue with access home directory for agent using centos 8…

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_plugin_workdir.py
+++ b/tests/integration_tests/tests/agent_tests/test_plugin_workdir.py
@@ -42,9 +42,14 @@ class PluginWorkdirTest(AgentTestCase):
         host_instance_id = self.client.node_instances.list(
             deployment_id=deployment.id,
             node_id='host')[0].id
-        host_file = os.path.join('/etc/cloudify', host_instance_id,
-                                 'work/plugins/testmockoperations',
-                                 filename)
+        # Get the version of manager
+        version = self.client.manager.get_version()['version']
+        host_file = os.path.join(
+            '/opt/cloudify-agent-{0}'.format(version),
+            host_instance_id,
+            'work/plugins/testmockoperations',
+            filename
+        )
         out = self.read_manager_file(central_file)
         self.assertEqual(central_content, out)
         out = self.read_host_file(host_file,

--- a/tests/integration_tests/tests/agent_tests/test_plugins.py
+++ b/tests/integration_tests/tests/agent_tests/test_plugins.py
@@ -43,8 +43,11 @@ class PluginInstallationTest(AgentTestCase):
         )
 
     def _agent_plugin_dir(self, agent_id, plugin):
+        agent_base_dir = '/opt/cloudify-agent-{0}'.format(
+            self.client.manager.get_version()['version']
+        )
         return os.path.join(
-            self.execute_on_manager(['bash', '-c', 'echo ~cfyuser']).strip(),
+            agent_base_dir,
             agent_id,
             'env', 'plugins',
             plugin.tenant_name,


### PR DESCRIPTION
This PR created in order to update the integration tests related to agent installation as we changed the location of install agent from home user directory to the `/opt/cloudify-agent-{version}` as part of this [PR](https://github.com/cloudify-cosmo/cloudify-agent/pull/735/files) 