### PR TITLE
RD-1337 Don't complain about lost stream in pytest

### DIFF
--- a/tests/integration_tests/framework/amqp_events_printer.py
+++ b/tests/integration_tests/framework/amqp_events_printer.py
@@ -17,7 +17,7 @@ import os
 import json
 import time
 
-from pika.exceptions import ConnectionClosed
+from pika.exceptions import ConnectionClosed, StreamLostError
 
 import cloudify.event
 import cloudify.logs
@@ -90,6 +90,6 @@ def print_events(container_id):
         try:
             connection = utils.create_pika_connection(container_id)
             _consume_events(connection)
-        except ConnectionClosed as e:
+        except (ConnectionClosed, StreamLostError) as e:
             logger.debug('print_events got: %s', e)
             time.sleep(3)


### PR DESCRIPTION
During integrations_tests we (sometimes) kill the container after the
test, thus events printer gets connection reset.  This patch prevents
unhandled exceptions from being thrown in that case.