### PR TITLE
CYBL-1107-Automatically fix inputs' types

### DIFF
--- a/rest-service/manager_rest/deployment_update/manager.py
+++ b/rest-service/manager_rest/deployment_update/manager.py
@@ -84,7 +84,8 @@ class DeploymentUpdateManager(object):
                                 additional_inputs,
                                 new_blueprint_id=None,
                                 preview=False,
-                                runtime_only_evaluation=False):
+                                runtime_only_evaluation=False,
+                                auto_correct_types=False):
         # enables reverting to original blueprint resources
         deployment = self.sm.get(models.Deployment, deployment_id)
         old_blueprint = deployment.blueprint
@@ -103,7 +104,8 @@ class DeploymentUpdateManager(object):
 
         # applying intrinsic functions
         plan = get_deployment_plan(parsed_deployment, new_inputs,
-                                   runtime_only_evaluation)
+                                   runtime_only_evaluation,
+                                   auto_correct_types)
 
         deployment_update_id = '{0}-{1}'.format(deployment.id, uuid.uuid4())
         deployment_update = models.DeploymentUpdate(

--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -83,7 +83,8 @@ class DeploymentUpdate(SecuredResource):
         """
         manager, skip_install, skip_uninstall, skip_reinstall, workflow_id, \
             ignore_failure, install_first, preview, update_plugins, \
-            runtime_eval, force = self._parse_args(id, request.json)
+            runtime_eval, auto_correct_args, force = \
+            self._parse_args(id, request.json)
         blueprint, inputs, reinstall_list = \
             self._get_and_validate_blueprint_and_inputs(id, request.json)
         blueprint_dir_abs = _get_plugin_update_blueprint_abs_path(
@@ -97,7 +98,8 @@ class DeploymentUpdate(SecuredResource):
         file_name = blueprint.main_file_name
         deployment_update = manager.stage_deployment_update(
             id, deployment_dir, file_name, inputs, blueprint.id, preview,
-            runtime_only_evaluation=runtime_eval)
+            runtime_only_evaluation=runtime_eval,
+            auto_correct_types=auto_correct_args)
         manager.extract_steps_from_deployment_update(deployment_update)
         return manager.commit_deployment_update(deployment_update,
                                                 skip_install,
@@ -114,7 +116,7 @@ class DeploymentUpdate(SecuredResource):
         request_json = request.args
         manager, skip_install, skip_uninstall, _, workflow_id, \
             ignore_failure, install_first, _, update_plugins, \
-            runtime_eval, force = self._parse_args(
+            runtime_eval, _, force = self._parse_args(
                 deployment_id, request_json, using_post_request=True)
         deployment_update, _ = \
             UploadedBlueprintsDeploymentUpdateManager(). \
@@ -182,6 +184,10 @@ class DeploymentUpdate(SecuredResource):
             'runtime_only_evaluation',
             request_json.get('runtime_only_evaluation', False)
         )
+        auto_correct_types = verify_and_convert_bool(
+            'auto_correct_types',
+            request_json.get('auto_correct_types', False)
+        )
         force = verify_and_convert_bool(
             'force',
             request_json.get('force', False)
@@ -198,6 +204,7 @@ class DeploymentUpdate(SecuredResource):
                 preview,
                 update_plugins,
                 runtime_only_evaluation,
+                auto_correct_types,
                 force)
 
 

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -342,11 +342,13 @@ def get_parsed_deployment(blueprint,
 
 def get_deployment_plan(parsed_deployment,
                         inputs,
-                        runtime_only_evaluation=False):
+                        runtime_only_evaluation=False,
+                        auto_correct_types=False):
     try:
         return tasks.prepare_deployment_plan(
             parsed_deployment, get_secret_method, inputs=inputs,
-            runtime_only_evaluation=runtime_only_evaluation)
+            runtime_only_evaluation=runtime_only_evaluation,
+            auto_correct_types=auto_correct_types)
     except parser_exceptions.MissingRequiredInputError as e:
         raise manager_exceptions.MissingRequiredDeploymentInputError(
             str(e))


### PR DESCRIPTION
In some rare (?) cases there might exist deployments with invalid type
of inputs (e.g. '20' stored where input type should be integer).  This
patch adds functionality to attempt to automatically cast types of input
values to expected (a.k.a. inputs auto-correction).