### PR TITLE
RD-796 Adding deployments labels to include

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v1/deployments.py
@@ -63,7 +63,7 @@ class DeploymentsId(SecuredResource):
         """
         Get deployment by id
         """
-        _include = None if 'labels' in _include else _include
+        _include = None if (_include and 'labels' in _include) else _include
         return get_storage_manager().get(
             models.Deployment,
             deployment_id,

--- a/rest-service/manager_rest/rest/resources_v1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v1/deployments.py
@@ -63,6 +63,7 @@ class DeploymentsId(SecuredResource):
         """
         Get deployment by id
         """
+        _include = None if 'labels' in _include else _include
         return get_storage_manager().get(
             models.Deployment,
             deployment_id,

--- a/rest-service/manager_rest/rest/resources_v2/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v2/deployments.py
@@ -64,6 +64,7 @@ class Deployments(resources_v1.Deployments):
             filters['deployment_group'] = lambda col: col.any(
                 models.DeploymentGroup.id == request.args['_group_id']
             )
+        _include = None if 'labels' in _include else _include
         result = get_storage_manager().list(
             models.Deployment,
             include=_include,

--- a/rest-service/manager_rest/rest/resources_v2/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v2/deployments.py
@@ -64,7 +64,7 @@ class Deployments(resources_v1.Deployments):
             filters['deployment_group'] = lambda col: col.any(
                 models.DeploymentGroup.id == request.args['_group_id']
             )
-        _include = None if 'labels' in _include else _include
+        _include = None if (_include and 'labels' in _include) else _include
         result = get_storage_manager().list(
             models.Deployment,
             include=_include,


### PR DESCRIPTION
labels are defined in the Deployment table as a backref from the DeploymentLabel table and not as a column. So, putting labels in the _include parameter doesn't work. The solution for this is to get the whole Deployment element and let the _include parameter refine the returned results, according to the values specified in it.