### PR TITLE
Inputs type casting functionality

### DIFF
--- a/rest-service/manager_rest/deployment_update/manager.py
+++ b/rest-service/manager_rest/deployment_update/manager.py
@@ -83,7 +83,8 @@ class DeploymentUpdateManager(object):
                                 additional_inputs,
                                 new_blueprint_id=None,
                                 preview=False,
-                                runtime_only_evaluation=False):
+                                runtime_only_evaluation=False,
+                                auto_correct_types=False):
         # enables reverting to original blueprint resources
         deployment = self.sm.get(models.Deployment, deployment_id)
         old_blueprint = deployment.blueprint
@@ -102,7 +103,8 @@ class DeploymentUpdateManager(object):
 
         # applying intrinsic functions
         plan = get_deployment_plan(parsed_deployment, new_inputs,
-                                   runtime_only_evaluation)
+                                   runtime_only_evaluation,
+                                   auto_correct_types)
 
         deployment_update_id = '{0}-{1}'.format(deployment.id, uuid.uuid4())
         deployment_update = models.DeploymentUpdate(

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -313,11 +313,13 @@ def get_parsed_deployment(blueprint,
 
 def get_deployment_plan(parsed_deployment,
                         inputs,
-                        runtime_only_evaluation=False):
+                        runtime_only_evaluation=False,
+                        auto_correct_types=False):
     try:
         return tasks.prepare_deployment_plan(
             parsed_deployment, get_secret_method, inputs=inputs,
-            runtime_only_evaluation=runtime_only_evaluation)
+            runtime_only_evaluation=runtime_only_evaluation,
+            auto_correct_types=auto_correct_types)
     except parser_exceptions.MissingRequiredInputError as e:
         raise manager_exceptions.MissingRequiredDeploymentInputError(
             str(e))


### PR DESCRIPTION
In some rare (?) cases there might exist deployments with invalid type
of inputs (e.g. '20' stored where input type should be integer).  This
patch adds functionality to attempt to automatically cast types of input
values to expected (a.k.a. inputs auto-correction).