### PR TITLE
dep-groups PUT: allow the "inputs" parameter

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -469,6 +469,7 @@ class DeploymentGroupsId(SecuredResource):
             'blueprint_id': {'optional': True},
             'default_inputs': {'optional': True},
             'visibility': {'optional': True},
+            'inputs': {'optional': True},
         })
         sm = get_storage_manager()
         try:


### PR DESCRIPTION
'inputs' is used in `_add_group_deployments`, and is used in tests