### PR TITLE
RD-1121 Deployment list: filter by group id

### DIFF
--- a/rest-service/manager_rest/rest/resources_v2/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v2/deployments.py
@@ -62,7 +62,7 @@ class Deployments(resources_v1.Deployments):
         )
         if '_group_id' in request.args:
             filters['deployment_group'] = lambda col: col.any(
-                models.DeploymentGroup.id == request.args.get('_group_id')
+                models.DeploymentGroup.id == request.args['_group_id']
             )
         result = get_storage_manager().list(
             models.Deployment,

--- a/rest-service/manager_rest/rest/resources_v2/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v2/deployments.py
@@ -60,6 +60,10 @@ class Deployments(resources_v1.Deployments):
             '_get_all_results',
             request.args.get('_get_all_results', False)
         )
+        if '_group_id' in request.args:
+            filters['deployment_group'] = lambda col: col.any(
+                models.DeploymentGroup.id == request.args.get('_group_id')
+            )
         result = get_storage_manager().list(
             models.Deployment,
             include=_include,

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -33,7 +33,7 @@ from manager_rest.constants import LABEL_LEN
 from manager_rest import utils, manager_exceptions
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
-from manager_rest.storage import models, get_storage_manager
+from manager_rest.storage import models, get_storage_manager, db
 from manager_rest.manager_exceptions import (BadParametersError,
                                              IllegalActionError)
 from manager_rest.resource_manager import get_resource_manager
@@ -564,6 +564,7 @@ class DeploymentGroupsId(SecuredResource):
             )
             group.deployments.append(dep)
             deployment_count += 1
+        db.session.commit()
 
     @authorize('deployment_group_delete')
     def delete(self, group_id):

--- a/rest-service/manager_rest/rest/resources_v3_1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/executions.py
@@ -12,7 +12,8 @@
 #  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
-#
+
+import uuid
 from datetime import datetime
 
 from flask import request
@@ -181,6 +182,7 @@ class ExecutionGroups(SecuredResource):
         dep_group = sm.get(models.DeploymentGroup,
                            request_dict['deployment_group_id'])
         group = models.ExecutionGroup(
+            id=str(uuid.uuid4()),
             deployment_group=dep_group,
             workflow_id=workflow_id,
             created_at=datetime.now(),

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -406,12 +406,19 @@ class DeploymentGroup(CreatedAtMixin, SQLResourceBase):
     def deployment_ids(self):
         return [dep.id for dep in self.deployments]
 
+    @property
+    def default_blueprint_id(self):
+        if not self.default_blueprint:
+            return None
+        return self.default_blueprint.id
+
     @classproperty
     def response_fields(cls):
         fields = super(DeploymentGroup, cls).response_fields
         fields['deployment_ids'] = flask_fields.List(
             flask_fields.String()
         )
+        fields['default_blueprint_id'] = flask_fields.String()
         return fields
 
 
@@ -561,6 +568,8 @@ class ExecutionGroup(CreatedAtMixin, SQLResourceBase):
         return one_to_many_relationship(
             cls, DeploymentGroup, cls._deployment_group_fk)
 
+    deployment_group_id = association_proxy('deployment_group', 'id')
+
     @declared_attr
     def executions(cls):
         return many_to_many_relationship(cls, Execution)
@@ -575,6 +584,7 @@ class ExecutionGroup(CreatedAtMixin, SQLResourceBase):
         fields['execution_ids'] = flask_fields.List(
             flask_fields.String()
         )
+        fields['deployment_group_id'] = flask_fields.String()
         return fields
 
 


### PR DESCRIPTION
It must be unfortunately separate because `@create_filters` has
no way to figure out the sql necessary for this.

This is the way to filter by a many-to-many. With the any.