### PR TITLE
RD-1313 Revert labels length limit

### DIFF
--- a/rest-service/manager_rest/constants.py
+++ b/rest-service/manager_rest/constants.py
@@ -74,8 +74,6 @@ MODELS_TO_PERMISSIONS = {
 FORBIDDEN_METHODS = ['POST', 'PATCH', 'PUT']
 SANITY_MODE_FILE_PATH = '/opt/manager/sanity_mode'
 
-LABEL_LEN = 56
-
 EQUAL = 'equal'
 NOT_EQUAL = 'not_equal'
 IS_NULL = 'is_null'

--- a/rest-service/manager_rest/rest/filters_utils.py
+++ b/rest-service/manager_rest/rest/filters_utils.py
@@ -2,8 +2,7 @@ import re
 
 from manager_rest import manager_exceptions
 from manager_rest.rest.rest_utils import validate_inputs
-from manager_rest.constants import (LABEL_LEN, EQUAL, NOT_EQUAL, IS_NULL,
-                                    IS_NOT_NULL)
+from manager_rest.constants import EQUAL, NOT_EQUAL, IS_NULL, IS_NOT_NULL
 
 
 class BadLabelsFilter(manager_exceptions.BadParametersError):
@@ -86,11 +85,9 @@ def _parse_labels_filter(labels_filter, sign):
     for value in label_values:
         try:
             parsed_value = value.strip()
-            validate_inputs(
-                {'filter key': label_key}, len_input_value=LABEL_LEN)
-            validate_inputs(
-                {'filter value': parsed_value}, len_input_value=LABEL_LEN,
-                err_prefix=value_msg_prefix)
+            validate_inputs({'filter key': label_key})
+            validate_inputs({'filter value': parsed_value},
+                            err_prefix=value_msg_prefix)
         except manager_exceptions.BadParametersError as e:
             err_msg = 'The filter rule {0} is invalid. '.format(labels_filter)
             raise manager_exceptions.BadParametersError(err_msg + str(e))

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -29,7 +29,6 @@ from cloudify.deployment_dependencies import (create_deployment_dependency,
                                               SOURCE_DEPLOYMENT,
                                               TARGET_DEPLOYMENT)
 
-from manager_rest.constants import LABEL_LEN
 from manager_rest import utils, manager_exceptions
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
@@ -162,8 +161,7 @@ def _get_labels(request_dict):
         if ((not isinstance(key, text_type)) or
                 (not isinstance(value, text_type))):
             _raise_bad_labels_list()
-        rest_utils.validate_inputs({'key': key, 'value': value},
-                                   len_input_value=LABEL_LEN)
+        rest_utils.validate_inputs({'key': key, 'value': value})
         labels_list.append((key.lower(), value.lower()))
 
     _test_unique_labels(labels_list)

--- a/rest-service/manager_rest/rest/resources_v3_1/labels.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/labels.py
@@ -1,6 +1,5 @@
 from flask import request
 
-from manager_rest.constants import LABEL_LEN
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
 from manager_rest.storage import models, get_storage_manager
@@ -41,8 +40,7 @@ class DeploymentsLabelsKey(SecuredResource):
     @rest_decorators.search('value')
     def get(self, key, pagination=None, search=None):
         """Get all deployments' labels' values for the specified key."""
-        rest_utils.validate_inputs(
-            {'label_key': key}, len_input_value=LABEL_LEN)
+        rest_utils.validate_inputs({'label_key': key})
         get_all_results = rest_utils.verify_and_convert_bool(
             '_get_all_results',
             request.args.get('_get_all_results', False)

--- a/rest-service/manager_rest/test/endpoints/test_filters.py
+++ b/rest-service/manager_rest/test/endpoints/test_filters.py
@@ -2,8 +2,7 @@ from cloudify.models_states import VisibilityState
 from cloudify_rest_client.exceptions import CloudifyClientError
 
 from manager_rest.test import base_test
-from manager_rest.constants import (LABEL_LEN, EQUAL, NOT_EQUAL, IS_NULL,
-                                    IS_NOT_NULL)
+from manager_rest.constants import EQUAL, NOT_EQUAL, IS_NULL, IS_NOT_NULL
 from manager_rest.test.attribute import attr
 from manager_rest.storage.models_base import db
 from manager_rest.utils import get_filters_list_from_mapping
@@ -142,7 +141,6 @@ class FiltersTestCase(base_test.BaseServerTestCase):
 
     def test_filter_create_fails(self):
         err_rules = [
-            (['a={0}'.format('b'*(LABEL_LEN+1))], '.*too long.*'),
             (['a= '], '.*is empty.*'),
             (['a!=b]'], '.*illegal characters.*'),
             (['a'], '.*not in the right format.*'),


### PR DESCRIPTION
After discussing with @qooban and Ofer, we understood that labels' keys and values should not be limited to 56 characters. This PR implements it.