### PR TITLE
RD-653 Identify blueprints for a removed plugin

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -342,10 +342,11 @@ class ResourceManager(object):
                        b.plan[constants.DEPLOYMENT_PLUGINS_TO_INSTALL] +
                        extract_host_agent_plugins_from_plan(b.plan)):
                     affected_blueprint_ids.append(b.id)
-            raise manager_exceptions.PluginInUseError(
-                'Plugin "{0}" is currently in use in blueprints: {1}. '
-                'You can "force" plugin removal if needed.'.format(
-                    plugin.id, ', '.join(affected_blueprint_ids)))
+            if affected_blueprint_ids:
+                raise manager_exceptions.PluginInUseError(
+                    'Plugin "{0}" is currently in use in blueprints: {1}. '
+                    'You can "force" plugin removal if needed.'.format(
+                        plugin.id, ', '.join(affected_blueprint_ids)))
         workflow_executor.uninstall_plugin(plugin)
 
         # Remove from storage

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -335,12 +335,9 @@ class ResourceManager(object):
             for b in self.sm.list(models.Blueprint,
                                   include=['id', 'plan'],
                                   get_all_results=True):
-                if any(plugin.package_name == p.package_name \
-                       and plugin.package_version == p.package_version
-                       for p in
-                       b.plan[constants.WORKFLOW_PLUGINS_TO_INSTALL] +
-                       b.plan[constants.DEPLOYMENT_PLUGINS_TO_INSTALL] +
-                       extract_host_agent_plugins_from_plan(b.plan)):
+                if any(plugin.package_name == p.get('package_name') \
+                       and plugin.package_version == p.get('package_version')
+                       for p in b.plugins):
                     affected_blueprint_ids.append(b.id)
             if affected_blueprint_ids:
                 raise manager_exceptions.PluginInUseError(

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -335,14 +335,12 @@ class ResourceManager(object):
             for b in self.sm.list(models.Blueprint,
                                   include=['id', 'plan'],
                                   get_all_results=True):
-                plugins = set(
-                    (p.get('package_name'), p.get('package_version'))
-                    for sublist in
-                    [b.plan[constants.WORKFLOW_PLUGINS_TO_INSTALL] +
-                     b.plan[constants.DEPLOYMENT_PLUGINS_TO_INSTALL] +
-                     extract_host_agent_plugins_from_plan(b.plan)]
-                    for p in sublist)
-                if (plugin.package_name, plugin.package_version) in plugins:
+                if any(plugin.package_name == p.package_name \
+                       and plugin.package_version == p.package_version
+                       for p in
+                       b.plan[constants.WORKFLOW_PLUGINS_TO_INSTALL] +
+                       b.plan[constants.DEPLOYMENT_PLUGINS_TO_INSTALL] +
+                       extract_host_agent_plugins_from_plan(b.plan)):
                     affected_blueprint_ids.append(b.id)
             raise manager_exceptions.PluginInUseError(
                 'Plugin "{0}" is currently in use in blueprints: {1}. '

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -337,7 +337,7 @@ class ResourceManager(object):
                                   get_all_results=True):
                 if any(plugin.package_name == p.get('package_name') \
                        and plugin.package_version == p.get('package_version')
-                       for p in b.plugins):
+                       for p in self._blueprint_plugins(b)):
                     affected_blueprint_ids.append(b.id)
             if affected_blueprint_ids:
                 raise manager_exceptions.PluginInUseError(
@@ -353,6 +353,12 @@ class ResourceManager(object):
         archive_path = utils.get_plugin_archive_path(plugin_id,
                                                      plugin.archive_name)
         shutil.rmtree(os.path.dirname(archive_path), ignore_errors=True)
+
+    @staticmethod
+    def _blueprint_plugins(blueprint):
+        return blueprint.plan[constants.WORKFLOW_PLUGINS_TO_INSTALL] + \
+               blueprint.plan[constants.DEPLOYMENT_PLUGINS_TO_INSTALL] + \
+               extract_host_agent_plugins_from_plan(blueprint.plan)
 
     def upload_blueprint(self, blueprint_id, app_file_name, blueprint_url,
                          file_server_root, validate_only=False):

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -335,7 +335,7 @@ class ResourceManager(object):
             for b in self.sm.list(models.Blueprint,
                                   include=['id', 'plan'],
                                   get_all_results=True):
-                if any(plugin.package_name == p.get('package_name') \
+                if any(plugin.package_name == p.get('package_name')
                        and plugin.package_version == p.get('package_version')
                        for p in self._blueprint_plugins(b)):
                     affected_blueprint_ids.append(b.id)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -94,12 +94,6 @@ class Blueprint(CreatedAtMixin, SQLResourceBase):
     error = db.Column(db.Text)
     error_traceback = db.Column(db.Text)
 
-    @property
-    def plugins(self):
-        return self.plan[constants.WORKFLOW_PLUGINS_TO_INSTALL] + \
-               self.plan[constants.DEPLOYMENT_PLUGINS_TO_INSTALL] + \
-               extract_from(self.plan)
-
 
 class Snapshot(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'snapshots'

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -94,6 +94,12 @@ class Blueprint(CreatedAtMixin, SQLResourceBase):
     error = db.Column(db.Text)
     error_traceback = db.Column(db.Text)
 
+    @property
+    def plugins(self):
+        return self.plan[constants.WORKFLOW_PLUGINS_TO_INSTALL] + \
+               self.plan[constants.DEPLOYMENT_PLUGINS_TO_INSTALL] + \
+               extract_from(self.plan)
+
 
 class Snapshot(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'snapshots'


### PR DESCRIPTION
A fix in an algorithm that chooses which blueprints would be affected
by a plugin removal.  Deployments are not taken into considerations,
blueprint-plugins relationships are based on blueprint plans solely.

Also in case a plugin is used in any blueprint and hence should not be
removed, the list printed out as an error message contains valid
blueprint ids.