### PR TITLE
Make maintenance_mode.requested_by a cascade=SETNULL

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/9d261e90b1f3_5_1_1_to_5_2.py
+++ b/resources/rest-service/cloudify/migrations/versions/9d261e90b1f3_5_1_1_to_5_2.py
@@ -59,9 +59,11 @@ def upgrade():
     fix_previous_versions()
     create_execution_groups_table()
     add_new_config_entries()
+    set_null_on_maintenance_mode_cascade()
 
 
 def downgrade():
+    revert_set_null_on_maintenance_mode_cascade()
     remove_new_config_entries()
     drop_execution_groups_table()
     revert_fixes()
@@ -562,3 +564,40 @@ def drop_execution_groups_table():
     op.drop_index(
         op.f('execution_group__creator_id_idx'), table_name='execution_groups')
     op.drop_table('execution_groups')
+
+
+def set_null_on_maintenance_mode_cascade():
+    """Make maintenance_mode.requested_by a cascade=SET NULL"""
+    op.drop_constraint(
+        'maintenance_mode__requested_by_fkey',
+        'maintenance_mode',
+        type_='foreignkey'
+    )
+    op.create_foreign_key(
+        op.f('maintenance_mode__requested_by_fkey'),
+        'maintenance_mode',
+        'users',
+        ['_requested_by'],
+        ['id'],
+        ondelete='SET NULL'
+    )
+
+
+def revert_set_null_on_maintenance_mode_cascade():
+    """Make maintenance_mode.requested_by a cascade=DELETE
+
+    This reverts set_null_on_maintenance_mode_cascade
+    """
+    op.drop_constraint(
+        op.f('maintenance_mode__requested_by_fkey'),
+        'maintenance_mode',
+        type_='foreignkey'
+    )
+    op.create_foreign_key(
+        'maintenance_mode__requested_by_fkey',
+        'maintenance_mode',
+        'users',
+        ['_requested_by'],
+        ['id'],
+        ondelete='CASCADE'
+    )

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -735,7 +735,7 @@ class MaintenanceMode(SQLModelBase):
 
     @declared_attr
     def _requested_by(cls):
-        return foreign_key(User.id, nullable=True)
+        return foreign_key(User.id, nullable=True, ondelete='SET NULL')
 
     @declared_attr
     def requested_by(cls):


### PR DESCRIPTION
Might as well do that instead, no reason to cascade=DELETE.
This is more predictable, dropping a user doesn't silently sometimes
exit maintenance mode then