### PR TITLE
RD-872 Allow --force plugins update in components

### DIFF
--- a/rest-service/manager_rest/deployment_update/manager.py
+++ b/rest-service/manager_rest/deployment_update/manager.py
@@ -170,7 +170,8 @@ class DeploymentUpdateManager(object):
                                  ignore_failure=False,
                                  install_first=False,
                                  reinstall_list=None,
-                                 update_plugins=True):
+                                 update_plugins=True,
+                                 force=False):
         # Mark deployment update as committing
         dep_update.keep_old_deployment_dependencies = skip_uninstall
         dep_update.state = STATES.UPDATING
@@ -250,7 +251,8 @@ class DeploymentUpdateManager(object):
             reinstall_list=reinstall_list,
             central_plugins_to_install=central_plugins_to_install,
             central_plugins_to_uninstall=central_plugins_to_uninstall,
-            update_plugins=update_plugins
+            update_plugins=update_plugins,
+            force=force
         )
 
         # Update deployment attributes in the storage manager
@@ -416,7 +418,8 @@ class DeploymentUpdateManager(object):
                                  reinstall_list=None,
                                  central_plugins_to_install=None,
                                  central_plugins_to_uninstall=None,
-                                 update_plugins=True):
+                                 update_plugins=True,
+                                 force=False):
         """Executed the update workflow or a custom workflow
 
         :param dep_update: deployment update object
@@ -437,6 +440,8 @@ class DeploymentUpdateManager(object):
         :param central_plugins_to_uninstall: plugins to uninstall that have the
         central_deployment_agent as the executor.
         :param update_plugins: whether or not to perform plugin updates.
+        :param force: force update (i.e. even if the blueprint is used to
+        create components).
 
         :return: an Execution object.
         """
@@ -508,7 +513,8 @@ class DeploymentUpdateManager(object):
             blueprint_id=dep_update.new_blueprint_id,
             parameters=parameters,
             allow_custom_parameters=True,
-            allow_overlapping_running_wf=True
+            allow_overlapping_running_wf=True,
+            force=force,
         )
 
     def finalize_commit(self, deployment_update_id):

--- a/rest-service/manager_rest/plugins_update/constants.py
+++ b/rest-service/manager_rest/plugins_update/constants.py
@@ -44,6 +44,7 @@ ALL_TO_LATEST = 'all_to_latest'
 TO_MINOR = 'to_minor'
 ALL_TO_MINOR = 'all_to_minor'
 MAPPING = 'mapping'
+FORCE = 'force'
 
 UPDATES = 'updates'
 PLUGIN_NAME = 'plugin_name'

--- a/rest-service/manager_rest/plugins_update/manager.py
+++ b/rest-service/manager_rest/plugins_update/manager.py
@@ -87,12 +87,12 @@ class PluginsUpdateManager(object):
         temp_blueprint.is_hidden = True
         return self.sm.update(temp_blueprint)
 
-    def _stage_plugin_update(self, blueprint):
+    def _stage_plugin_update(self, blueprint, forced):
         update_id = str(uuid.uuid4())
         plugins_update = models.PluginsUpdate(
             id=update_id,
             created_at=utils.get_formatted_timestamp(),
-            forced=False)
+            forced=forced)
         plugins_update.set_blueprint(blueprint)
         return self.sm.put(plugins_update)
 
@@ -112,7 +112,8 @@ class PluginsUpdateManager(object):
 
         changes_required = _did_plugins_to_install_change(temp_plan,
                                                           blueprint.plan)
-        plugins_update = self._stage_plugin_update(blueprint)
+        plugins_update = self._stage_plugin_update(blueprint,
+                                                   filters.get('force', False))
         if changes_required:
             plugins_update.deployments_to_update = [
                 dep.id for dep in self._get_deployments_to_update(blueprint_id)

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -320,7 +320,8 @@ class ResourceManager(object):
             execution_parameters={
                 'update_id': plugins_update.id,
                 'deployments_to_update': plugins_update.deployments_to_update,
-                'temp_blueprint_id': plugins_update.temp_blueprint_id
+                'temp_blueprint_id': plugins_update.temp_blueprint_id,
+                'force': plugins_update.forced,
             },
             verify_no_executions=False,
             fake_execution=no_changes_required)

