### PR TITLE
RD-1191 Adding filters ratio

### DIFF
--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -656,8 +656,7 @@ class SQLStorageManager(object):
                                                       pagination,
                                                       get_all_results)
         pagination = {'total': total, 'size': size, 'offset': offset}
-        filtered = ({'filtered': total, 'total': self.count(model_class)}
-                    if filter_rules else {})
+        filtered = (self.count(model_class) - total) if filter_rules else None
 
         current_app.logger.debug('Returning: {0}'.format(results))
         return ListResult(items=results, metadata={'pagination': pagination,

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -656,9 +656,12 @@ class SQLStorageManager(object):
                                                       pagination,
                                                       get_all_results)
         pagination = {'total': total, 'size': size, 'offset': offset}
+        filtered = ({'filtered': total, 'total': self.count(model_class)}
+                    if filter_rules else {})
 
         current_app.logger.debug('Returning: {0}'.format(results))
-        return ListResult(items=results, metadata={'pagination': pagination})
+        return ListResult(items=results, metadata={'pagination': pagination,
+                                                   'filtered': filtered})
 
     def summarize(self, target_field, sub_field, model_class,
                   pagination, get_all_results, all_tenants, filters):

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -995,7 +995,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
             filter_rules={'_filter_rules': ['env=aws', 'arch=k8s']})
         self.assertEqual(len(deployments), 1)
         self.assertEqual(deployments[0], dep1)
-        self._assert_metadata_filtered(deployments, 1, 2)
+        self._assert_metadata_filtered(deployments, 1)
 
     @attr(client_min_version=3.1,
           client_max_version=base_test.LATEST_API_VERSION)
@@ -1007,7 +1007,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
             filter_rules={'_filter_id': self.FILTER_ID})
         self.assertEqual(len(deployments), 1)
         self.assertEqual(deployments[0], dep2)
-        self._assert_metadata_filtered(deployments, 1, 2)
+        self._assert_metadata_filtered(deployments, 1)
 
     @attr(client_min_version=3.1,
           client_max_version=base_test.LATEST_API_VERSION)
@@ -1017,7 +1017,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
         deployments = self.client.deployments.list(
             filter_rules={'_filter_rules': ['aRcH=k8S']})
         self.assertEqual(len(deployments), 2)
-        self._assert_metadata_filtered(deployments, 2, 2)
+        self._assert_metadata_filtered(deployments, 0)
 
     def _assert_deployment_labels(self, deployment_labels, compared_labels):
         simplified_labels = set()
@@ -1032,8 +1032,6 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
 
         self.assertEqual(simplified_labels, compared_labels_set)
 
-    def _assert_metadata_filtered(self, deployments_list, filtered_cnt,
-                                  total_cnt):
-        filtered = deployments_list.metadata['filtered']
-        self.assertEqual(filtered['filtered'], filtered_cnt)
-        self.assertEqual(filtered['total'], total_cnt)
+    def _assert_metadata_filtered(self, deployments_list, filtered_cnt):
+        self.assertEqual(
+            deployments_list.metadata.get('filtered'), filtered_cnt)

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -995,6 +995,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
             filter_rules={'_filter_rules': ['env=aws', 'arch=k8s']})
         self.assertEqual(len(deployments), 1)
         self.assertEqual(deployments[0], dep1)
+        self._assert_metadata_filtered(deployments, 1, 2)
 
     @attr(client_min_version=3.1,
           client_max_version=base_test.LATEST_API_VERSION)
@@ -1006,6 +1007,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
             filter_rules={'_filter_id': self.FILTER_ID})
         self.assertEqual(len(deployments), 1)
         self.assertEqual(deployments[0], dep2)
+        self._assert_metadata_filtered(deployments, 1, 2)
 
     @attr(client_min_version=3.1,
           client_max_version=base_test.LATEST_API_VERSION)
@@ -1015,6 +1017,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
         deployments = self.client.deployments.list(
             filter_rules={'_filter_rules': ['aRcH=k8S']})
         self.assertEqual(len(deployments), 2)
+        self._assert_metadata_filtered(deployments, 2, 2)
 
     def _assert_deployment_labels(self, deployment_labels, compared_labels):
         simplified_labels = set()
@@ -1028,3 +1031,9 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
             compared_labels_set.add((key, value))
 
         self.assertEqual(simplified_labels, compared_labels_set)
+
+    def _assert_metadata_filtered(self, deployments_list, filtered_cnt,
+                                  total_cnt):
+        filtered = deployments_list.metadata['filtered']
+        self.assertEqual(filtered['filtered'], filtered_cnt)
+        self.assertEqual(filtered['total'], total_cnt)


### PR DESCRIPTION
As specified in the design doc, when listing deployments using filters, we need to specify how many deployments were filtered out of the total number of deployments. Auxiliary PRs:
https://github.com/cloudify-cosmo/cloudify-cli/pull/1194