### PR TITLE
setup.py: fix find_packages syntax

### DIFF
--- a/workflows/setup.py
+++ b/workflows/setup.py
@@ -21,7 +21,7 @@ setup(
     version='5.2.0-.dev1',
     author='Cloudify',
     author_email='cosmo-admin@cloudify.co',
-    packages=find_packages(include='cloudify_system_workflows'),
+    packages=find_packages(),
     license='LICENSE',
     description='Various Cloudify Workflows',
     install_requires=[


### PR DESCRIPTION
it should be `cloudify_system_workflows*` with the `*`, but it might as
well be just this too