### PR TITLE
RD-1450 Endpoint for creating Nodes

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/__init__.py
@@ -120,3 +120,7 @@ from .filters import (                           # NOQA
     Filters,
     FiltersId,
 )
+
+from .nodes import (  # NOQA
+    Nodes,
+)

--- a/rest-service/manager_rest/rest/resources_v3_1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/nodes.py
@@ -4,12 +4,10 @@ from manager_rest import manager_exceptions
 from manager_rest.rest import rest_utils
 from manager_rest.security.authorization import authorize
 from manager_rest.storage import get_storage_manager, models
-from manager_rest.rest import rest_decorators
 
 
 class Nodes(v3_Nodes):
     @authorize('node_create')
-    @rest_decorators.marshal_with(models.Node)
     def post(self):
         request_dict = rest_utils.get_json_and_verify_params({
             'nodes': {'type': list},
@@ -25,7 +23,7 @@ class Nodes(v3_Nodes):
                 node.set_deployment(deployment)
                 sm.put(node)
                 created.append(node)
-        return created, 200
+        return None, 201
 
     def _deployment_id_from_nodes(self, raw_nodes):
         deployment_ids = set()

--- a/rest-service/manager_rest/rest/resources_v3_1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/nodes.py
@@ -14,6 +14,8 @@ class Nodes(v3_Nodes):
         })
         sm = get_storage_manager()
         raw_nodes = request_dict['nodes']
+        if not raw_nodes:
+            return None, 204
         created = []
         with sm.transaction():
             deployment_id = self._deployment_id_from_nodes(raw_nodes)

--- a/rest-service/manager_rest/rest/resources_v3_1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/nodes.py
@@ -1,5 +1,6 @@
 from ..resources_v3 import Nodes as v3_Nodes
 
+from manager_rest import manager_exceptions
 from manager_rest.rest import rest_utils
 from manager_rest.security.authorization import authorize
 from manager_rest.storage import get_storage_manager, models
@@ -30,6 +31,11 @@ class Nodes(v3_Nodes):
         deployment_ids = set()
         for node in raw_nodes:
             deployment_ids.add(node['deployment_id'])
+        if len(deployment_ids) != 1:
+            raise manager_exceptions.ConflictError(
+                'All nodes must belong to the same deployment, '
+                'but found {0} deployments'.format(len(deployment_ids))
+            )
         return deployment_ids.pop()
 
     def _node_from_raw_node(self, raw_node):

--- a/rest-service/manager_rest/rest/resources_v3_1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/nodes.py
@@ -26,15 +26,12 @@ class Nodes(v3_Nodes):
         return None, 201
 
     def _deployment_id_from_nodes(self, raw_nodes):
-        deployment_ids = set()
-        for node in raw_nodes:
-            deployment_ids.add(node['deployment_id'])
-        if len(deployment_ids) != 1:
+        deployment_id = raw_nodes[0]['deployment_id']
+        if any(n['deployment_id'] != deployment_id for n in raw_nodes):
             raise manager_exceptions.ConflictError(
-                'All nodes must belong to the same deployment, '
-                'but found {0} deployments'.format(len(deployment_ids))
+                'All nodes must belong to the same deployment'
             )
-        return deployment_ids.pop()
+        return deployment_id
 
     def _node_from_raw_node(self, raw_node):
         node_type = raw_node['type']

--- a/rest-service/manager_rest/rest/resources_v3_1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/nodes.py
@@ -1,0 +1,75 @@
+from ..resources_v3 import Nodes as v3_Nodes
+
+from manager_rest.rest import rest_utils
+from manager_rest.security.authorization import authorize
+from manager_rest.storage import get_storage_manager, models
+from manager_rest.rest import rest_decorators
+
+
+class Nodes(v3_Nodes):
+    @authorize('node_create')
+    @rest_decorators.marshal_with(models.Node)
+    def post(self):
+        request_dict = rest_utils.get_json_and_verify_params({
+            'nodes': {'type': list},
+        })
+        sm = get_storage_manager()
+        raw_nodes = request_dict['nodes']
+        created = []
+        with sm.transaction():
+            deployment_id = self._deployment_id_from_nodes(raw_nodes)
+            deployment = sm.get(models.Deployment, deployment_id)
+            for raw_node in raw_nodes:
+                node = self._node_from_raw_node(raw_node)
+                node.set_deployment(deployment)
+                sm.put(node)
+                created.append(node)
+        return created, 200
+
+    def _deployment_id_from_nodes(self, raw_nodes):
+        deployment_ids = set()
+        for node in raw_nodes:
+            deployment_ids.add(node['deployment_id'])
+        return deployment_ids.pop()
+
+    def _node_from_raw_node(self, raw_node):
+        node_type = raw_node['type']
+        type_hierarchy = raw_node.get('type_hierarchy') or []
+        if not type_hierarchy:
+            type_hierarchy = [node_type]
+        try:
+            scalable = raw_node['capabilities']['scalable']['properties']
+        except KeyError:
+            scalable = {}
+        return models.Node(
+            id=raw_node['id'],
+            type=node_type,
+            type_hierarchy=type_hierarchy,
+            number_of_instances=scalable.get('current_instances') or 1,
+            planned_number_of_instances=scalable.get('current_instances') or 1,
+            deploy_number_of_instances=scalable.get('default_instances') or 1,
+            min_number_of_instances=scalable.get('min_instances') or 1,
+            max_number_of_instances=scalable.get('max_instances') or 1,
+            host_id=raw_node.get('host_id'),
+            properties=raw_node.get('properties') or {},
+            operations=raw_node.get('operations') or {},
+            plugins=raw_node.get('plugins') or {},
+            plugins_to_install=raw_node.get('plugins_to_install'),
+            relationships=self._prepare_node_relationships(raw_node)
+        )
+
+    def _prepare_node_relationships(self, raw_node):
+        if 'relationships' not in raw_node:
+            return []
+        prepared_relationships = []
+        for raw_relationship in raw_node['relationships']:
+            relationship = {
+                'target_id': raw_relationship['target_id'],
+                'type': raw_relationship['type'],
+                'type_hierarchy': raw_relationship['type_hierarchy'],
+                'properties': raw_relationship['properties'],
+                'source_operations': raw_relationship['source_operations'],
+                'target_operations': raw_relationship['target_operations'],
+            }
+            prepared_relationships.append(relationship)
+        return prepared_relationships

