### PR TITLE
RD-694 Filters in deployments list

### DIFF
--- a/amqp-postgres/test-requirements.txt
+++ b/amqp-postgres/test-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cloudify-cosmo/cloudify-common@RD-695-add-more-commands-to-filters#egg=cloudify-common[dispatcher]==RD-695-add-more-commands-to-filters
+git+https://github.com/cloudify-cosmo/cloudify-common@RD-694-filters-in-deployments-list#egg=cloudify-common[dispatcher]==RD-694-filters-in-deployments-list
 -e ../rest-service
 mock
 pytest

--- a/rest-service/dev-requirements.txt
+++ b/rest-service/dev-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cloudify-cosmo/cloudify-common@RD-695-add-more-commands-to-filters#egg=cloudify-common[dispatcher]==RD-695-add-more-commands-to-filters
+git+https://github.com/cloudify-cosmo/cloudify-common@RD-694-filters-in-deployments-list#egg=cloudify-common[dispatcher]==RD-694-filters-in-deployments-list
 
 # For dealing with the binary leftovers of psycopg2 in the 2.7.x version
 psycopg2==2.7.4 --no-binary psycopg2

--- a/rest-service/manager_rest/rest/resources_v2/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v2/deployments.py
@@ -17,8 +17,6 @@
 from flask import request
 from flask_restful_swagger import swagger
 
-from cloudify._compat import text_type
-
 from .. import rest_utils
 from manager_rest import manager_exceptions
 from manager_rest.rest import (
@@ -88,11 +86,9 @@ class Deployments(resources_v1.Deployments):
 
 
 def _get_filter_rules():
-    request_dict = rest_utils.get_json_and_verify_params(
-        {'filter_rules': {'type': list, 'optional': True},
-         'filter_name': {'type': text_type, 'optional': True}})
-    filter_rules = request_dict.get('filter_rules')
-    filter_name = request_dict.get('filter_name')
+    filter_rules = request.args.get('_filter_rules')
+    filter_name = request.args.get('_filter_name')
+
     if not filter_rules and not filter_name:
         return
 
@@ -103,7 +99,7 @@ def _get_filter_rules():
         )
 
     if filter_rules:
-        return rest_utils.parse_labels_filters(filter_rules)
+        return rest_utils.parse_labels_filters(filter_rules.split(','))
 
     if filter_name:
         filter_elem = get_storage_manager().get(models.Filter, filter_name)

--- a/rest-service/manager_rest/rest/resources_v2/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v2/deployments.py
@@ -17,7 +17,10 @@
 from flask import request
 from flask_restful_swagger import swagger
 
+from cloudify._compat import text_type
+
 from .. import rest_utils
+from manager_rest import manager_exceptions
 from manager_rest.rest import (
     resources_v1,
     rest_decorators,
@@ -66,7 +69,8 @@ class Deployments(resources_v1.Deployments):
             pagination=pagination,
             sort=sort,
             all_tenants=all_tenants,
-            get_all_results=get_all_results
+            get_all_results=get_all_results,
+            filter_rules=_get_filter_rules()
         )
 
         if _include and 'workflows' in _include:
@@ -81,6 +85,29 @@ class Deployments(resources_v1.Deployments):
                 result.items[index] = r
 
         return result
+
+
+def _get_filter_rules():
+    request_dict = rest_utils.get_json_and_verify_params(
+        {'filter_rules': {'type': list, 'optional': True},
+         'filter_name': {'type': text_type, 'optional': True}})
+    filter_rules = request_dict.get('filter_rules')
+    filter_name = request_dict.get('filter_name')
+    if not filter_rules and not filter_name:
+        return
+
+    if filter_rules and filter_name:
+        raise manager_exceptions.BadParametersError(
+            'Filter rules and filter name cannot be provided together. '
+            'Please specify one of them or neither.'
+        )
+
+    if filter_rules:
+        return rest_utils.parse_labels_filters(filter_rules)
+
+    if filter_name:
+        filter_elem = get_storage_manager().get(models.Filter, filter_name)
+        return filter_elem.value.get('labels', [])
 
 
 class DeploymentModifications(resources_v1.DeploymentModifications):

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -48,7 +48,6 @@ SHARED_RESOURCE_TYPE = 'cloudify.nodes.SharedResource'
 COMPONENT_TYPE = 'cloudify.nodes.Component'
 EXTERNAL_SOURCE = 'external_source'
 EXTERNAL_TARGET = 'external_target'
-LABEL_LEN = 56
 
 
 class DeploymentsId(resources_v1.DeploymentsId):
@@ -162,7 +161,7 @@ def _get_labels(request_dict):
                 (not isinstance(value, text_type))):
             _raise_bad_labels_list()
         rest_utils.validate_inputs({'key': key, 'value': value},
-                                   len_input_value=LABEL_LEN)
+                                   len_input_value=rest_utils.LABEL_LEN)
         labels_list.append((key.lower(), value.lower()))
 
     _test_unique_labels(labels_list)

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -14,6 +14,7 @@
 #  * limitations under the License.
 
 import os
+import re
 import uuid
 import pytz
 import copy
@@ -36,7 +37,7 @@ from cloudify._compat import urlquote, text_type
 from cloudify.models_states import VisibilityState
 from cloudify.snapshots import SNAPSHOT_RESTORE_FLAG_FILE
 
-from manager_rest.storage import models
+from manager_rest.storage import models, filters
 from manager_rest.constants import REST_SERVICE_NAME
 from manager_rest.dsl_functions import (get_secret_method,
                                         evaluate_intrinsic_functions)
@@ -47,6 +48,7 @@ from manager_rest.utils import is_administrator, get_formatted_timestamp
 states_except_private = copy.deepcopy(VisibilityState.STATES)
 states_except_private.remove('private')
 VISIBILITY_EXCEPT_PRIVATE = states_except_private
