### PR TITLE
RD-1480 Expose latest execution state for deployment

### DIFF
--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -157,7 +157,7 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         self.sm.put(dep)
 
         serialized_dep = dep.to_response()
-        self.assertEqual(23, len(serialized_dep))
+        self.assertEqual(26, len(serialized_dep))
         self.assertEqual(dep.id, serialized_dep['id'])
         self.assertEqual(dep.created_at, serialized_dep['created_at'])
         self.assertEqual(dep.updated_at, serialized_dep['updated_at'])
@@ -171,6 +171,7 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         serialized_dep.pop('tenant_name')
         serialized_dep.pop('created_by')
         serialized_dep.pop('site_name')
+        serialized_dep.pop('latest_execution_status')
 
         # Deprecated columns, for backwards compatibility -
         # was added to the response

--- a/tests/integration_tests/resources/dsl/sleep_workflows.yaml
+++ b/tests/integration_tests/resources/dsl/sleep_workflows.yaml
@@ -15,6 +15,7 @@ node_templates:
 
 workflows:
     sleep: mock_workflows.mock_workflows.workflows.sleep
+    simple_sleep: mock_workflows.mock_workflows.workflows.simple_sleep
     sleep_with_graph_usage: mock_workflows.mock_workflows.workflows.sleep_with_graph_usage
     sleep_with_cancel_support:
         mapping: mock_workflows.mock_workflows.workflows.sleep_with_cancel_support

