### PR TITLE
marshal_with: don't hide ORM exceptions

### DIFF
--- a/rest-service/manager_rest/rest/rest_decorators.py
+++ b/rest-service/manager_rest/rest/rest_decorators.py
@@ -95,14 +95,10 @@ class marshal_with(object):
         :param response_class: response class to marshal result with.
          class must have a "resource_fields" class variable
         """
-        if hasattr(response_class, 'response_fields'):
+        try:
             self._fields = response_class.response_fields
-        elif hasattr(response_class, 'resource_fields'):
+        except AttributeError:
             self._fields = response_class.resource_fields
-        else:
-            raise RuntimeError(
-                'Response class {0} does not contain a "resource_fields" '
-                'class variable'.format(type(response_class)))
 
         self.response_class = response_class
 


### PR DESCRIPTION
hasattr eats the underlying exception if one is thrown when
computing .response_fields
This way doesn't.

I do realize we're now not going to throw the `RuntimeError`, but
instead we'll just throw an AttributeError as is more proper anyway