### PR TITLE
Wait just a little bit longer for service status

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_manager_status.py
+++ b/tests/integration_tests/tests/agentless_tests/test_manager_status.py
@@ -110,7 +110,7 @@ class TestManagerStatus(AgentlessTestCase):
                 SERVICES[service]
             )
         )
-        time.sleep(5)
+        time.sleep(10)
         status = self.client.manager.get_status()
         self.assertEqual(status['status'], ServiceStatus.HEALTHY)
         self.assertEqual(status['services'][service]['status'],

--- a/tests/integration_tests/tests/agentless_tests/test_manager_status.py
+++ b/tests/integration_tests/tests/agentless_tests/test_manager_status.py
@@ -110,8 +110,20 @@ class TestManagerStatus(AgentlessTestCase):
                 SERVICES[service]
             )
         )
-        time.sleep(10)
-        status = self.client.manager.get_status()
+
+        countdown, status = 12, {}
+        while not _service_is_started(service, status) and countdown > 0:
+            time.sleep(1)
+            status = self.client.manager.get_status()
+            countdown -= 1
+
         self.assertEqual(status['status'], ServiceStatus.HEALTHY)
         self.assertEqual(status['services'][service]['status'],
                          NodeServiceStatus.ACTIVE)
+
+
+def _service_is_started(service, status):
+    return (
+        status.get('status') == ServiceStatus.HEALTHY and
+        status['services'][service]['status'] == NodeServiceStatus.ACTIVE
+    )


### PR DESCRIPTION
We have experienced some flakyness in the test.  In case a machine it
was running on was under a load, 5 seconds sleep was not enough.