### PR TITLE
unittests: allow creating clients with different users

### DIFF
--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -119,13 +119,20 @@ class TestClient(FlaskClient):
     """A helper class that overrides flask's default testing.FlaskClient
     class for the purpose of adding authorization headers to all rest calls
     """
+    def __init__(self, *args, **kwargs):
+        self._user = kwargs.pop('user')
+        super(TestClient, self).__init__(*args, **kwargs)
+
     def open(self, *args, **kwargs):
         kwargs = kwargs or {}
-        admin = get_admin_user()
         kwargs['headers'] = kwargs.get('headers') or {}
         if CLOUDIFY_EXECUTION_TOKEN_HEADER not in kwargs['headers']:
-            kwargs['headers'].update(utils.create_auth_header(
-                username=admin['username'], password=admin['password']))
+            kwargs['headers'].update(
+                utils.create_auth_header(
+                    username=self._user['username'],
+                    password=self._user['password']
+                )
+            )
         kwargs['headers'][constants.CLOUDIFY_TENANT_HEADER] = \
             constants.DEFAULT_TENANT_NAME
         return super(TestClient, self).open(*args, **kwargs)
@@ -147,17 +154,20 @@ class BaseServerTestCase(unittest.TestCase):
                                   username,
                                   password,
                                   tenant=DEFAULT_TENANT_NAME):
-        headers = utils.create_auth_header(username=username,
-                                           password=password)
-
-        headers[CLOUDIFY_TENANT_HEADER] = tenant
-        return cls.create_client(headers=headers)
+        app = cls._get_app(server.app, user={
+            'username': username,
+            'password': password
+        })
+        headers = {CLOUDIFY_TENANT_HEADER: tenant}
+        return cls.create_client(headers=headers, app=app)
 
     @classmethod
-    def create_client(cls, headers=None):
+    def create_client(cls, headers=None, app=None):
+        if app is None:
+            app = cls.app
         client = CloudifyClient(host='localhost',
                                 headers=headers)
-        mock_http_client = MockHTTPClient(cls.app,
+        mock_http_client = MockHTTPClient(app,
                                           headers=headers,
                                           file_server=cls.file_server)
         client._client = mock_http_client
@@ -401,14 +411,17 @@ class BaseServerTestCase(unittest.TestCase):
         utils.set_current_tenant(default_tenant)
 
     @staticmethod
-    def _get_app(flask_app):
+    def _get_app(flask_app, user=None):
         """Create a flask.testing FlaskClient
 
         :param flask_app: Flask app
+        :param user: a dict containing username and password
         :return: Our modified version of Flask's test client
         """
+        if user is None:
+            user = get_admin_user()
         flask_app.test_client_class = TestClient
-        return flask_app.test_client()
+        return flask_app.test_client(user=user)
 
     @staticmethod
     def _setup_current_user():

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -133,8 +133,10 @@ class TestClient(FlaskClient):
                     password=self._user['password']
                 )
             )
-        kwargs['headers'][constants.CLOUDIFY_TENANT_HEADER] = \
+        kwargs['headers'].setdefault(
+            constants.CLOUDIFY_TENANT_HEADER,
             constants.DEFAULT_TENANT_NAME
+        )
         return super(TestClient, self).open(*args, **kwargs)
 
 

--- a/rest-service/manager_rest/test/endpoints/test_version.py
+++ b/rest-service/manager_rest/test/endpoints/test_version.py
@@ -15,9 +15,9 @@
 
 from manager_rest.test.attribute import attr
 
+from manager_rest import utils
 from manager_rest.version import get_version_data
 from manager_rest.test.security_utils import get_admin_user
-from manager_rest.constants import CLOUDIFY_TENANT_HEADER, DEFAULT_TENANT_NAME
 from manager_rest.test.base_test import BaseServerTestCase, LATEST_API_VERSION
 
 
