### PR TITLE
RD-1232 Parameters propagation in components fix

### DIFF
--- a/cloudify_types/cloudify_types/component/component.py
+++ b/cloudify_types/cloudify_types/component/component.py
@@ -467,16 +467,18 @@ class Component(object):
 
         execution_args = self.config.get('executions_start_args', {})
 
+        request_args = dict(
+            deployment_id=self.deployment_id,
+            workflow_id=self.workflow_id,
+            **execution_args
+        )
+        if self.workflow_id == ctx.workflow_id:
+            request_args.update(dict(parameters=ctx.workflow_parameters))
+
         ctx.logger.info('Starting execution for "{0}" deployment'.format(
             self.deployment_id))
         execution = self._http_client_wrapper(
-            'executions', 'start',
-            dict(
-                 deployment_id=self.deployment_id,
-                 workflow_id=self.workflow_id,
-                 parameters=ctx.workflow_parameters,
-                 **execution_args
-             ))
+            'executions', 'start', request_args)
 
         ctx.logger.debug('Execution start response: "{0}".'.format(execution))
 


### PR DESCRIPTION
Propagate workflow parameters across (sub)components only in case the
original workflow_id matches the workflow_id executed on a
(sub)component.