### PR TITLE
RD-1515 Add --auto-correct-types to plugins update

### DIFF
--- a/rest-service/manager_rest/plugins_update/constants.py
+++ b/rest-service/manager_rest/plugins_update/constants.py
@@ -45,6 +45,7 @@ TO_MINOR = 'to_minor'
 ALL_TO_MINOR = 'all_to_minor'
 MAPPING = 'mapping'
 FORCE = 'force'
+AUTO_CORRECT_TYPES = 'auto_correct_types'
 
 UPDATES = 'updates'
 PLUGIN_NAME = 'plugin_name'

--- a/rest-service/manager_rest/plugins_update/manager.py
+++ b/rest-service/manager_rest/plugins_update/manager.py
@@ -96,7 +96,8 @@ class PluginsUpdateManager(object):
         plugins_update.set_blueprint(blueprint)
         return self.sm.put(plugins_update)
 
-    def initiate_plugins_update(self, blueprint_id, filters):
+    def initiate_plugins_update(self, blueprint_id, filters,
+                                auto_correct_types=False):
         """Creates a temporary blueprint and executes the plugins update
         workflow.
         """
@@ -126,8 +127,9 @@ class PluginsUpdateManager(object):
             plugins_update.state = STATES.UPDATING
             self.sm.update(plugins_update)
 
-        plugins_update.execution = get_resource_manager(
-            self.sm).update_plugins(plugins_update, not changes_required)
+        plugins_update.execution = \
+            get_resource_manager(self.sm).update_plugins(
+                plugins_update, not changes_required, auto_correct_types)
         plugins_update.state = (STATES.EXECUTING_WORKFLOW if changes_required
                                 else STATES.NO_CHANGES_REQUIRED)
         return self.sm.update(plugins_update)

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -308,7 +308,9 @@ class ResourceManager(object):
                 )
         return True
 
