### PR TITLE
RD-1049 Update cryptography

### DIFF
--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     'python-dateutil==2.5.3',
     'voluptuous==0.9.3',
     'pika==0.11.2',
-    'cryptography==2.5.0',
+    'cryptography==3.3.1',
     'psycopg2==2.7.4',
     'pytz==2018.4',
     'packaging==17.1',

--- a/workflows/setup.py
+++ b/workflows/setup.py
@@ -31,7 +31,7 @@ setup(
         'cloudify-common==5.2.0-.dev1',
         'retrying==1.3.3',
         'psycopg2==2.7.4',
-        'cryptography==2.5.0',
+        'cryptography==3.3.1',
         'python-dateutil==2.5.3',
         'pytz==2018.4',
     ]


### PR DESCRIPTION
Older versions than 3.2 are raising dependabot security alerts.