### PR TITLE
RD-1506 + RD-1568 Add specialized execution FKs

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -377,7 +377,7 @@ class ResourceManager(object):
 
     def upload_blueprint(self, blueprint_id, app_file_name, blueprint_url,
                          file_server_root, validate_only=False, labels=None):
-        self._execute_system_workflow(
+        return self._execute_system_workflow(
             wf_id='upload_blueprint',
             task_mapping='cloudify_system_workflows.blueprint.upload',
             verify_no_executions=False,

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2148,7 +2148,7 @@ class ResourceManager(object):
         wf_id = 'create_deployment_environment'
         deployment_env_creation_task_name = \
             'cloudify_system_workflows.deployment_environment.create'
-        self._execute_system_workflow(
+        create_execution = self._execute_system_workflow(
             wf_id=wf_id,
             task_mapping=deployment_env_creation_task_name,
             deployment=deployment,
@@ -2167,6 +2167,8 @@ class ResourceManager(object):
                 }
             }
         )
+        deployment.create_execution = create_execution
+        self.sm.update(deployment)
 
     def _check_for_active_executions(self, deployment_id, force,
                                      queue, schedule):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -366,6 +366,7 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
                                foreign_keys=[cls._create_execution_fk],
                                cascade='all, delete',
                                post_update=True)
+
     @declared_attr
     def blueprint(cls):
         return one_to_many_relationship(cls, Blueprint, cls._blueprint_fk)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -342,11 +342,20 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
     _site_fk = foreign_key(Site._storage_id,
                            nullable=True,
                            ondelete='SET NULL')
+    _create_execution_fk = foreign_key('executions._storage_id',
+                                       nullable=True,
+                                       ondelete='SET NULL')
 
     @classproperty
     def labels_model(cls):
         return DeploymentLabel
 
+    @declared_attr
+    def create_execution(cls):
+        """The create-deployment-environment execution for this deployment"""
+        return db.relationship('Execution',
+                               foreign_keys=[cls._create_execution_fk],
+                               cascade='all, delete')
     @declared_attr
     def blueprint(cls):
         return one_to_many_relationship(cls, Blueprint, cls._blueprint_fk)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -364,7 +364,8 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         """The create-deployment-environment execution for this deployment"""
         return db.relationship('Execution',
                                foreign_keys=[cls._create_execution_fk],
-                               cascade='all, delete')
+                               cascade='all, delete',
+                               post_update=True)
     @declared_attr
     def blueprint(cls):
         return one_to_many_relationship(cls, Blueprint, cls._blueprint_fk)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -92,6 +92,9 @@ class Blueprint(CreatedAtMixin, SQLResourceBase):
     state = db.Column(db.Text)
     error = db.Column(db.Text)
     error_traceback = db.Column(db.Text)
+    _upload_execution_fk = foreign_key('executions._storage_id',
+                                       nullable=True,
+                                       ondelete='SET NULL')
 
     @classproperty
     def labels_model(cls):
@@ -101,6 +104,12 @@ class Blueprint(CreatedAtMixin, SQLResourceBase):
     def labels(cls):
         # labels are defined as `backref` in DeploymentsLabel model
         return None
+
+    @declared_attr
+    def upload_execution(cls):
+        return db.relationship('Execution',
+                               foreign_keys=[cls._upload_execution_fk],
+                               cascade='all, delete')
 
     @classproperty
     def response_fields(cls):

--- a/rest-service/manager_rest/upload_manager.py
+++ b/rest-service/manager_rest/upload_manager.py
@@ -541,13 +541,14 @@ class UploadedBlueprintsManager(UploadedDataManager):
             self.upload_archive_to_file_server(data_id)
 
         try:
-            rm.upload_blueprint(
+            new_blueprint.upload_execution = rm.upload_blueprint(
                 data_id,
                 application_file_name,
                 blueprint_url,
                 config.instance.file_server_root,   # for the import resolver
                 labels=labels
             )
+            rm.sm.update(new_blueprint)
         except manager_exceptions.ExistingRunningExecutionError as e:
             new_blueprint.state = BlueprintUploadState.FAILED_UPLOADING
             new_blueprint.error = str(e)
@@ -716,7 +717,7 @@ class UploadedBlueprintsValidator(UploadedBlueprintsManager):
             self.upload_archive_to_file_server(data_id)
 
         try:
-            rm.upload_blueprint(
+            temp_blueprint.upload_execution = rm.upload_blueprint(
                 data_id,
                 application_file_name,
                 blueprint_url,


### PR DESCRIPTION
- FK in the deployments table that points to the create-dep-env execution
- FK in the blueprints table that points to the upload-blueprint execution

Both are nullable so that snapshot-restore doesn't need any special treatment.
They'll just be null. (and old versions don't have an upload-blueprint
execution anyway)

`ondelete=SET NULL` means that when the execution is deleted, the FK is set to null.
`cascade='all, delete'` means that when the deployment is deleted (but only from the orm),
the execution is deleted as well.