### PR TITLE
RD-1410 Add labels/blueprints endpoint

### DIFF
--- a/amqp-postgres/test-requirements.txt
+++ b/amqp-postgres/test-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cloudify-cosmo/cloudify-common@RD-1410-add-labels-blueprints-endpoint#egg=cloudify-common[dispatcher]==RD-1410-add-labels-blueprints-endpoint
+git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common[dispatcher]
 -e ../rest-service
 mock
 pytest

--- a/amqp-postgres/test-requirements.txt
+++ b/amqp-postgres/test-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common[dispatcher]==master
+git+https://github.com/cloudify-cosmo/cloudify-common@RD-1410-add-labels-blueprints-endpoint#egg=cloudify-common[dispatcher]==RD-1410-add-labels-blueprints-endpoint
 -e ../rest-service
 mock
 pytest

--- a/rest-service/dev-requirements.txt
+++ b/rest-service/dev-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common[dispatcher]
+git+https://github.com/cloudify-cosmo/cloudify-common@RD-1410-add-labels-blueprints-endpoint#egg=cloudify-common[dispatcher]
 
 # For dealing with the binary leftovers of psycopg2 in the 2.7.x version
 psycopg2==2.7.4 --no-binary psycopg2

--- a/rest-service/dev-requirements.txt
+++ b/rest-service/dev-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cloudify-cosmo/cloudify-common@RD-1410-add-labels-blueprints-endpoint#egg=cloudify-common[dispatcher]
+git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common[dispatcher]
 
 # For dealing with the binary leftovers of psycopg2 in the 2.7.x version
 psycopg2==2.7.4 --no-binary psycopg2

--- a/rest-service/manager_rest/rest/endpoint_mapper.py
+++ b/rest-service/manager_rest/rest/endpoint_mapper.py
@@ -140,6 +140,8 @@ def setup_resources(api):
         'DeploymentGroupsId': 'deployment-groups/<string:group_id>',
         'ExecutionGroups': 'execution-groups',
         'ExecutionGroupsId': 'execution-groups/<string:group_id>',
+        'BlueprintsLabels': 'labels/blueprints',
+        'BlueprintsLabelsKey': 'labels/blueprints/<string:key>',
     }
 
     # Set version endpoint as a non versioned endpoint

