### PR TITLE
Fix typo in exec-scheduler log path

### DIFF
--- a/execution-scheduler/execution_scheduler/main.py
+++ b/execution-scheduler/execution_scheduler/main.py
@@ -21,7 +21,7 @@ DEFAULT_INTERVAL = 60
 SCHEDULER_LOCK_BASE = 10000
 # so we won't conflict with usage collector, which uses lock numbers 1 and 2
 
-DEFAULT_LOG_PATH = '/var/log/cloudify/execution_scheduler/scheduler.log'
+DEFAULT_LOG_PATH = '/var/log/cloudify/execution-scheduler/scheduler.log'
 CONFIG_PATH = '/opt/manager/cloudify-rest.conf'
 REST_SECURITY_PATH = '/opt/manager/rest-security.conf'
 


### PR DESCRIPTION
It is supposed to be `-`, not `_`, eg. https://github.com/cloudify-cosmo/cloudify-manager/blob/a5b68e05602e3b15aba688632bfff66a8cf2cbca/packaging/cloudify-rest-service.spec#L149