--- a/tests/integration_tests/tests/agentless_tests/test_deployment_statuses.py
+++ b/tests/integration_tests/tests/agentless_tests/test_deployment_statuses.py
@@ -1,0 +1,382 @@
+import time
+
+import pytest
+
+from integration_tests import AgentlessTestCase
+from integration_tests.tests.utils import (
+    get_resource as resource,
+    generate_scheduled_for_date
+)
+
+from cloudify.models_states import ExecutionState as Execution
+from cloudify.models_states import DeploymentState
+
+
+@pytest.mark.usefixtures('cloudmock_plugin')
+@pytest.mark.usefixtures('mock_workflows_plugin')
+@pytest.mark.usefixtures('testmockoperations_plugin')
+class DeploymentStatuses(AgentlessTestCase):
+
+    def _force_deployment_to_be_queued(self, deployment_id):
+        execution_1 = self.client.snapshots.create('snapshot_1',
+                                                   include_credentials=True,
+                                                   include_logs=True,
+                                                   include_events=True,
+                                                   include_metrics=True,
+                                                   queue=True)
+        self.wait_for_execution_to_end(execution_1)
+        self.manually_update_execution_status(
+            Execution.STARTED,
+            execution_1.id
+        )
+        execution_2 = self.execute_workflow(
+            workflow_name='install',
+            deployment_id=deployment_id,
+            wait_for_execution=False,
+            queue=True
+        )
+        return execution_1, execution_2
+
+    def test_deployment_statuses_after_creation(self):
+        dsl_path = resource("dsl/basic.yaml")
+        deployment = self.deploy(dsl_path)
+        deployment = self.client.deployments.get(deployment.id)
+        self.assertEqual(
+            deployment.latest_execution_status,
+            DeploymentState.COMPLETED
+        )
+        self.assertEqual(
+            deployment.installation_status,
+            DeploymentState.INACTIVE
+        )
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.REQUIRE_ATTENTION
+        )
+
+    def test_deployment_statuses_after_install(self):
+        dsl_path = resource("dsl/basic.yaml")
+        deployment = self.deploy(dsl_path)
+
+        self.execute_workflow(workflow_name='install',
+                              deployment_id=deployment.id,
+                              wait_for_execution=True)
+
+        deployment = self.client.deployments.get(deployment.id)
+        self.assertEqual(
+            deployment.latest_execution_status,
+            DeploymentState.COMPLETED
+        )
+        self.assertEqual(
+            deployment.installation_status,
+            DeploymentState.ACTIVE
+        )
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.GOOD
+        )
+
+    def test_deployment_statuses_after_uninstall(self):
+        dsl_path = resource("dsl/basic.yaml")
+        deployment = self.deploy(dsl_path)
+
+        self.execute_workflow(workflow_name='install',
+                              deployment_id=deployment.id,
+                              wait_for_execution=True)
+
+        self.execute_workflow(workflow_name='uninstall',
+                              deployment_id=deployment.id,
+                              wait_for_execution=True)
+
+        deployment = self.client.deployments.get(deployment.id)
+        self.assertEqual(
+            deployment.latest_execution_status,
+            DeploymentState.COMPLETED
+        )
+        # Uninstall mark all node instances as "delete"
+        self.assertEqual(
+            deployment.installation_status,
+            DeploymentState.INACTIVE
+        )
+        # Since the installation_state is "inactive" then the
+        # deployment_status should be "require_attention"
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.REQUIRE_ATTENTION
+        )
+
+    def test_deployment_statuses_after_cancel_without_install_nodes(self):
+        # Create deployment environment + execute "sleep_with_cancel_support"
+        dsl_path = resource("dsl/sleep_workflows.yaml")
+        deployment = self.deploy(dsl_path)
+        execution = self.execute_workflow(
+            workflow_name='simple_sleep',
+            deployment_id=deployment.id,
+            wait_for_execution=False
+        )
+
+        execution = self.client.executions.cancel(execution.id)
+        self.wait_for_execution_to_end(execution)
+
+        deployment = self.client.deployments.get(deployment.id)
+        self.assertEqual(
+            deployment.latest_execution_status,
+            DeploymentState.CANCELLED
+        )
+        self.assertEqual(
+            deployment.installation_status,
+            DeploymentState.INACTIVE
+        )
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.REQUIRE_ATTENTION
+        )
+
+    def test_deployment_statuses_after_cancel_with_install_nodes(self):
+        dsl_path = resource("dsl/sleep_workflows.yaml")
+        deployment = self.deploy(dsl_path)
+        self.execute_workflow(workflow_name='install',
+                              deployment_id=deployment.id,
+                              wait_for_execution=True)
+
+        execution = self.execute_workflow(
+            workflow_name='simple_sleep',
+            deployment_id=deployment.id,
+            wait_for_execution=False
+        )
+        execution = self.client.executions.cancel(execution.id)
+        self.wait_for_execution_to_end(execution)
+
+        deployment = self.client.deployments.get(deployment.id)
+        self.assertEqual(
+            deployment.latest_execution_status,
+            DeploymentState.CANCELLED
+        )
+        self.assertEqual(
+            deployment.installation_status,
+            DeploymentState.ACTIVE
+        )
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.GOOD
+        )
+
+    def test_deployment_statuses_during_cancelling_without_install_nodes(self):
+        # Create deployment environment + execute "sleep_with_cancel_support"
+        dsl_path = resource("dsl/sleep_workflows.yaml")
+        deployment = self.deploy(dsl_path)
+        execution = self.execute_workflow(
+            workflow_name='simple_sleep',
+            deployment_id=deployment.id,
+            wait_for_execution=False
+        )
+
+        self.client.executions.cancel(execution.id)
+        deployment = self.client.deployments.get(deployment.id)
+        self.assertEqual(
+            deployment.latest_execution_status,
+            DeploymentState.IN_PROGRESS
+        )
+        self.assertEqual(
+            deployment.installation_status,
+            DeploymentState.INACTIVE
+        )
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.IN_PROGRESS
+        )
+
+    def test_deployment_statuses_during_cancelling_with_install_nodes(self):
+        dsl_path = resource("dsl/sleep_workflows.yaml")
+        deployment = self.deploy(dsl_path)
+        self.execute_workflow(workflow_name='install',
+                              deployment_id=deployment.id,
+                              wait_for_execution=True)
+
+        execution = self.execute_workflow(
+            workflow_name='simple_sleep',
+            deployment_id=deployment.id,
+            wait_for_execution=False
+        )
+
+        self.client.executions.cancel(execution.id)
+        deployment = self.client.deployments.get(deployment.id)
+        self.assertEqual(
+            deployment.latest_execution_status,
+            DeploymentState.IN_PROGRESS
+        )
+        self.assertEqual(
+            deployment.installation_status,
+            DeploymentState.ACTIVE
+        )
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.IN_PROGRESS
+        )
+
+    def test_deployment_statuses_during_kill_cancelling(self):
+        dsl_path = resource("dsl/sleep_workflows.yaml")
+        deployment = self.deploy(dsl_path)
+        self.execute_workflow(workflow_name='install',
+                              deployment_id=deployment.id,
+                              wait_for_execution=True)
+
+        execution = self.execute_workflow(
+            workflow_name='simple_sleep',
+            deployment_id=deployment.id,
+            wait_for_execution=False
+        )
+
+        self.client.executions.cancel(execution.id, kill=True)
+        deployment = self.client.deployments.get(deployment.id)
+        self.assertIn(
+            deployment.latest_execution_status,
+            [DeploymentState.IN_PROGRESS, DeploymentState.CANCELLED]
+        )
+        self.assertEqual(
+            deployment.installation_status,
+            DeploymentState.ACTIVE
+        )
+        if deployment.latest_execution_status == DeploymentState.CANCELLED:
+            self.assertEqual(
+                deployment.deployment_status,
+                DeploymentState.GOOD
+            )
+        else:
+            self.assertEqual(
+                deployment.deployment_status,
+                DeploymentState.IN_PROGRESS
+            )
+
+    def test_deployment_statuses_after_failed_workflow(self):
+        dsl_path = resource('dsl/workflow_api.yaml')
+        deployment = self.deploy(dsl_path)
+        self.execute_workflow(workflow_name='install',
+                              deployment_id=deployment.id,
+                              wait_for_execution=True)
+
+        with self.assertRaises(RuntimeError):
+            self.execute_workflow(
+                workflow_name='execute_operation',
+                deployment_id=deployment.id,
+                parameters={
+                    'operation': 'test.fail',
+                    'node_ids': ['test_node']
+                },
+                wait_for_execution=True
+            )
+
+        deployment = self.client.deployments.get(deployment.id)
+        self.assertEqual(
+            deployment.latest_execution_status,
+            DeploymentState.FAILED
+        )
+        self.assertEqual(
+            deployment.installation_status,
+            DeploymentState.ACTIVE
+        )
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.REQUIRE_ATTENTION
+        )
+
+    def test_deployment_statuses_for_scheduled_execution(self):
+        dsl_path = resource("dsl/basic.yaml")
+        deployment = self.deploy(dsl_path)
+        deployment = self.client.deployments.get(deployment.id)
+        scheduled_time = generate_scheduled_for_date()
+        execution = self.client.executions.start(deployment_id=deployment.id,
+                                                 workflow_id='install',
+                                                 schedule=scheduled_time)
+        self.assertEqual(Execution.SCHEDULED, execution.status)
+        self.assertEqual(
+            deployment.latest_execution_status,
+            DeploymentState.COMPLETED
+        )
+        self.assertEqual(
+            deployment.installation_status,
+            DeploymentState.INACTIVE
+        )
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.REQUIRE_ATTENTION
+        )
+        # Wait for exec to 'wake up'
+        time.sleep(62)
+        self.wait_for_execution_to_end(execution)
+        deployment = self.client.deployments.get(deployment.id)
+        self.assertEqual(
+            deployment.latest_execution_status,
+            DeploymentState.COMPLETED,
+        )
+        self.assertEqual(
+            deployment.installation_status,
+            DeploymentState.ACTIVE,
+        )
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.GOOD,
+        )
+
+    def test_deployment_statuses_for_queued_execution(self):
+        dsl_path = resource("dsl/basic.yaml")
+        deployment = self.deploy(dsl_path)
+        self._force_deployment_to_be_queued(deployment.id)
+
+        deployment = self.client.deployments.get(deployment.id)
+        self.assertEqual(
+            deployment.latest_execution_status,
+            DeploymentState.IN_PROGRESS
+        )
+        self.assertEqual(
+            deployment.installation_status,
+            DeploymentState.INACTIVE
+        )
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.IN_PROGRESS
+        )
+
+    def test_deployment_statuses_after_queued_execution_finish(self):
+        dsl_path = resource("dsl/basic.yaml")
+        deployment = self.deploy(dsl_path)
+        exe1, exe2 = self._force_deployment_to_be_queued(deployment.id)
+
+        self.client.executions.update(exe1.id, Execution.TERMINATED)
+        queued_execution = self.client.executions.get(exe2.id)
+        self.wait_for_execution_to_end(queued_execution)
+
+        deployment = self.client.deployments.get(deployment.id)
+        self.assertEqual(
+            deployment.latest_execution_status,
+            DeploymentState.COMPLETED
+        )
+        self.assertEqual(
+            deployment.installation_status,
+            DeploymentState.ACTIVE
+        )
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.GOOD
+        )
+
+    def test_deployment_statuses_after_dry_run(self):
+        dsl_path = resource("dsl/basic.yaml")
+        _, execution_id = self.deploy_application(dsl_path,
+                                                  wait_for_execution=True,
+                                                  dry_run=True)
+
+        execution = self.client.executions.get(execution_id)
+        deployment = self.client.deployments.get(execution.deployment_id)
+        self.assertEqual(
+            deployment.latest_execution_status,
+            DeploymentState.COMPLETED,
+        )
+        self.assertEqual(
+            deployment.installation_status,
+            DeploymentState.INACTIVE,
+        )
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.REQUIRE_ATTENTION,
+        )

