### PR TITLE
RD-982 Handling labels with csys prefix

### DIFF
--- a/rest-service/manager_rest/constants.py
+++ b/rest-service/manager_rest/constants.py
@@ -78,3 +78,6 @@ EQUAL = 'equal'
 NOT_EQUAL = 'not_equal'
 IS_NULL = 'is_null'
 IS_NOT_NULL = 'is_not_null'
+
+CFY_LABELS = []
+CFY_LABELS_PREFIX = 'csys-'

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -25,7 +25,9 @@ from cloudify.snapshots import SNAPSHOT_RESTORE_FLAG_FILE
 from cloudify.models_states import VisibilityState, BlueprintUploadState
 
 from manager_rest.storage import models
-from manager_rest.constants import REST_SERVICE_NAME
+from manager_rest.constants import (REST_SERVICE_NAME,
+                                    CFY_LABELS,
+                                    CFY_LABELS_PREFIX)
 from manager_rest.dsl_functions import (get_secret_method,
                                         evaluate_intrinsic_functions)
 from manager_rest import manager_exceptions, config, app_context
@@ -680,10 +682,19 @@ def get_labels_list(raw_labels_list):
                     (not isinstance(value, text_type))):
                 _raise_bad_labels_list()
             validate_inputs({'key': key, 'value': value})
+            if key.startswith(CFY_LABELS_PREFIX) and key not in CFY_LABELS:
+                _raise_labels_prefix_not_allowed()
             labels_list.append((key.lower(), value.lower()))
 
     test_unique_labels(labels_list)
     return labels_list
+
+
+def _raise_labels_prefix_not_allowed():
+    raise manager_exceptions.BadParametersError(
+        'All labels with a `{0}` prefix are reserved for internal use. '
+        'Allowed `{0}` prefixed labels are: {1}'.format(
+            CFY_LABELS_PREFIX, ', '.join(CFY_LABELS)))
 
 
 def _raise_bad_labels_list():

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -988,6 +988,19 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
 
     @attr(client_min_version=3.1,
           client_max_version=base_test.LATEST_API_VERSION)
+    def test_invalid_use_of_system_prefix_in_labels(self):
+        resource_id = 'i{0}'.format(uuid.uuid4())
+        error_msg = '400: .*reserved for internal use.*'
+        self.assertRaisesRegex(CloudifyClientError,
+                               error_msg,
+                               self.put_deployment,
+                               blueprint_file_name='blueprint.yaml',
+                               blueprint_id=resource_id,
+                               deployment_id=resource_id,
+                               labels=[{'csys-blah': 'val1'}])
+
+    @attr(client_min_version=3.1,
+          client_max_version=base_test.LATEST_API_VERSION)
     def test_list_deployments_with_filter_rules(self):
         dep1 = self.put_deployment_with_labels(self.LABELS)
         self.put_deployment_with_labels(self.LABELS_2)


### PR DESCRIPTION
Label keys with the prefix `csys-` should be reserved for internal use. I.e. the user can only assign such labels if they have an implementation. 