--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -82,8 +82,8 @@ class DeploymentUpdate(SecuredResource):
         blueprint id.
         """
         manager, skip_install, skip_uninstall, skip_reinstall, workflow_id, \
-            ignore_failure, install_first, preview, \
-            update_plugins, runtime_eval = self._parse_args(id, request.json)
+            ignore_failure, install_first, preview, update_plugins, \
+            runtime_eval, force = self._parse_args(id, request.json)
         blueprint, inputs, reinstall_list = \
             self._get_and_validate_blueprint_and_inputs(id, request.json)
         blueprint_dir_abs = _get_plugin_update_blueprint_abs_path(
@@ -107,13 +107,14 @@ class DeploymentUpdate(SecuredResource):
                                                 ignore_failure,
                                                 install_first,
                                                 reinstall_list,
-                                                update_plugins=update_plugins)
+                                                update_plugins=update_plugins,
+                                                force=force)
 
     def _commit(self, deployment_id):
         request_json = request.args
         manager, skip_install, skip_uninstall, _, workflow_id, \
             ignore_failure, install_first, _, update_plugins, \
-            runtime_eval, = self._parse_args(
+            runtime_eval, force = self._parse_args(
                 deployment_id, request_json, using_post_request=True)
         deployment_update, _ = \
             UploadedBlueprintsDeploymentUpdateManager(). \
@@ -126,7 +127,8 @@ class DeploymentUpdate(SecuredResource):
                                                 workflow_id,
                                                 ignore_failure,
                                                 install_first,
-                                                update_plugins=update_plugins)
+                                                update_plugins=update_plugins,
+                                                force=force)
 
     @staticmethod
     def _get_and_validate_blueprint_and_inputs(deployment_id, request_json):
@@ -180,6 +182,10 @@ class DeploymentUpdate(SecuredResource):
             'runtime_only_evaluation',
             request_json.get('runtime_only_evaluation', False)
         )
+        force = verify_and_convert_bool(
+            'force',
+            request_json.get('force', False)
+        )
         manager = get_deployment_updates_manager(preview)
         manager.validate_no_active_updates_per_deployment(deployment_id)
         return (manager,
@@ -191,7 +197,8 @@ class DeploymentUpdate(SecuredResource):
                 install_first,
                 preview,
                 update_plugins,
-                runtime_only_evaluation)
+                runtime_only_evaluation,
+                force)
 
 
 class DeploymentUpdateId(SecuredResource):

--- a/rest-service/manager_rest/rest/resources_v3_1/plugins.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/plugins.py
@@ -31,7 +31,8 @@ from manager_rest.plugins_update.constants import (PLUGIN_NAMES,
                                                    ALL_TO_LATEST,
                                                    TO_MINOR,
                                                    ALL_TO_MINOR,
-                                                   MAPPING)
+                                                   MAPPING,
+                                                   FORCE)
 from manager_rest.plugins_update.manager import get_plugins_updates_manager
 from manager_rest.rest import (resources_v2,
                                resources_v2_1,
@@ -112,6 +113,7 @@ class PluginsUpdate(SecuredResource):
                 ALL_TO_MINOR: {'type': bool, 'optional': True},
                 TO_MINOR: {'type': list, 'optional': True},
                 MAPPING: {'type': dict, 'optional': True},
+                FORCE: {'type': bool, 'optional': True}
             })
         except BadRequest:
             filters = {}

--- a/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
@@ -142,7 +142,8 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
             execution.parameters,
             {'update_id': plugins_update.id,
              'deployments_to_update': ['d1', 'd2'],
-             'temp_blueprint_id': plugins_update.temp_blueprint_id})
+             'temp_blueprint_id': plugins_update.temp_blueprint_id,
+             'force': False})
 
     def test_raises_while_plugins_updates_are_active(self):
         self.put_blueprint(blueprint_id='hello_world')

--- a/workflows/cloudify_system_workflows/plugins.py
+++ b/workflows/cloudify_system_workflows/plugins.py
@@ -54,7 +54,8 @@ def _operate_on_plugin(ctx, plugin, action):
 
 
 @workflow(system_wide=True)
-def update(ctx, update_id, temp_blueprint_id, deployments_to_update, **_):
+def update(ctx, update_id, temp_blueprint_id, deployments_to_update, force,
+           **_):
     """Execute deployment update for all the given deployments_to_update.
 
     :param update_id: plugins update ID.