-    def update_plugins(self, plugins_update, no_changes_required=False):
+    def update_plugins(self, plugins_update,
+                       no_changes_required=False,
+                       auto_correct_types=False):
         """Executes the plugin update workflow.
 
         :param plugins_update: a PluginUpdate object.
@@ -324,6 +326,7 @@ class ResourceManager(object):
                 'deployments_to_update': plugins_update.deployments_to_update,
                 'temp_blueprint_id': plugins_update.temp_blueprint_id,
                 'force': plugins_update.forced,
+                'auto_correct_types': auto_correct_types,
             },
             verify_no_executions=False,
             fake_execution=no_changes_required)

--- a/rest-service/manager_rest/rest/resources_v3_1/plugins.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/plugins.py
@@ -32,7 +32,8 @@ from manager_rest.plugins_update.constants import (PLUGIN_NAMES,
                                                    TO_MINOR,
                                                    ALL_TO_MINOR,
                                                    MAPPING,
-                                                   FORCE)
+                                                   FORCE,
+                                                   AUTO_CORRECT_TYPES)
 from manager_rest.plugins_update.manager import get_plugins_updates_manager
 from manager_rest.rest import (resources_v2,
                                resources_v2_1,
@@ -113,13 +114,16 @@ class PluginsUpdate(SecuredResource):
                 ALL_TO_MINOR: {'type': bool, 'optional': True},
                 TO_MINOR: {'type': list, 'optional': True},
                 MAPPING: {'type': dict, 'optional': True},
-                FORCE: {'type': bool, 'optional': True}
+                FORCE: {'type': bool, 'optional': True},
+                AUTO_CORRECT_TYPES: {'type': bool, 'optional': True},
             })
         except BadRequest:
             filters = {}
+        auto_correct_types = filters.pop(AUTO_CORRECT_TYPES, False)
         if phase == PHASES.INITIAL:
             return get_plugins_updates_manager().initiate_plugins_update(
-                blueprint_id=id, filters=filters)
+                blueprint_id=id, filters=filters,
+                auto_correct_types=auto_correct_types)
         elif phase == PHASES.FINAL:
             return get_plugins_updates_manager().finalize(
                 plugins_update_id=id)

--- a/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
@@ -146,6 +146,23 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
              'force': False,
              'auto_correct_types': False})
 
+    def test_plugins_update_auto_correct_types_flag(self):
+        self.put_blueprint(blueprint_id='hello_world')
+        self.client.deployments.create('hello_world', 'dep')
+        self.wait_for_deployment_creation(self.client, 'dep')
+        plugins_update = self.client.plugins_update.update_plugins(
+            'hello_world', auto_correct_types=True)
+        self.assertListEqual(['dep'],
+                             plugins_update.deployments_to_update)
+        execution = self.client.executions.get(plugins_update.execution_id)
+        self.assertDictEqual(
+            execution.parameters,
+            {'update_id': plugins_update.id,
+             'deployments_to_update': ['dep'],
+             'temp_blueprint_id': plugins_update.temp_blueprint_id,
+             'force': False,
+             'auto_correct_types': True})
+
     def test_raises_while_plugins_updates_are_active(self):
         self.put_blueprint(blueprint_id='hello_world')
         self.client.deployments.create('hello_world', 'd123')

--- a/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
@@ -152,10 +152,9 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
         self.wait_for_deployment_creation(self.client, 'dep')
         plugins_update = self.client.plugins_update.update_plugins(
             'hello_world', auto_correct_types=True)
-        self.assertListEqual(['dep'],
-                             plugins_update.deployments_to_update)
+        self.assertEqual(['dep'], plugins_update.deployments_to_update)
         execution = self.client.executions.get(plugins_update.execution_id)
-        self.assertDictEqual(
+        self.assertEqual(
             execution.parameters,
             {'update_id': plugins_update.id,
              'deployments_to_update': ['dep'],

--- a/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
@@ -143,7 +143,8 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
             {'update_id': plugins_update.id,
              'deployments_to_update': ['d1', 'd2'],
              'temp_blueprint_id': plugins_update.temp_blueprint_id,
-             'force': False})
+             'force': False,
+             'auto_correct_types': False})
 
     def test_raises_while_plugins_updates_are_active(self):
         self.put_blueprint(blueprint_id='hello_world')

--- a/tests/integration_tests/tests/agent_tests/test_plugin_update.py
+++ b/tests/integration_tests/tests/agent_tests/test_plugin_update.py
@@ -252,31 +252,6 @@ class TestPluginUpdate(AgentTestWithPlugins):
         self._execute_workflows()
         self._assert_host_values(self.versions[1])
 
-    @setup_for_plugins_update
-    def test_auto_correct_types(self):
-        self.setup_deployment_id = 'd{0}'.format(uuid.uuid4())
-        self.setup_node_id = 'node'
-        self.plugin_name = 'version_aware'
-
-        self.deploy_application(
-            dsl_path=self._get_dsl_blueprint_path(''),
-            blueprint_id=self.base_blueprint_id,
-            deployment_id=self.setup_deployment_id
-        )
-        self._upload_v_2_plugin()
-
-        # Execute base (V 1.0) workflows
-        self._execute_workflows()
-        self._assert_host_values(self.versions[0])
-
-        # This should do the update
-        plugins_update = self._perform_plugins_update(
-            to_latest=[self.plugin_name],
-            auto_correct_types=True)
-        self.assertEqual(plugins_update.state, STATES.SUCCESSFUL)
-        self._execute_workflows()
-        self._assert_host_values(self.versions[1])
-
     def _perform_plugins_update(self, **kwargs):
         plugins_update = self.client.plugins_update.update_plugins(
             self.base_blueprint_id, **kwargs)

--- a/tests/integration_tests/tests/agent_tests/test_plugin_update.py
+++ b/tests/integration_tests/tests/agent_tests/test_plugin_update.py
@@ -252,6 +252,31 @@ class TestPluginUpdate(AgentTestWithPlugins):
         self._execute_workflows()
         self._assert_host_values(self.versions[1])
 
+    @setup_for_plugins_update
+    def test_auto_correct_types(self):
+        self.setup_deployment_id = 'd{0}'.format(uuid.uuid4())
+        self.setup_node_id = 'node'
+        self.plugin_name = 'version_aware'
+
+        self.deploy_application(
+            dsl_path=self._get_dsl_blueprint_path(''),
+            blueprint_id=self.base_blueprint_id,
+            deployment_id=self.setup_deployment_id
+        )
+        self._upload_v_2_plugin()
+
+        # Execute base (V 1.0) workflows
+        self._execute_workflows()
+        self._assert_host_values(self.versions[0])
+
+        # This should do the update
+        plugins_update = self._perform_plugins_update(
+            to_latest=[self.plugin_name],
+            auto_correct_types=True)
+        self.assertEqual(plugins_update.state, STATES.SUCCESSFUL)
+        self._execute_workflows()
+        self._assert_host_values(self.versions[1])
+
     def _perform_plugins_update(self, **kwargs):
         plugins_update = self.client.plugins_update.update_plugins(
             self.base_blueprint_id, **kwargs)

--- a/workflows/cloudify_system_workflows/plugins.py
+++ b/workflows/cloudify_system_workflows/plugins.py
@@ -65,9 +65,8 @@ def update(ctx, update_id, temp_blueprint_id, deployments_to_update, force,
     the temp blueprint ID provided.
     :param force: force update (i.e. even if the blueprint is used to create
     components).
-    :param auto_correct_types: update deployments with auto_correct_types
-    flag, which will attempt to cast inputs to the types defined by
-    the blueprint.
+    :param auto_correct_types: update deployments with auto_correct_types flag,
+     which will attempt to cast inputs to the types defined by the blueprint.
     """
 
     def get_wait_for_execution_message(execution_id):