+LABEL_LEN = 56
 
 
 @contextmanager
@@ -587,3 +589,82 @@ def _get_deployment_from_target_func(sm, target_dep_func, source_dep_id):
         return sm.get(models.Deployment, target_dep_id, fail_silently=True)
 
     return None
+
+
+def parse_labels_filters(labels_filters_list):
+    """Validate and parse a list of labels filters
+
+    :param labels_filters_list: A list of labels filters. Labels filters must
+           be one of: <key>=<value>, <key>=[<value1>,<value2>,...],
+           <key>!=<value>, <key>!=[<value1>,<value2>,...], <key> is null,
+           <key> is not null
+
+    :return The labels filters list with the labels' keys and values in
+            lowercase and stripped of whitespaces
+    """
+    parsed_filter = None
+    parsed_labels_filters = []
+    for labels_filter in labels_filters_list:
+        try:
+            if '!=' in labels_filter:
+                parsed_filter = _parse_labels_filter(labels_filter, '!=')
+
+            elif '=' in labels_filter:
+                parsed_filter = _parse_labels_filter(labels_filter, '=')
+
+            elif 'null' in labels_filter:
+                match_null = re.match(r'(\S+) is null', labels_filter)
+                match_not_null = re.match(r'(\S+) is not null', labels_filter)
+                if match_null:
+                    parsed_filter = match_null.group(1).lower() + ' is null'
+                elif match_not_null:
+                    parsed_filter = (match_not_null.group(1).lower() +
+                                     ' is not null')
+                else:
+                    filters.raise_bad_labels_filter(labels_filter)
+
+            else:
+                filters.raise_bad_labels_filter(labels_filter)
+
+        except ValueError:
+            filters.raise_bad_labels_filter(labels_filter)
+
+        if parsed_filter:
+            parsed_labels_filters.append(parsed_filter)
+
+    return parsed_labels_filters
+
+
+def _parse_labels_filter(labels_filter, sign):
+    """Validate and parse a labels filter
+
+    :param labels_filter: One of <key>=<value>, <key>=[<value1>,<value2>,...],
+           <key>!=<value>, <key>!=[<value1>,<value2>,...]
+    :param sign: Either '=' or '!='
+    :return: The labels_filter, with its key and value(s) in lowercase and
+             stripped of whitespaces
+    """
+    label_key, raw_label_value = labels_filter.split(sign)
+    label_value = filters.get_label_value(raw_label_value.strip())
+    if isinstance(label_value, list):
+        value_msg_prefix = 'One of the filter values'
+        label_values_list = label_value
+    else:
+        value_msg_prefix = None
+        label_values_list = [label_value]
+    for value in label_values_list:
+        try:
+            validate_inputs(
+                {'filter key': label_key.strip()}, len_input_value=LABEL_LEN)
+            validate_inputs(
+                {'filter value': value.strip()}, len_input_value=LABEL_LEN,
+                err_prefix=value_msg_prefix)
+        except manager_exceptions.BadParametersError as e:
+            err_msg = 'The filter rule {0} is invalid. '.format(labels_filter)
+            raise manager_exceptions.BadParametersError(err_msg + str(e))
+
+    parsed_values_list = [value.strip().lower() for value in label_values_list]
+    parsed_value = (('[' + ','.join(parsed_values_list) + ']')
+                    if isinstance(label_value, list) else
+                    parsed_values_list[0])
+    return label_key.strip().lower() + sign + parsed_value

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -314,6 +314,10 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
                            nullable=True,
                            ondelete='SET NULL')
 
+    @classproperty
+    def labels_model(cls):
+        return DeploymentLabel
+
     @declared_attr
     def blueprint(cls):
         return one_to_many_relationship(cls, Blueprint, cls._blueprint_fk)

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -955,3 +955,8 @@ class BaseServerTestCase(unittest.TestCase):
             labels=labels)
 
         return deployment
+
+    def create_filter(self, filter_name, filter_rules,
+                      visibility=VisibilityState.TENANT):
+        return self.client.filters.create(
+            filter_name, filter_rules, visibility)

--- a/rest-service/manager_rest/test/endpoints/test_filters.py
+++ b/rest-service/manager_rest/test/endpoints/test_filters.py
@@ -4,8 +4,8 @@ from cloudify_rest_client.exceptions import CloudifyClientError
 from manager_rest.test import base_test
 from manager_rest.test.attribute import attr
 from manager_rest.storage.models_base import db
+from manager_rest.rest.rest_utils import LABEL_LEN
 from manager_rest.manager_exceptions import BadParametersError
-from manager_rest.rest.resources_v3_1.deployments import LABEL_LEN
 from manager_rest.storage.filters import add_labels_filters_to_query
 from manager_rest.storage.resource_models import Deployment, DeploymentLabel
 
@@ -58,11 +58,6 @@ class FiltersTestCase(base_test.BaseServerTestCase):
     SIMPLE_RULE = ['a=b']
     LEGAL_RULES = ['a=b', 'c!=d', 'e=[f,g]', 'h!=[i,j]',
                    'k is null', 'l is not null']
-
-    def create_filter(self, filter_name, filter_rules,
-                      visibility=VisibilityState.TENANT):
-        return self.client.filters.create(
-            filter_name, filter_rules, visibility)
 
     def list_filters(self, **kwargs):
         return self.client.filters.list(**kwargs)


### PR DESCRIPTION
Adding filter rules to deployments list. 
Much of the code changes are related to passing the code from filters.py (API v3.1) to rest_utils.py so it can be used from deployments.py (API v2.0).

The complementary PR in cloudify-common is https://github.com/cloudify-cosmo/cloudify-common/pull/622