--- a/rest-service/manager_rest/rest/resources_v3_1/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/__init__.py
@@ -107,6 +107,8 @@ from .snapshots import ( # noqa
 from .labels import (                           # NOQA
     DeploymentsLabels,
     DeploymentsLabelsKey,
+    BlueprintsLabels,
+    BlueprintsLabelsKey
 )
 from .permissions import (  # NOQA
     Permissions,

--- a/rest-service/manager_rest/rest/resources_v3_1/labels.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/labels.py
@@ -7,103 +7,100 @@ from manager_rest.storage import models, get_storage_manager
 from .. import rest_decorators, rest_utils
 
 
-class _Labels(SecuredResource):
-    @staticmethod
-    def _get(resource_model, resource_labels_model, pagination, search):
-        """Get all the resource's labels' keys"""
-        get_all_results = rest_utils.verify_and_convert_bool(
-            '_get_all_results',
-            request.args.get('_get_all_results', False)
-        )
-        results = get_storage_manager().list(
-            resource_labels_model,
-            include=['key'],
-            pagination=pagination,
-            filters={'_labeled_model_fk': resource_model._storage_id},
-            get_all_results=get_all_results,
-            distinct=['key'],
-            substr_filters=search,
-            sort={'key': 'asc'}
-        )
-
-        results.items = [label.key for label in results]
-        return results
-
-
-class _LabelsKey(SecuredResource):
-    @staticmethod
-    def _get(key, resource_model, resource_labels_model, pagination, search):
-        """Get all resource's labels' values for the specified key."""
-        rest_utils.validate_inputs({'label_key': key})
-        get_all_results = rest_utils.verify_and_convert_bool(
-            '_get_all_results',
-            request.args.get('_get_all_results', False)
-        )
-        results = get_storage_manager().list(
-            resource_labels_model,
-            include=['value'],
-            pagination=pagination,
-            filters={'key': key,
-                     '_labeled_model_fk': resource_model._storage_id},
-            get_all_results=get_all_results,
-            distinct=['value'],
-            substr_filters=search,
-            sort={'value': 'asc'}
-        )
-
-        results.items = [label.value for label in results]
-        return results
-
-
-class DeploymentsLabels(_Labels):
+class DeploymentsLabels(SecuredResource):
     @authorize('labels_list')
     @rest_decorators.marshal_list_response
     @rest_decorators.paginate
     @rest_decorators.search('key')
     def get(self, pagination=None, search=None):
         """Get all deployments' labels' keys"""
-        return self._get(models.Deployment,
-                         models.DeploymentLabel,
-                         pagination,
-                         search)
+        return get_labels_keys(models.Deployment,
+                               models.DeploymentLabel,
+                               pagination,
+                               search)
 
 
-class DeploymentsLabelsKey(_LabelsKey):
+class DeploymentsLabelsKey(SecuredResource):
     @authorize('labels_list')
     @rest_decorators.marshal_list_response
     @rest_decorators.paginate
     @rest_decorators.search('value')
     def get(self, key, pagination=None, search=None):
         """Get all deployments' labels' values for the specified key."""
-        return self._get(key,
-                         models.Deployment,
-                         models.DeploymentLabel,
-                         pagination,
-                         search)
+        return get_labels_key_values(key,
+                                     models.Deployment,
+                                     models.DeploymentLabel,
+                                     pagination,
+                                     search)
 
 
-class BlueprintsLabels(_Labels):
+class BlueprintsLabels(SecuredResource):
     @authorize('labels_list')
     @rest_decorators.marshal_list_response
     @rest_decorators.paginate
     @rest_decorators.search('key')
     def get(self, pagination=None, search=None):
         """Get all blueprints' labels' keys"""
-        return self._get(models.Blueprint,
-                         models.BlueprintLabel,
-                         pagination,
-                         search)
+        return get_labels_keys(models.Blueprint,
+                               models.BlueprintLabel,
+                               pagination,
+                               search)
 
 
-class BlueprintsLabelsKey(_LabelsKey):
+class BlueprintsLabelsKey(SecuredResource):
     @authorize('labels_list')
     @rest_decorators.marshal_list_response
     @rest_decorators.paginate
     @rest_decorators.search('value')
     def get(self, key, pagination=None, search=None):
         """Get all blueprints' labels' values for the specified key."""
-        return self._get(key,
-                         models.Blueprint,
-                         models.BlueprintLabel,
-                         pagination,
-                         search)
+        return get_labels_key_values(key,
+                                     models.Blueprint,
+                                     models.BlueprintLabel,
+                                     pagination,
+                                     search)
+
+
+def get_labels_keys(resource_model, resource_labels_model, pagination, search):
+    """Get all the resource's labels' keys"""
+    get_all_results = rest_utils.verify_and_convert_bool(
+        '_get_all_results',
+        request.args.get('_get_all_results', False)
+    )
+    results = get_storage_manager().list(
+        resource_labels_model,
+        include=['key'],
+        pagination=pagination,
+        filters={'_labeled_model_fk': resource_model._storage_id},
+        get_all_results=get_all_results,
+        distinct=['key'],
+        substr_filters=search,
+        sort={'key': 'asc'}
+    )
+
+    results.items = [label.key for label in results]
+    return results
+
+
+def get_labels_key_values(key, resource_model, resource_labels_model,
+                          pagination, search):
+    """Get all resource's labels' values for the specified key."""
+    rest_utils.validate_inputs({'label_key': key})
+    get_all_results = rest_utils.verify_and_convert_bool(
+        '_get_all_results',
+        request.args.get('_get_all_results', False)
+    )
+    results = get_storage_manager().list(
+        resource_labels_model,
+        include=['value'],
+        pagination=pagination,
+        filters={'key': key,
+                 '_labeled_model_fk': resource_model._storage_id},
+        get_all_results=get_all_results,
+        distinct=['value'],
+        substr_filters=search,
+        sort={'value': 'asc'}
+    )
+
+    results.items = [label.value for label in results]
+    return results

--- a/rest-service/manager_rest/rest/resources_v3_1/labels.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/labels.py
@@ -7,22 +7,19 @@ from manager_rest.storage import models, get_storage_manager
 from .. import rest_decorators, rest_utils
 
 
-class DeploymentsLabels(SecuredResource):
-    @authorize('labels_list')
-    @rest_decorators.marshal_list_response
-    @rest_decorators.paginate
-    @rest_decorators.search('key')
-    def get(self, pagination=None, search=None):
-        """Get all deployments' labels' keys in the current tenant"""
+class _Labels(SecuredResource):
+    @staticmethod
+    def _get(resource_model, resource_labels_model, pagination, search):
+        """Get all the resource's labels' keys"""
         get_all_results = rest_utils.verify_and_convert_bool(
             '_get_all_results',
             request.args.get('_get_all_results', False)
         )
         results = get_storage_manager().list(
-            models.DeploymentLabel,
+            resource_labels_model,
             include=['key'],
             pagination=pagination,
-            filters={'_labeled_model_fk': models.Deployment._storage_id},
+            filters={'_labeled_model_fk': resource_model._storage_id},
             get_all_results=get_all_results,
             distinct=['key'],
             substr_filters=search,
@@ -33,24 +30,21 @@ class DeploymentsLabels(SecuredResource):
         return results
 
 
-class DeploymentsLabelsKey(SecuredResource):
-    @authorize('labels_list')
-    @rest_decorators.marshal_list_response
-    @rest_decorators.paginate
-    @rest_decorators.search('value')
-    def get(self, key, pagination=None, search=None):
-        """Get all deployments' labels' values for the specified key."""
+class _LabelsKey(SecuredResource):
+    @staticmethod
+    def _get(key, resource_model, resource_labels_model, pagination, search):
+        """Get all resource's labels' values for the specified key."""
         rest_utils.validate_inputs({'label_key': key})
         get_all_results = rest_utils.verify_and_convert_bool(
             '_get_all_results',
             request.args.get('_get_all_results', False)
         )
         results = get_storage_manager().list(
-            models.DeploymentLabel,
+            resource_labels_model,
             include=['value'],
             pagination=pagination,
             filters={'key': key,
-                     '_labeled_model_fk': models.Deployment._storage_id},
+                     '_labeled_model_fk': resource_model._storage_id},
             get_all_results=get_all_results,
             distinct=['value'],
             substr_filters=search,
@@ -59,3 +53,57 @@ class DeploymentsLabelsKey(SecuredResource):
 
         results.items = [label.value for label in results]
         return results
+
+
+class DeploymentsLabels(_Labels):
+    @authorize('labels_list')
+    @rest_decorators.marshal_list_response
+    @rest_decorators.paginate
+    @rest_decorators.search('key')
+    def get(self, pagination=None, search=None):
+        """Get all deployments' labels' keys"""
+        return self._get(models.Deployment,
+                         models.DeploymentLabel,
+                         pagination,
+                         search)
+
+
+class DeploymentsLabelsKey(_LabelsKey):
+    @authorize('labels_list')
+    @rest_decorators.marshal_list_response
+    @rest_decorators.paginate
+    @rest_decorators.search('value')
+    def get(self, key, pagination=None, search=None):
+        """Get all deployments' labels' values for the specified key."""
+        return self._get(key,
+                         models.Deployment,
+                         models.DeploymentLabel,
+                         pagination,
+                         search)
+
+
+class BlueprintsLabels(_Labels):
+    @authorize('labels_list')
+    @rest_decorators.marshal_list_response
+    @rest_decorators.paginate
+    @rest_decorators.search('key')
+    def get(self, pagination=None, search=None):
+        """Get all blueprints' labels' keys"""
+        return self._get(models.Blueprint,
+                         models.BlueprintLabel,
+                         pagination,
+                         search)
+
+
+class BlueprintsLabelsKey(_LabelsKey):
+    @authorize('labels_list')
+    @rest_decorators.marshal_list_response
+    @rest_decorators.paginate
+    @rest_decorators.search('value')
+    def get(self, key, pagination=None, search=None):
+        """Get all blueprints' labels' values for the specified key."""
+        return self._get(key,
+                         models.Blueprint,
+                         models.BlueprintLabel,
+                         pagination,
+                         search)

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -217,6 +217,7 @@ class BaseServerTestCase(unittest.TestCase):
                         client.deployment_groups.api = mock_http_client
                         client.execution_groups.api = mock_http_client
                         client.execution_schedules.api = mock_http_client
+                        client.blueprints_labels.api = mock_http_client
 
         return client
 

--- a/rest-service/manager_rest/test/endpoints/test_labels.py
+++ b/rest-service/manager_rest/test/endpoints/test_labels.py
@@ -23,13 +23,13 @@ class DeploymentsLabelsTestCase(base_test.BaseServerTestCase):
     LABELS = [{'env': 'aws'}, {'arch': 'k8s'}]
     LABELS_2 = [{'env': 'gcp'}, {'arch': 'k8s'}]
 
-    def test_list_keys(self):
+    def test_list_deployment_labels_keys(self):
         self.put_deployment_with_labels(self.LABELS)
         self.put_deployment_with_labels(self.LABELS_2)
         keys_list = self.client.deployments_labels.list_keys()
         self.assertEqual(set(keys_list.items), {'env', 'arch'})
 
-    def test_list_key_values(self):
+    def test_list_deployment_labels_key_values(self):
         self.put_deployment_with_labels(self.LABELS)
         self.put_deployment_with_labels(self.LABELS_2)
         env_values = self.client.deployments_labels.list_key_values('env')
@@ -37,10 +37,23 @@ class DeploymentsLabelsTestCase(base_test.BaseServerTestCase):
         self.assertEqual(set(env_values.items), {'aws', 'gcp'})
         self.assertEqual(arch_values.items, ['k8s'])
 
-    def test_empty_labels(self):
+    def test_deployment_labels_empty_labels(self):
         keys_list = self.client.deployments_labels.list_keys()
         self.assertEmpty(keys_list.items)
 
-    def test_key_does_not_exist(self):
+    def test_deployment_labels_key_does_not_exist(self):
         not_exist = self.client.deployments_labels.list_key_values('env')
         self.assertEmpty(not_exist.items)
+
+    def test_list_blueprint_labels_keys(self):
+        self.put_blueprint(blueprint_file_name='blueprint_with_labels.yaml')
+        keys_list = self.client.blueprints_labels.list_keys()
+        self.assertEqual(set(keys_list.items), {'bp_key1', 'bp_key2'})
+
+    def test_list_blueprint_labels_key_values(self):
+        self.put_blueprint(blueprint_file_name='blueprint_with_labels.yaml')
+        key1_values = self.client.blueprints_labels.list_key_values('bp_key1')
+        key2_values = self.client.blueprints_labels.list_key_values('bp_key2')
+        self.assertEqual(set(key1_values.items), {'bp_key1_val1'})
+        self.assertEqual(set(key2_values.items),
+                         {'bp_key2_val1', 'bp_key2_val2'})

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_labels.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_labels.yaml
@@ -1,0 +1,13 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - cloudify/types/types.yaml
+
+blueprint-labels:
+  bp_key1:
+    value:
+      - bp_key1_val1
+  bp_key2:
+    value:
+      - bp_key2_val1
+      - bp_key2_val2


### PR DESCRIPTION
This PR adds the endpoint `labels/blueprints`. Currently, blueprints' labels are only supported when supplied through the blueprint itself under `blueprint-labels`. 

The complementary PR for the rest client is https://github.com/cloudify-cosmo/cloudify-common/pull/663.