### PR TITLE
RD-1515 Add --auto-correct-types to plugins update

### DIFF
--- a/rest-service/manager_rest/plugins_update/constants.py
+++ b/rest-service/manager_rest/plugins_update/constants.py
@@ -44,6 +44,7 @@ ALL_TO_LATEST = 'all_to_latest'
 TO_MINOR = 'to_minor'
 ALL_TO_MINOR = 'all_to_minor'
 MAPPING = 'mapping'
+AUTO_CORRECT_TYPES = 'auto_correct_types'
 
 UPDATES = 'updates'
 PLUGIN_NAME = 'plugin_name'

--- a/rest-service/manager_rest/plugins_update/manager.py
+++ b/rest-service/manager_rest/plugins_update/manager.py
@@ -95,7 +95,8 @@ class PluginsUpdateManager(object):
         plugins_update.set_blueprint(blueprint)
         return self.sm.put(plugins_update)
 
-    def initiate_plugins_update(self, blueprint_id, filters):
+    def initiate_plugins_update(self, blueprint_id, filters,
+                                auto_correct_types=False):
         """Creates a temporary blueprint and executes the plugins update
         workflow.
         """
@@ -124,8 +125,9 @@ class PluginsUpdateManager(object):
             plugins_update.state = STATES.UPDATING
             self.sm.update(plugins_update)
 
-        plugins_update.execution = get_resource_manager(
-            self.sm).update_plugins(plugins_update, not changes_required)
+        plugins_update.execution = \
+            get_resource_manager(self.sm).update_plugins(
+                plugins_update, not changes_required, auto_correct_types)
         plugins_update.state = (STATES.EXECUTING_WORKFLOW if changes_required
                                 else STATES.NO_CHANGES_REQUIRED)
         return self.sm.update(plugins_update)

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -304,7 +304,9 @@ class ResourceManager(object):
                 )
         return True
 
-    def update_plugins(self, plugins_update, no_changes_required=False):
+    def update_plugins(self, plugins_update,
+                       no_changes_required=False,
+                       auto_correct_types=False):
         """Executes the plugin update workflow.
 
         :param plugins_update: a PluginUpdate object.
@@ -318,7 +320,8 @@ class ResourceManager(object):
             execution_parameters={
                 'update_id': plugins_update.id,
                 'deployments_to_update': plugins_update.deployments_to_update,
-                'temp_blueprint_id': plugins_update.temp_blueprint_id
+                'temp_blueprint_id': plugins_update.temp_blueprint_id,
+                'auto_correct_types': auto_correct_types,
             },
             verify_no_executions=False,
             fake_execution=no_changes_required)

--- a/rest-service/manager_rest/rest/resources_v3_1/plugins.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/plugins.py
@@ -31,7 +31,8 @@ from manager_rest.plugins_update.constants import (PLUGIN_NAMES,
                                                    ALL_TO_LATEST,
                                                    TO_MINOR,
                                                    ALL_TO_MINOR,
-                                                   MAPPING)
+                                                   MAPPING,
+                                                   AUTO_CORRECT_TYPES)
 from manager_rest.plugins_update.manager import get_plugins_updates_manager
 from manager_rest.rest import (resources_v2,
                                resources_v2_1,
@@ -112,12 +113,15 @@ class PluginsUpdate(SecuredResource):
                 ALL_TO_MINOR: {'type': bool, 'optional': True},
                 TO_MINOR: {'type': list, 'optional': True},
                 MAPPING: {'type': dict, 'optional': True},
+                AUTO_CORRECT_TYPES: {'type': bool, 'optional': True},
             })
         except BadRequest:
             filters = {}
+        auto_correct_types = filters.pop(AUTO_CORRECT_TYPES, False)
         if phase == PHASES.INITIAL:
             return get_plugins_updates_manager().initiate_plugins_update(
-                blueprint_id=id, filters=filters)
+                blueprint_id=id, filters=filters,
+                auto_correct_types=auto_correct_types)
         elif phase == PHASES.FINAL:
             return get_plugins_updates_manager().finalize(
                 plugins_update_id=id)

--- a/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
@@ -146,7 +146,7 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
              'auto_correct_types': False})
 
     def test_plugins_update_auto_correct_types_flag(self):
-        self.put_blueprint(blueprint_id='hello_world')
+        self.put_file(*self.put_blueprint_args(blueprint_id='hello_world'))
         self.client.deployments.create('hello_world', 'dep')
         self.wait_for_deployment_creation(self.client, 'dep')
         plugins_update = self.client.plugins_update.update_plugins(

--- a/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
@@ -142,7 +142,23 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
             execution.parameters,
             {'update_id': plugins_update.id,
              'deployments_to_update': ['d1', 'd2'],
-             'temp_blueprint_id': plugins_update.temp_blueprint_id})
+             'temp_blueprint_id': plugins_update.temp_blueprint_id,
+             'auto_correct_types': False})
+
+    def test_plugins_update_auto_correct_types_flag(self):
+        self.put_blueprint(blueprint_id='hello_world')
+        self.client.deployments.create('hello_world', 'dep')
+        self.wait_for_deployment_creation(self.client, 'dep')
+        plugins_update = self.client.plugins_update.update_plugins(
+            'hello_world', auto_correct_types=True)
+        self.assertEqual(['dep'], plugins_update.deployments_to_update)
+        execution = self.client.executions.get(plugins_update.execution_id)
+        self.assertEqual(
+            execution.parameters,
+            {'update_id': plugins_update.id,
+             'deployments_to_update': ['dep'],
+             'temp_blueprint_id': plugins_update.temp_blueprint_id,
+             'auto_correct_types': True})
 
     def test_raises_while_plugins_updates_are_active(self):
         self.put_file(*self.put_blueprint_args(blueprint_id='hello_world'))

--- a/workflows/cloudify_system_workflows/plugins.py
+++ b/workflows/cloudify_system_workflows/plugins.py
@@ -54,7 +54,8 @@ def _operate_on_plugin(ctx, plugin, action):
 
 
 @workflow(system_wide=True)
-def update(ctx, update_id, temp_blueprint_id, deployments_to_update, **_):
+def update(ctx, update_id, temp_blueprint_id, deployments_to_update,
+           auto_correct_types, **_):
     """Execute deployment update for all the given deployments_to_update.
 
     :param update_id: plugins update ID.