@@ -62,6 +63,8 @@ def update(ctx, update_id, temp_blueprint_id, deployments_to_update, **_):
     this workflow only.
     :param deployments_to_update: deployments to perform the update on, using
     the temp blueprint ID provided.
+    :param force: force update (i.e. even if the blueprint is used to create
+    components).
     """
 
     def get_wait_for_execution_message(execution_id):
@@ -77,7 +80,8 @@ def update(ctx, update_id, temp_blueprint_id, deployments_to_update, **_):
                                             blueprint_id=temp_blueprint_id,
                                             skip_install=True,
                                             skip_uninstall=True,
-                                            skip_reinstall=True) \
+                                            skip_reinstall=True,
+                                            force=force) \
             .execution_id
 
         wait_for(client.executions.get,

--- a/workflows/cloudify_system_workflows/tests/test_plugins.py
+++ b/workflows/cloudify_system_workflows/tests/test_plugins.py
@@ -109,12 +109,13 @@ class TestPluginsUpdate(unittest.TestCase):
                     "Deployment update of deployment {0} with execution ID {0}"
                     " failed, stopped this plugins update "
                     "\\(id='my_update_id'\\)\\.".format(failed_execution_id)):
-                update_func(MagicMock(), 'my_update_id', None, dep_ids)
+                update_func(MagicMock(), 'my_update_id', None, dep_ids, False)
             should_call_these = [call(deployment_id=i,
                                       blueprint_id=None,
                                       skip_install=True,
                                       skip_uninstall=True,
-                                      skip_reinstall=True)
+                                      skip_reinstall=True,
+                                      force=False)
                                  for i in range(failed_execution_id)]
             self.deployment_update_mock.assert_has_calls(should_call_these)
 
@@ -122,7 +123,8 @@ class TestPluginsUpdate(unittest.TestCase):
                                           blueprint_id=None,
                                           skip_install=True,
                                           skip_uninstall=True,
-                                          skip_reinstall=True)
+                                          skip_reinstall=True,
+                                          force=False)
                                      for i in range(
                     failed_execution_id + 1, len(dep_ids))]
             for _call in self.deployment_update_mock.mock_calls:
@@ -146,12 +148,13 @@ class TestPluginsUpdate(unittest.TestCase):
             = finalize_update_mock
         self.mock_rest_client.executions.get \
             .return_value = PropertyMock(status=ExecutionState.TERMINATED)
-        update_func(MagicMock(), '12345678', None, dep_ids)
+        update_func(MagicMock(), '12345678', None, dep_ids, False)
         should_call_these = [call(deployment_id=i,
                                   blueprint_id=None,
                                   skip_install=True,
                                   skip_uninstall=True,
-                                  skip_reinstall=True)
+                                  skip_reinstall=True,
+                                  force=False)
                              for i in range(len(dep_ids))]
         self.deployment_update_mock.assert_has_calls(should_call_these)
         finalize_update_mock.assert_called_with('12345678')


### PR DESCRIPTION
The `force` parameter is used to force plugin update on blueprints used (also) as components.