--- a/workflows/cloudify_system_workflows/plugins.py
+++ b/workflows/cloudify_system_workflows/plugins.py
@@ -74,6 +74,10 @@ def update(ctx, update_id, temp_blueprint_id, deployments_to_update, force,
         return 'Deployment update has failed with execution ID: ' \
                '{0}.'.format(execution_id)
 
+    ctx.logger.info('Executing update_plugin system workflow with flags: '
+                    'force={0}, auto_correct_types={1}'.
+                    format(force, auto_correct_types))
+
     client = get_rest_client()
     for dep in deployments_to_update:
         ctx.send_event('Executing deployment update for deployment '

--- a/workflows/cloudify_system_workflows/plugins.py
+++ b/workflows/cloudify_system_workflows/plugins.py
@@ -55,7 +55,7 @@ def _operate_on_plugin(ctx, plugin, action):
 
 @workflow(system_wide=True)
 def update(ctx, update_id, temp_blueprint_id, deployments_to_update, force,
-           **_):
+           auto_correct_types, **_):
     """Execute deployment update for all the given deployments_to_update.
 
     :param update_id: plugins update ID.
@@ -65,6 +65,9 @@ def update(ctx, update_id, temp_blueprint_id, deployments_to_update, force,
     the temp blueprint ID provided.
     :param force: force update (i.e. even if the blueprint is used to create
     components).
+    :param auto_correct_types: update deployments with auto_correct_types
+    flag, which will attempt to cast inputs to the types defined by
+    the blueprint.
     """
 
     def get_wait_for_execution_message(execution_id):
@@ -76,12 +79,14 @@ def update(ctx, update_id, temp_blueprint_id, deployments_to_update, force,
         ctx.send_event('Executing deployment update for deployment '
                        '{}...'.format(dep))
         execution_id = client.deployment_updates \
-            .update_with_existing_blueprint(deployment_id=dep,
-                                            blueprint_id=temp_blueprint_id,
-                                            skip_install=True,
-                                            skip_uninstall=True,
-                                            skip_reinstall=True,
-                                            force=force) \
+            .update_with_existing_blueprint(
+                deployment_id=dep,
+                blueprint_id=temp_blueprint_id,
+                skip_install=True,
+                skip_uninstall=True,
+                skip_reinstall=True,
+                force=force,
+                auto_correct_types=auto_correct_types) \
             .execution_id
 
         wait_for(client.executions.get,

--- a/workflows/cloudify_system_workflows/tests/test_plugins.py
+++ b/workflows/cloudify_system_workflows/tests/test_plugins.py
@@ -109,13 +109,15 @@ class TestPluginsUpdate(unittest.TestCase):
                     "Deployment update of deployment {0} with execution ID {0}"
                     " failed, stopped this plugins update "
                     "\\(id='my_update_id'\\)\\.".format(failed_execution_id)):
-                update_func(MagicMock(), 'my_update_id', None, dep_ids, False)
+                update_func(MagicMock(), 'my_update_id', None,
+                            dep_ids, False, False)
             should_call_these = [call(deployment_id=i,
                                       blueprint_id=None,
                                       skip_install=True,
                                       skip_uninstall=True,
                                       skip_reinstall=True,
-                                      force=False)
+                                      force=False,
+                                      auto_correct_types=False)
                                  for i in range(failed_execution_id)]
             self.deployment_update_mock.assert_has_calls(should_call_these)
 
@@ -124,7 +126,8 @@ class TestPluginsUpdate(unittest.TestCase):
                                           skip_install=True,
                                           skip_uninstall=True,
                                           skip_reinstall=True,
-                                          force=False)
+                                          force=False,
+                                          auto_correct_types=False)
                                      for i in range(
                     failed_execution_id + 1, len(dep_ids))]
             for _call in self.deployment_update_mock.mock_calls:
@@ -148,13 +151,14 @@ class TestPluginsUpdate(unittest.TestCase):
             = finalize_update_mock
         self.mock_rest_client.executions.get \
             .return_value = PropertyMock(status=ExecutionState.TERMINATED)
-        update_func(MagicMock(), '12345678', None, dep_ids, False)
+        update_func(MagicMock(), '12345678', None, dep_ids, False, False)
         should_call_these = [call(deployment_id=i,
                                   blueprint_id=None,
                                   skip_install=True,
                                   skip_uninstall=True,
                                   skip_reinstall=True,
-                                  force=False)
+                                  force=False,
+                                  auto_correct_types=False)
                              for i in range(len(dep_ids))]
         self.deployment_update_mock.assert_has_calls(should_call_these)
         finalize_update_mock.assert_called_with('12345678')


### PR DESCRIPTION
--auto-correct-types flag issued with plugins update should be passed
down to the deployments update flows.