### PR TITLE
CBYL-1094 Move files between filesystems with ease

### DIFF
--- a/mgmtworker/mgmtworker/monitoring.py
+++ b/mgmtworker/mgmtworker/monitoring.py
@@ -1,5 +1,6 @@
-from os import kill, rename, sep
+from os import kill, sep
 from os.path import join
+from shutil import move
 from signal import SIGHUP
 from subprocess import check_output
 
@@ -155,8 +156,7 @@ def _deploy_prometheus_missing_alerts(destination, service_name, hosts):
     with NamedTemporaryFile(mode='w+t', delete=False) as f:
         f.write(template)
         tmp_file_name = f.name
-    rename(tmp_file_name,
-           join(PROMETHEUS_ALERTS_DIR, destination))
+    move(tmp_file_name, join(PROMETHEUS_ALERTS_DIR, destination))
     return destination
 
 


### PR DESCRIPTION
When deploying an alert about missing metrics for Prometheus a os.rename
function was used.  That sometimes resulted in an error in case both
source and destination were not on the same filesystem (OSError 18:
Invalid cross-device link).  Using shutil.move instaed of os.rename
fixes that.