### PR TITLE
RD-1397 Allow schedules handle complex weekdays

### DIFF
--- a/rest-service/manager_rest/test/endpoints/test_execution_schedules.py
+++ b/rest-service/manager_rest/test/endpoints/test_execution_schedules.py
@@ -134,7 +134,7 @@ class ExecutionSchedulesTestCase(BaseServerTestCase):
     def test_schedule_invalid_weekdays(self):
         self.assertRaisesRegex(
             CloudifyClientError,
-            '400: weekdays list contains invalid weekdays',
+            '400:.* invalid weekday',
             self.client.execution_schedules.create,
             'bad-weekdays', self.deployment_id, 'install',
             since=self.an_hour_from_now, frequency='4 hours',
@@ -147,7 +147,7 @@ class ExecutionSchedulesTestCase(BaseServerTestCase):
         )
         self.assertRaisesRegex(
             CloudifyClientError,
-            '400: weekdays list contains invalid weekdays',
+            '400:.* invalid weekday',
             self.client.execution_schedules.update,
             'good-weekdays', weekdays='oneday, someday'
         )

--- a/rest-service/manager_rest/test/infrastructure/test_scheduling_rules.py
+++ b/rest-service/manager_rest/test/infrastructure/test_scheduling_rules.py
@@ -28,6 +28,23 @@ class SchedulingRulesTest(BaseServerTestCase):
         }
         self._assert_dates(since, until, rule, 5, expected_dates)
 
+    def test_parse_rule_complex_weekdays(self):
+        since = '2018-1-1T00:00:00.000Z'
+        until = None
+        rule = {
+            'frequency': '2 mo',
+            'count': 5,
+            'weekdays': ['2MO', '3TU']
+        }
+        expected_dates = {
+            '2018-01-08 00:00:00',
+            '2018-01-16 00:00:00',
+            '2018-03-12 00:00:00',
+            '2018-03-20 00:00:00',
+            '2018-05-14 00:00:00',
+        }
+        self._assert_dates(since, until, rule, 5, expected_dates)
+
     def test_parse_rule_raw_format(self):
         since = '2018-1-1T00:00:00.000Z'
         until = '2019-1-2T00:00:00.000Z'

--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'psutil==5.7.2',
     'virtualenv==15.1.0',
     'wagon>=0.9.1',
-    'python-dateutil==2.5.3',
+    'python-dateutil==2.8.1',
     'voluptuous==0.9.3',
     'pika==1.1.0',
     'cryptography==3.3.1',

--- a/workflows/setup.py
+++ b/workflows/setup.py
@@ -29,7 +29,7 @@ setup(
         'retrying==1.3.3',
         'psycopg2==2.7.4',
         'cryptography==3.3.1',
-        'python-dateutil==2.5.3',
+        'python-dateutil==2.8.1',
         'pytz==2021.1',
     ]
 )


### PR DESCRIPTION
This allows the user to specify complex weekday rules (via CLI or a blueprint), such as ''3mo, l-fr", which will evaluate to "run every 3rd Monday and last Friday of a month"