### PR TITLE
RD-1204 Fix schedules integration test

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_execution_schedules.py
+++ b/tests/integration_tests/tests/agentless_tests/test_execution_schedules.py
@@ -1,4 +1,3 @@
-from time import sleep
 from datetime import datetime
 
 from retrying import retry


### PR DESCRIPTION
The test logic was faulty:
1 minute wait is not actually enough to guarantee a run of the execution because, e.g
* schedule created in 12:00:01 -> next occurrence is computed to 12:01:00
* check_schedules runs in 12:00:59 and the new schedule goes ignored b/c its next occurrence has not yet come
* check_schedules runs in 12:01:59, catches the next occurrence and runs the execution

so we need to wait a maximum of 2 minutes to ensure the test passes