--- a/rest-service/manager_rest/test/endpoints/test_nodes.py
+++ b/rest-service/manager_rest/test/endpoints/test_nodes.py
@@ -18,7 +18,7 @@ from unittest import skip
 
 from cloudify_rest_client.exceptions import CloudifyClientError
 
-from manager_rest.storage import db
+from manager_rest.storage import db, models
 from manager_rest.test import base_test
 from manager_rest import manager_exceptions
 from manager_rest.test.mocks import put_node_instance
@@ -424,3 +424,17 @@ class NodesTest(base_test.BaseServerTestCase):
                 self.assertEqual(1, len(scaling_groups))
                 self.assertDictContainsSubset({'name': 'group1'},
                                               scaling_groups[0])
+
+
+class NodesCreateTest(base_test.BaseServerTestCase):
+    def test_create_single(self):
+        self.put_deployment('dep1')
+        self.client.nodes.create_many([
+            {
+                'id': 'test_node1',
+                'deployment_id': 'dep1',
+                'type': 'cloudify.nodes.Root'
+            }
+        ])
+        nodes = self.sm.list(models.Node)
+        assert any(n.id == 'test_node1' for n in nodes)

--- a/rest-service/manager_rest/test/endpoints/test_nodes.py
+++ b/rest-service/manager_rest/test/endpoints/test_nodes.py
@@ -427,14 +427,24 @@ class NodesTest(base_test.BaseServerTestCase):
 
 
 class NodesCreateTest(base_test.BaseServerTestCase):
-    def test_create_single(self):
+    def test_create_nodes(self):
         self.put_deployment('dep1')
         self.client.nodes.create_many([
             {
                 'id': 'test_node1',
                 'deployment_id': 'dep1',
                 'type': 'cloudify.nodes.Root'
+            },
+            {
+                'id': 'test_node2',
+                'deployment_id': 'dep1',
+                'type': 'cloudify.nodes.Root'
             }
         ])
         nodes = self.sm.list(models.Node)
-        assert any(n.id == 'test_node1' for n in nodes)
+        node1 = [n for n in nodes if n.id == 'test_node1']
+        node2 = [n for n in nodes if n.id == 'test_node2']
+        assert len(node1) == 1
+        node1 = node1[0]
+        assert len(node2) == 1
+        assert node1.deployment_id == 'dep1'

--- a/rest-service/manager_rest/test/endpoints/test_nodes.py
+++ b/rest-service/manager_rest/test/endpoints/test_nodes.py
@@ -453,7 +453,7 @@ class NodesCreateTest(base_test.BaseServerTestCase):
         self.put_blueprint()
         self.client.deployments.create('blueprint', 'dep1')
         self.client.deployments.create('blueprint', 'dep2')
-        with self.assertRaisesRegexp(CloudifyClientError, 'deployment'):
+        with self.assertRaisesRegexp(CloudifyClientError, 'same deployment'):
             self.client.nodes.create_many([
                 {
                     'id': 'test_node1',

--- a/rest-service/manager_rest/test/endpoints/test_nodes.py
+++ b/rest-service/manager_rest/test/endpoints/test_nodes.py
@@ -448,3 +448,21 @@ class NodesCreateTest(base_test.BaseServerTestCase):
         node1 = node1[0]
         assert len(node2) == 1
         assert node1.deployment_id == 'dep1'
+
+    def test_create_different_deployments(self):
+        self.put_blueprint()
+        self.client.deployments.create('blueprint', 'dep1')
+        self.client.deployments.create('blueprint', 'dep2')
+        with self.assertRaisesRegexp(CloudifyClientError, 'deployment'):
+            self.client.nodes.create_many([
+                {
+                    'id': 'test_node1',
+                    'deployment_id': 'dep1',
+                    'type': 'cloudify.nodes.Root'
+                },
+                {
+                    'id': 'test_node2',
+                    'deployment_id': 'dep2',
+                    'type': 'cloudify.nodes.Root'
+                }
+            ])

--- a/rest-service/manager_rest/test/endpoints/test_nodes.py
+++ b/rest-service/manager_rest/test/endpoints/test_nodes.py
@@ -524,3 +524,6 @@ class NodesCreateTest(base_test.BaseServerTestCase):
         assert node.deploy_number_of_instances == default_instances
         assert node.min_number_of_instances == min_instances
         assert node.max_number_of_instances == max_instances
+
+    def test_empty_list(self):
+        self.client.nodes.create_many([])  # doesn't throw


### PR DESCRIPTION
Add an endpoint for batch-creating Nodes.

This is going to be useful for the "async deployment creation" track, where
we move creating nodes & node-instances out to a workflow. Then the workflow
of course needs a way to create those nodes.