@@ -62,22 +63,29 @@ def update(ctx, update_id, temp_blueprint_id, deployments_to_update, **_):
     this workflow only.
     :param deployments_to_update: deployments to perform the update on, using
     the temp blueprint ID provided.
+    :param auto_correct_types: update deployments with auto_correct_types flag,
+     which will attempt to cast inputs to the types defined by the blueprint.
     """
 
     def get_wait_for_execution_message(execution_id):
         return 'Deployment update has failed with execution ID: ' \
                '{0}.'.format(execution_id)
 
+    ctx.logger.info('Executing update_plugin system workflow with flag: '
+                    'auto_correct_types={0}'.format(auto_correct_types))
+
     client = get_rest_client()
     for dep in deployments_to_update:
         ctx.send_event('Executing deployment update for deployment '
                        '{}...'.format(dep))
         execution_id = client.deployment_updates \
-            .update_with_existing_blueprint(deployment_id=dep,
-                                            blueprint_id=temp_blueprint_id,
-                                            skip_install=True,
-                                            skip_uninstall=True,
-                                            skip_reinstall=True) \
+            .update_with_existing_blueprint(
+                deployment_id=dep,
+                blueprint_id=temp_blueprint_id,
+                skip_install=True,
+                skip_uninstall=True,
+                skip_reinstall=True,
+                auto_correct_types=auto_correct_types) \
             .execution_id
 
         wait_for(client.executions.get,

--- a/workflows/cloudify_system_workflows/tests/test_plugins.py
+++ b/workflows/cloudify_system_workflows/tests/test_plugins.py
@@ -109,12 +109,14 @@ class TestPluginsUpdate(unittest.TestCase):
                     "Deployment update of deployment {0} with execution ID {0}"
                     " failed, stopped this plugins update "
                     "\\(id='my_update_id'\\)\\.".format(failed_execution_id)):
-                update_func(MagicMock(), 'my_update_id', None, dep_ids)
+                update_func(MagicMock(), 'my_update_id', None,
+                            dep_ids, False)
             should_call_these = [call(deployment_id=i,
                                       blueprint_id=None,
                                       skip_install=True,
                                       skip_uninstall=True,
-                                      skip_reinstall=True)
+                                      skip_reinstall=True,
+                                      auto_correct_types=False)
                                  for i in range(failed_execution_id)]
             self.deployment_update_mock.assert_has_calls(should_call_these)
 
@@ -122,7 +124,8 @@ class TestPluginsUpdate(unittest.TestCase):
                                           blueprint_id=None,
                                           skip_install=True,
                                           skip_uninstall=True,
-                                          skip_reinstall=True)
+                                          skip_reinstall=True,
+                                          auto_correct_types=False)
                                      for i in range(
                     failed_execution_id + 1, len(dep_ids))]
             for _call in self.deployment_update_mock.mock_calls:
@@ -146,12 +149,13 @@ class TestPluginsUpdate(unittest.TestCase):
             = finalize_update_mock
         self.mock_rest_client.executions.get \
             .return_value = PropertyMock(status=ExecutionState.TERMINATED)
-        update_func(MagicMock(), '12345678', None, dep_ids)
+        update_func(MagicMock(), '12345678', None, dep_ids, False)
         should_call_these = [call(deployment_id=i,
                                   blueprint_id=None,
                                   skip_install=True,
                                   skip_uninstall=True,
-                                  skip_reinstall=True)
+                                  skip_reinstall=True,
+                                  auto_correct_types=False)
                              for i in range(len(dep_ids))]
         self.deployment_update_mock.assert_has_calls(should_call_these)
         finalize_update_mock.assert_called_with('12345678')


### PR DESCRIPTION
* Pass auto-correct-types to update_plugin workflow

--auto-correct-types flag issued with plugins update should be passed
down to the deploymetns update flows.  This patch is the first step on
this path – it passes this flag to the update_plugin system workflow in
execution_parameters dictionary.  The use of the dictionary and not
another database column is a consequence of the commitment not to modify
the database schema in patch releases (and this patch is intended to be
a part of 5.1.3 release).

* Tests fix

* One more test fix (workflows' test_plugins)