### PR TITLE
RD-1098 dep groups: create deployments from inputs

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/9d261e90b1f3_5_1_1_to_5_2.py
+++ b/resources/rest-service/cloudify/migrations/versions/9d261e90b1f3_5_1_1_to_5_2.py
@@ -150,8 +150,15 @@ def create_deployment_groups_table():
         ),
         sa.Column('created_at', UTCDateTime(), nullable=False),
         sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('_default_blueprint_fk', sa.Integer(), nullable=True),
+        sa.Column('default_inputs', JSONString(), nullable=True),
         sa.Column('_tenant_id', sa.Integer(), nullable=False),
         sa.Column('_creator_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['_default_blueprint_fk'], ['blueprints._storage_id'],
+            name=op.f('deployment_group__default_blueprint_fk_fkey'),
+            ondelete='SET NULL'
+        ),
         sa.ForeignKeyConstraint(
             ['_creator_id'], ['users.id'],
             name=op.f('deployment_group__creator_id_fkey'),
@@ -164,6 +171,12 @@ def create_deployment_groups_table():
         ),
         sa.PrimaryKeyConstraint(
             '_storage_id', name=op.f('deployment_group_pkey'))
+    )
+    op.create_index(
+        op.f('deployment_group__default_blueprint_fk_idx'),
+        'deployment_group',
+        ['_default_blueprint_fk'],
+        unique=False
     )
     op.create_index(
         op.f('deployment_group__creator_id_idx'),
@@ -214,6 +227,9 @@ def create_deployment_groups_table():
 
 def drop_deployment_groups_table():
     op.drop_table('deployment_group_deployments')
+    op.drop_index(
+        op.f('deployment_group__default_blueprint_fk_idx'),
+        table_name='deployment_group')
     op.drop_index(
         op.f('deployment_group_visibility_idx'), table_name='deployment_group')
     op.drop_index(

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -507,6 +507,9 @@ class DeploymentGroupsId(SecuredResource):
         request_dict = rest_utils.get_json_and_verify_params({
             'description': {'optional': True},
             'deployment_ids': {'optional': True},
+            'blueprint_id': {'optional': True},
+            'default_inputs': {'optional': True},
+            'visibility': {'optional': True},
         })
         sm = get_storage_manager()
         try:
@@ -517,7 +520,8 @@ class DeploymentGroupsId(SecuredResource):
                 description=request_dict.get('description'),
                 created_at=datetime.now()
             )
-            sm.put(group)
+        self._set_group_attributes(sm, group, request_dict)
+        sm.put(group)
 
         self._set_group_deployments(
             sm, group, request_dict.get('deployment_ids'))
@@ -525,6 +529,20 @@ class DeploymentGroupsId(SecuredResource):
             models.DeploymentGroup,
             group_id
         )
+
+    def _set_group_attributes(self, sm, group, request_dict):
+        if request_dict.get('visibility') is not None:
+            group.visibility = request_dict['visibility']
+
+        if request_dict.get('default_inputs') is not None:
+            group.default_inputs = request_dict['default_inputs']
+
+        if request_dict.get('description') is not None:
+            group.description = request_dict['description']
+
+        if request_dict.get('blueprint_id'):
+            group.default_blueprint = sm.get(
+                models.Blueprint, request_dict['blueprint_id'])
 
     def _set_group_deployments(self, sm, group, deployment_ids=None):
         if deployment_ids is not None:

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -387,6 +387,16 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
 
 class DeploymentGroup(CreatedAtMixin, SQLResourceBase):
     description = db.Column(db.Text)
+    default_inputs = db.Column(JSONString)
+    _default_blueprint_fk = foreign_key(
+        Blueprint._storage_id,
+        ondelete='SET NULL',
+        nullable=True)
+
+    @declared_attr
+    def default_blueprint(cls):
+        return one_to_many_relationship(
+            cls, Blueprint, cls._default_blueprint_fk)
 
     @declared_attr
     def deployments(cls):

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -106,3 +106,36 @@ class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
                 visibility='invalid visibility'
             )
         assert cm.exception.status_code == 409
+
+    def test_create_deployment(self):
+        self.put_blueprint()
+        self.client.deployment_groups.put(
+            'group1',
+            blueprint_id='blueprint',
+            inputs=[{}]
+        )
+        group = self.sm.get(models.DeploymentGroup, 'group1')
+        assert len(group.deployments) == 1
+        dep = group.deployments[0]
+        assert dep.blueprint.id == 'blueprint'
+        assert dep.id == 'group1-1'
+
+    def test_add_deployments(self):
+        self.put_blueprint()
+        self.client.deployments.create('blueprint', 'dep1')
+        group = self.client.deployment_groups.put(
+            'group1',
+            blueprint_id='blueprint',
+            deployment_ids=['dep1']
+        )
+        assert set(group.deployment_ids) == {'dep1'}
+        group = self.client.deployment_groups.put(
+            'group1',
+            inputs=[{}]
+        )
+        assert set(group.deployment_ids) == {'dep1', 'group1-2'}
+        group = self.client.deployment_groups.put(
+            'group1',
+            inputs=[{}]
+        )
+        assert set(group.deployment_ids) == {'dep1', 'group1-2', 'group1-3'}


### PR DESCRIPTION
Given default blueprint and default inputs, create deployments 
while creating the deployment group