@@ -25,32 +25,20 @@ from manager_rest.test.base_test import BaseServerTestCase, LATEST_API_VERSION
 class VersionTestCase(BaseServerTestCase):
     def setUp(self):
         super(VersionTestCase, self).setUp()
-        admin = get_admin_user()
-        self.client = self.create_client_with_tenant(
-            username=admin['username'],
-            password=admin['password'],
-            tenant=DEFAULT_TENANT_NAME
-        )
-
-    @staticmethod
-    def _get_app(flask_app, user):
-        # Overriding the base class' app, because otherwise a custom
-        # auth header is set on every use of the client
-        return flask_app.test_client()
+        self._expected = get_version_data()
+        # Adding some values, for backwards compatibility with older clients
+        self._expected['build'] = None
+        self._expected['date'] = None
+        self._expected['commit'] = None
 
     def test_get_version(self):
-        self._test_get_version()
+        assert self.client.manager.get_version() == self._expected
 
     def test_version_does_not_require_tenant_header(self):
-        # Remove the the tenant header from the client, and make sure the
-        # rest call still works
-        self.client._client.headers.pop(CLOUDIFY_TENANT_HEADER, None)
-        self._test_get_version()
-
-    def _test_get_version(self):
-        version_dict = get_version_data()
-        # Adding some values, for backwards compatibility with older clients
-        version_dict['build'] = None
-        version_dict['date'] = None
-        version_dict['commit'] = None
-        self.assertDictEqual(self.client.manager.get_version(), version_dict)
+        # create a client without the tenant header
+        admin = get_admin_user()
+        no_tenant_client = self.create_client(headers=utils.create_auth_header(
+            username=admin['username'],
+            password=admin['password'],
+        ))
+        assert no_tenant_client.manager.get_version() == self._expected

--- a/rest-service/manager_rest/test/endpoints/test_version.py
+++ b/rest-service/manager_rest/test/endpoints/test_version.py
@@ -33,7 +33,7 @@ class VersionTestCase(BaseServerTestCase):
         )
 
     @staticmethod
-    def _get_app(flask_app):
+    def _get_app(flask_app, user):
         # Overriding the base class' app, because otherwise a custom
         # auth header is set on every use of the client
         return flask_app.test_client()

--- a/rest-service/manager_rest/test/security/test_base.py
+++ b/rest-service/manager_rest/test/security/test_base.py
@@ -28,7 +28,7 @@ class SecurityTestBase(BaseServerTestCase):
         add_users_to_db(get_test_users())
 
     @staticmethod
-    def _get_app(flask_app):
+    def _get_app(flask_app, user=None):
         # Overriding the base class' app, because otherwise a custom
         # auth header is set on every use of the client
         return flask_app.test_client()

--- a/rest-service/manager_rest/test/security/test_base.py
+++ b/rest-service/manager_rest/test/security/test_base.py
@@ -29,9 +29,10 @@ class SecurityTestBase(BaseServerTestCase):
 
     @staticmethod
     def _get_app(flask_app, user=None):
-        # Overriding the base class' app, because otherwise a custom
-        # auth header is set on every use of the client
-        return flask_app.test_client()
+        # security tests use a not-authenticated client by default
+        if user is None:
+            user = {'username': '', 'password': ''}
+        return BaseServerTestCase._get_app(flask_app, user=user)
 
     @contextmanager
     def use_secured_client(self, headers=None, **kwargs):
@@ -55,9 +56,9 @@ class SecurityTestBase(BaseServerTestCase):
     def _assert_user_unauthorized(self, headers=None, **kwargs):
         with self.use_secured_client(headers, **kwargs):
             self.assertRaises(
-                    UserUnauthorizedError,
-                    self.client.deployments.list
-                )
+                UserUnauthorizedError,
+                self.client.deployments.list
+            )
 
     @classmethod
     def create_configuration(cls):


### PR DESCRIPTION
Parametrize TestClient to use the passed-in credentials, instead of
hardcoding admin credentials.

With this, `create_client_with_tenant` actually uses the provided username.