### PR TITLE
RD-1429 Add a timeout to the patroni requests

### DIFF
--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -343,6 +343,7 @@ class Config(object):
                 result = requests.get(
                     'https://{}:8008'.format(candidate),
                     verify=self.postgresql_ca_cert_path,
+                    timeout=5,
                 )
             except Exception as err:
                 current_app.logger.error(


### PR DESCRIPTION
This ports #2685 to 5.2.0:

Otherwise, the restservice will stay dead forever, if a DB node
is blackholing traffic.

I used 5 as the timeout because it seems good enough. You'd have
already thrown your holy hand grenade by 3.

Note that (as opposed to the requests in RESTClients), this is
both the connect+read timeout, there's no need to distinguish here.