### PR TITLE
RD-1375 More changes to the update_plugin_imports script

### DIFF
--- a/rest-service/manager_rest/shell/update_plugin_imports.py
+++ b/rest-service/manager_rest/shell/update_plugin_imports.py
@@ -551,31 +551,34 @@ def get_imports(blueprint_file: typing.TextIO) -> dict:
     imports_token = None
     import_lines = {}
     blueprint_file.seek(0, 0)
-    for token in yaml.scan(blueprint_file):
-        if isinstance(token, (yaml.tokens.BlockMappingStartToken,
-                              yaml.tokens.BlockSequenceStartToken,
-                              yaml.tokens.FlowMappingStartToken,
-                              yaml.tokens.FlowSequenceStartToken)):
+    for t in yaml.scan(blueprint_file):
+        if isinstance(t, (yaml.tokens.BlockMappingStartToken,
+                          yaml.tokens.BlockSequenceStartToken,
+                          yaml.tokens.FlowMappingStartToken,
+                          yaml.tokens.FlowSequenceStartToken)):
             level += 1
-        if isinstance(token, (yaml.tokens.BlockEndToken,
-                              yaml.tokens.FlowMappingEndToken,
-                              yaml.tokens.FlowSequenceEndToken)):
+        if isinstance(t, (yaml.tokens.BlockEndToken,
+                          yaml.tokens.FlowMappingEndToken,
+                          yaml.tokens.FlowSequenceEndToken)):
             level -= 1
-        if level == 1:
-            if isinstance(token, yaml.tokens.ScalarToken) and \
-                    token.value == 'imports':
-                imports_token = token
-            elif imports_token and \
-                    isinstance(token, yaml.tokens.ScalarToken):
-                break
-        elif imports_token and level == 2 and \
-                isinstance(token, yaml.tokens.ScalarToken) and \
-                token.end_mark.index - \
-                token.start_mark.index < MAX_IMPORT_TOKEN_LENGTH:
-            import_lines[token.value] = {
-                START_POS: token.start_mark.index,
-                END_POS: token.end_mark.index,
-            }
+
+        if isinstance(t, yaml.tokens.ScalarToken):
+            if level == 1 and t.value == 'imports':
+                imports_token = t
+                continue
+
+            token_length = t.end_mark.index - t.start_mark.index
+
+            if level >= 1 and imports_token and \
+                    token_length < MAX_IMPORT_TOKEN_LENGTH:
+                import_lines[t.value] = {
+                    START_POS: t.start_mark.index,
+                    END_POS: t.end_mark.index,
+                }
+
+        if isinstance(t, yaml.tokens.KeyToken) and imports_token:
+            break
+
     return import_lines
 
 
@@ -589,8 +592,7 @@ def write_updated_blueprint(input_file_name: str, output_file_name: str,
                                               input_file.tell())
                     output_file.write(content)
                     output_file.write("{0}\n".format(update[REPLACEMENT]))
-                    content = input_file.read(update[END_POS] -
-                                              update[START_POS] + 1)
+                    input_file.read(update[END_POS] - update[START_POS] + 1)
                 content = input_file.read()
                 output_file.write(content)
     except (FileNotFoundError, PermissionError) as ex:
@@ -866,7 +868,7 @@ def main(tenant_names, all_tenants, plugin_names, blueprint_ids,
         for blueprint in blueprints:
             print('Processing blueprint of {0}: {1} '.format(tenant.name,
                                                              blueprint.id))
-            blueprint_identifier = '{0}-{1}'.format(tenant.name, blueprint.id)
+            blueprint_identifier = '{0}::{1}'.format(tenant.name, blueprint.id)
             if correct:
                 try:
                     result = correct_blueprint(


### PR DESCRIPTION
* RD-1375 Improve blueprint_identifier readibility

Instead of using hyphen to join tenant and blueprint_id to printout some
statistics, we'll use '::'.

* nit: removed unused variable

* Workaround ill-formatted `imports:` entries

In case these entries had no indentation the script failed to identify
them.  Now it can work with ill-formatted YAMLs too.