--- a/tests/integration_tests/tests/agentless_tests/test_executions.py
+++ b/tests/integration_tests/tests/agentless_tests/test_executions.py
@@ -43,7 +43,7 @@ class ExecutionsTest(AgentlessTestCase):
 
     def _wait_for_exec_to_end_and_modify_status(self, execution, new_status):
         self.wait_for_execution_to_end(execution)
-        self._manually_update_execution_status(new_status, execution.id)
+        self.manually_update_execution_status(new_status, execution.id)
         self._assert_execution_status(execution.id, new_status)
 
         return execution
@@ -84,13 +84,6 @@ class ExecutionsTest(AgentlessTestCase):
                                            _all_tenants=True,
                                            _offset=0,
                                            _size=1000).items
-
-    def _manually_update_execution_status(self, new_status, id):
-        run_postgresql_command(
-            self.env.container_id,
-            "UPDATE executions SET status = '{0}' WHERE id = '{1}'"
-                .format(new_status, id)
-        )
 
     def _assert_execution_status(self, execution_id,
                                  wanted_status, client=None):

--- a/tests/integration_tests/tests/test_cases.py
+++ b/tests/integration_tests/tests/test_cases.py
@@ -44,6 +44,7 @@ from integration_tests.tests.utils import (
     wait_for_deployment_creation_to_complete,
     wait_for_deployment_deletion_to_complete,
     verify_deployment_env_created,
+    run_postgresql_command,
     do_retries
 )
 
@@ -527,6 +528,13 @@ class AgentlessTestCase(BaseTestCase):
             compared_labels_set.add((key, value))
 
         self.assertEqual(simplified_labels, compared_labels_set)
+
+    def manually_update_execution_status(self, new_status, id):
+        run_postgresql_command(
+            self.env.container_id,
+            "UPDATE executions SET status = '{0}' WHERE id = '{1}'"
+                .format(new_status, id)
+        )
 
 
 class BaseAgentTestCase(BaseTestCase):


### PR DESCRIPTION
The objective behind this PR is to add support for multiple deployment statuses related to the following:
1. `latest_execution_status`: and this represent the latest execution workflow by translating the execution values to the following one:
    - in_progres
    - completed
    - cancelled
    - failed
2. `installation_status`: and this is mainly to check if the deployment status is active or inactive by checking the statuses of node instances associated with the deployment
3. `deployment_status`: and this represent the overall status based on the the values generated by `latest_execution_status` &&   `installation_status`

later  on we are going to expose sub_services and sub_environments statuses so that we can get a full picture of whats going on  
