### PR TITLE
Scheduler: use storage-manager filters correctly

### DIFF
--- a/execution-scheduler/execution_scheduler/main.py
+++ b/execution-scheduler/execution_scheduler/main.py
@@ -44,7 +44,10 @@ def check_schedules():
     sm = get_storage_manager()
     schedules = sm.full_access_list(
         models.ExecutionSchedule,
-        filters={'next_occurrence': lambda x: x < datetime.utcnow()}
+        filters={
+            models.ExecutionSchedule.next_occurrence:
+            lambda x: x < datetime.utcnow()
+        }
     )
     for schedule in schedules:
         lock_num = SCHEDULER_LOCK_BASE + schedule._storage_id

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -66,7 +66,8 @@ sources = [
     ('cloudify-manager/rest-service/manager_rest', ['/opt/manager/env']),
     ('cloudify-manager/workflows/cloudify_system_workflows', ['/opt/mgmtworker/env']),  # NOQA
     ('cloudify-manager/cloudify_types/cloudify_types', ['/opt/mgmtworker/env']),  # NOQA
-    ('cloudify-manager-install/cfy_manager', ['/opt/cloudify/cfy_manager'])
+    ('cloudify-manager-install/cfy_manager', ['/opt/cloudify/cfy_manager']),
+    ('cloudify-manager/execution-scheduler/execution_scheduler', ['/opt/manager/env']),  # NOQA
 ]
 
 # like sources, but just static files, not in a venv. Provide target


### PR DESCRIPTION
This takes a column, not a string