### PR TITLE
RD-1179 Fix detach agent installation failed tests

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_plugin_workdir.py
+++ b/tests/integration_tests/tests/agent_tests/test_plugin_workdir.py
@@ -42,14 +42,9 @@ class PluginWorkdirTest(AgentTestCase):
         host_instance_id = self.client.node_instances.list(
             deployment_id=deployment.id,
             node_id='host')[0].id
-        # Get the version of manager
-        version = self.client.manager.get_version()['version']
-        host_file = os.path.join(
-            '/opt/cloudify-agent-{0}'.format(version),
-            host_instance_id,
-            'work/plugins/testmockoperations',
-            filename
-        )
+        host_file = os.path.join('/etc/cloudify', host_instance_id,
+                                 'work/plugins/testmockoperations',
+                                 filename)
         out = self.read_manager_file(central_file)
         self.assertEqual(central_content, out)
         out = self.read_host_file(host_file,

--- a/tests/integration_tests/tests/agent_tests/test_plugins.py
+++ b/tests/integration_tests/tests/agent_tests/test_plugins.py
@@ -43,11 +43,8 @@ class PluginInstallationTest(AgentTestCase):
         )
 
     def _agent_plugin_dir(self, agent_id, plugin):
-        agent_base_dir = '/opt/cloudify-agent-{0}'.format(
-            self.client.manager.get_version()['version']
-        )
         return os.path.join(
-            agent_base_dir,
+            self.execute_on_manager(['bash', '-c', 'echo ~cfyuser']).strip(),
             agent_id,
             'env', 'plugins',
             plugin.tenant_name,

--- a/tests/integration_tests_plugins/dockercompute/plugin.yaml
+++ b/tests/integration_tests_plugins/dockercompute/plugin.yaml
@@ -16,4 +16,5 @@ node_types:
     interfaces:
       cloudify.interfaces.lifecycle:
         start: dockercompute.dockercompute.operations.start
+        prestop: dockercompute.dockercompute.operations.store_envdir
         delete: dockercompute.dockercompute.operations.delete


### PR DESCRIPTION
This PR added in order to fix integration tests that trying to install agent using plugin type with detach service
`cfyuser's homedir` was moved over to `/etc` because writing to `/opt` would require root access which we wanted to avoid.

