### PR TITLE
RD-1506 Blueprint upload: wait for the execution

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -368,7 +368,7 @@ class ResourceManager(object):
 
     def upload_blueprint(self, blueprint_id, app_file_name, blueprint_url,
                          file_server_root, validate_only=False):
-        self._execute_system_workflow(
+        return self._execute_system_workflow(
             wf_id='upload_blueprint',
             task_mapping='cloudify_system_workflows.blueprint.upload',
             verify_no_executions=False,

--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -125,7 +125,8 @@ class BlueprintsId(resources_v2.BlueprintsId):
                                   override_failed=override_failed)
         if not async_upload:
             sm = get_storage_manager()
-            response = rest_utils.get_uploaded_blueprint(sm, blueprint_id)
+            blueprint, _ = response
+            response = rest_utils.get_uploaded_blueprint(sm, blueprint)
         return response
 
     @swagger.operation(

--- a/rest-service/manager_rest/upload_manager.py
+++ b/rest-service/manager_rest/upload_manager.py
@@ -538,7 +538,9 @@ class UploadedBlueprintsManager(UploadedDataManager):
             self.upload_archive_to_file_server(data_id)
 
         try:
-            rm.upload_blueprint(
+            # unfortunate, but we must pass the execution back out
+            # to the caller, so they can poll on it
+            new_blueprint._upload_execution = rm.upload_blueprint(
                 data_id,
                 application_file_name,
                 blueprint_url,


### PR DESCRIPTION
Rather than polling on blueprint state, wait on the execution instead.
Blueprint state can unfortunately change several times, but the
execution status is actually reliable.