### PR TITLE
Adding verification to filters commands

### DIFF
--- a/amqp-postgres/test-requirements.txt
+++ b/amqp-postgres/test-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common[dispatcher]==master
+git+https://github.com/cloudify-cosmo/cloudify-common@RD-705-add-cli-filters-command#egg=cloudify-common[dispatcher]==RD-705-add-cli-filters-command
 -e ../rest-service
 mock
 pytest

--- a/rest-service/dev-requirements.txt
+++ b/rest-service/dev-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common[dispatcher]
+git+https://github.com/cloudify-cosmo/cloudify-common@RD-705-add-cli-filters-command#egg=cloudify-common[dispatcher]
 
 # For dealing with the binary leftovers of psycopg2 in the 2.7.x version
 psycopg2==2.7.4 --no-binary psycopg2

--- a/rest-service/manager_rest/rest/resources_v2/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v2/deployments.py
@@ -88,12 +88,12 @@ class Deployments(resources_v1.Deployments):
 
 def _get_filter_rules():
     filter_rules = request.args.get('_filter_rules')
-    filter_name = request.args.get('_filter_name')
+    filter_id = request.args.get('_filter_id')
 
-    if not filter_rules and not filter_name:
+    if not filter_rules and not filter_id:
         return
 
-    if filter_rules and filter_name:
+    if filter_rules and filter_id:
         raise manager_exceptions.BadParametersError(
             'Filter rules and filter name cannot be provided together. '
             'Please specify one of them or neither.'
@@ -102,8 +102,9 @@ def _get_filter_rules():
     if filter_rules:
         return create_labels_filters_mapping(filter_rules.split(','))
 
-    if filter_name:
-        filter_elem = get_storage_manager().get(models.Filter, filter_name)
+    if filter_id:
+        rest_utils.validate_inputs({'filter_id': filter_id})
+        filter_elem = get_storage_manager().get(models.Filter, filter_id)
         return filter_elem.value.get('labels', {})
 
 

--- a/rest-service/manager_rest/rest/resources_v3_1/filters.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/filters.py
@@ -74,6 +74,7 @@ class FiltersId(SecuredResource):
         """
         Get a filter by ID
         """
+        rest_utils.validate_inputs({'filter_id': filter_id})
         return get_storage_manager().get(
             models.Filter, filter_id, include=_include)
 
@@ -82,6 +83,7 @@ class FiltersId(SecuredResource):
         """
         Delete a filter by ID
         """
+        rest_utils.validate_inputs({'filter_id': filter_id})
         storage_manager = get_storage_manager()
         filter_elem = storage_manager.get(models.Filter, filter_id)
         _validate_filter_modification_permitted(filter_elem)
@@ -95,6 +97,7 @@ class FiltersId(SecuredResource):
 
         This function updates the filter rules and visibility
         """
+        rest_utils.validate_inputs({'filter_id': filter_id})
         if not request.json:
             raise manager_exceptions.IllegalActionError(
                 'Update a filter request must include at least one parameter '

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -991,7 +991,8 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
     def test_list_deployments_with_filter_rules(self):
         dep1 = self.put_deployment_with_labels(self.LABELS)
         self.put_deployment_with_labels(self.LABELS_2)
-        deployments = self.client.deployments.list(filter_rules=['env=aws'])
+        deployments = self.client.deployments.list(
+            filter_rules={'_filter_rules': ['env=aws']})
         self.assertEqual(len(deployments), 1)
         self.assertEqual(deployments[0], dep1)
 
@@ -1001,7 +1002,8 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
         self.put_deployment_with_labels(self.LABELS)
         dep2 = self.put_deployment_with_labels(self.LABELS_2)
         self.create_filter(self.FILTER_ID, self.FILTER_RULES_2)
-        deployments = self.client.deployments.list(filter_name=self.FILTER_ID)
+        deployments = self.client.deployments.list(
+            filter_rules={'_filter_id': self.FILTER_ID})
         self.assertEqual(len(deployments), 1)
         self.assertEqual(deployments[0], dep2)
 
@@ -1010,17 +1012,9 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
     def test_list_deployments_with_filter_rules_upper(self):
         self.put_deployment_with_labels(self.LABELS)
         self.put_deployment_with_labels(self.LABELS_2)
-        deployments = self.client.deployments.list(filter_rules=['aRcH=k8S'])
+        deployments = self.client.deployments.list(
+            filter_rules={'_filter_rules': ['aRcH=k8S']})
         self.assertEqual(len(deployments), 2)
-
-    @attr(client_min_version=3.1,
-          client_max_version=base_test.LATEST_API_VERSION)
-    def test_list_deployments_with_filter_fails(self):
-        self.assertRaisesRegex(RuntimeError,
-                               '.*cannot be provided together.*',
-                               self.client.deployments.list,
-                               filter_rules=self.FILTER_RULES,
-                               filter_name=self.FILTER_ID)
 
     def _assert_deployment_labels(self, deployment_labels, compared_labels):
         simplified_labels = set()

--- a/rest-service/manager_rest/test/endpoints/test_filters.py
+++ b/rest-service/manager_rest/test/endpoints/test_filters.py
@@ -110,15 +110,21 @@ class FiltersTestCase(base_test.BaseServerTestCase):
                              ['a{0}=b{0}'.format(i)])
 
     def test_list_filters_sort(self):
-        filter_names = ['c_filter', 'b_filter', 'a_filter']
+        filter_names = ['a_filter', 'c_filter', 'b_filter']
         for filter_name in filter_names:
             self.create_filter(filter_name, self.SIMPLE_RULE)
 
-        filters_list = self.client.filters.list(_sort='id')
-        filter_names.sort()
+        sorted_asc_filters_list = self.client.filters.list(sort='id')
         self.assertEqual(
-            [filter_elem.id for filter_elem in filters_list.items],
-            filter_names
+            [filter_elem.id for filter_elem in sorted_asc_filters_list],
+            sorted(filter_names)
+        )
+
+        sorted_dsc_filters_list = self.client.filters.list(
+            sort='id', is_descending=True)
+        self.assertEqual(
+            [filter_elem.id for filter_elem in sorted_dsc_filters_list],
+            sorted(filter_names, reverse=True)
         )
 
     def test_filter_create_lowercase(self):


### PR DESCRIPTION
This PR:
1. Adds a verification step for the different filters commands. I think this is necessary to avoid SQL injections. 
2. Drops `_filter_name` from the deployments list endpoint, following this change https://github.com/cloudify-cosmo/cloudify-common/pull/631.