### PR TITLE
RD-1519 Modify filters value column

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
+++ b/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
@@ -23,9 +23,11 @@ def upgrade():
     _create_blueprints_labels_table()
     _modify_deployments_labels_table()
     _add_specialized_execution_fk()
+    _modify_filters_table()
 
 
 def downgrade():
+    _modify_filters_table()
     _drop_specialized_execution_fk()
     _revert_changes_to_deployments_labels_table()
     _drop_blueprints_labels_table()
@@ -174,6 +176,15 @@ def _modify_deployments_labels_table():
     op.drop_column('deployments_labels', '_deployment_fk')
 
 
+def _modify_filters_table():
+    op.add_column('filters',
+                  sa.Column('filtered_resource', sa.Text(), nullable=False))
+    op.create_index(op.f('filters_filtered_resource_idx'),
+                    'filters',
+                    ['filtered_resource'],
+                    unique=False)
+
+
 def _revert_changes_to_deployments_labels_table():
     op.add_column('deployments_labels',
                   sa.Column('_deployment_fk',
@@ -216,3 +227,8 @@ def _drop_blueprints_labels_table():
     op.drop_index(op.f('blueprints_labels__creator_id_idx'),
                   table_name='blueprints_labels')
     op.drop_table('blueprints_labels')
+
+
+def _revert_changes_to_filters_table():
+    op.drop_index(op.f('filters_filtered_resource_idx'), table_name='filters')
+    op.drop_column('filters', 'filtered_resource')

--- a/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
+++ b/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
@@ -27,7 +27,7 @@ def upgrade():
 
 
 def downgrade():
-    _modify_filters_table()
+    _revert_changes_to_deployments_labels_table()
     _drop_specialized_execution_fk()
     _revert_changes_to_deployments_labels_table()
     _drop_blueprints_labels_table()

--- a/rest-service/manager_rest/constants.py
+++ b/rest-service/manager_rest/constants.py
@@ -111,11 +111,8 @@ class FilterRuleType(str, Enum):
     ATTRIBUTE = 'attribute'
 
 
-LABELS_OPERATORS = [labels_operator.value for labels_operator in
-                    LabelsOperator.__members__.values()]
+LABELS_OPERATORS = [operator.value for operator in LabelsOperator]
 
-ATTRS_OPERATORS = [attrs_operator.value for attrs_operator in
-                   AttrsOperator.__members__.values()]
+ATTRS_OPERATORS = [attrs_operator.value for attrs_operator in AttrsOperator]
 
-FILTER_RULE_TYPES = [filter_rule_type.value for filter_rule_type in
-                     FilterRuleType.__members__.values()]
+FILTER_RULE_TYPES = [rule_type.value for rule_type in FilterRuleType]

--- a/rest-service/manager_rest/constants.py
+++ b/rest-service/manager_rest/constants.py
@@ -13,6 +13,10 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
+
+from enum import Enum
+
+
 CONVENTION_APPLICATION_BLUEPRINT_FILE = 'blueprint.yaml'
 
 SUPPORTED_ARCHIVE_TYPES = ['zip', 'tar', 'tar.gz', 'tar.bz2']
@@ -74,11 +78,6 @@ MODELS_TO_PERMISSIONS = {
 FORBIDDEN_METHODS = ['POST', 'PATCH', 'PUT']
 SANITY_MODE_FILE_PATH = '/opt/manager/sanity_mode'
 
-EQUAL = 'equal'
-NOT_EQUAL = 'not_equal'
-IS_NULL = 'is_null'
-IS_NOT_NULL = 'is_not_null'
-
 CFY_LABELS = {'csys-obj-name',
               'csys-obj-type',
               'csys-env-type',
@@ -89,3 +88,34 @@ CFY_LABELS = {'csys-obj-name',
               'csys-obj-parent'}
 
 CFY_LABELS_PREFIX = 'csys-'
+
+
+class LabelsOperator(str, Enum):
+    ANY_OF = 'any_of'
+    NOT_ANY_OF = 'not_any_of'
+    IS_NULL = 'is_null'
+    IS_NOT_NULL = 'is_not_null'
+
+
+class AttrsOperator(str, Enum):
+    ANY_OF = 'any_of'
+    NOT_ANY_OF = 'not_any_of'
+    CONTAIN = 'contain'
+    NOT_CONTAIN = 'not_contain'
+    START_WITH = 'start_with'
+    END_WITH = 'end_with'
+
+
+class FilterRuleType(str, Enum):
+    LABEL = 'label'
+    ATTRIBUTE = 'attribute'
+
+
+LABELS_OPERATORS = [labels_operator.value for labels_operator in
+                    LabelsOperator.__members__.values()]
+
+ATTRS_OPERATORS = [attrs_operator.value for attrs_operator in
+                   AttrsOperator.__members__.values()]
+
+FILTER_RULE_TYPES = [filter_rule_type.value for filter_rule_type in
+                     FilterRuleType.__members__.values()]

--- a/rest-service/manager_rest/manager_exceptions.py
+++ b/rest-service/manager_rest/manager_exceptions.py
@@ -13,6 +13,7 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
+from manager_rest.constants import FILTER_RULE_TYPES
 
 INTERNAL_SERVER_ERROR_CODE = 'internal_server_error'
 
@@ -632,4 +633,14 @@ class InvalidYamlFormat(ManagerException):
             InvalidYamlFormat.ERROR_CODE,
             *args,
             **kwargs
+        )
+
+
+class BadFilterRule(BadParametersError):
+    def __init__(self, err_filter_rule, suffix=''):
+        super(BadFilterRule, self).__init__(
+            f"The filter rule {err_filter_rule} is not in the right format. "
+            f"Filter rule is a dictionary of the form {{key: <key>, values: "
+            f"[<values>], operator: <operator>, "
+            f"type: <one of {', '.join(FILTER_RULE_TYPES)}>}}. {suffix}"
         )

--- a/rest-service/manager_rest/rest/endpoint_mapper.py
+++ b/rest-service/manager_rest/rest/endpoint_mapper.py
@@ -135,8 +135,10 @@ def setup_resources(api):
         'PermissionsRole': 'permissions/<string:role_name>',
         'PermissionsRoleId':
             'permissions/<string:role_name>/<string:permission_name>',
-        'Filters': 'filters',
-        'FiltersId': 'filters/<string:filter_id>',
+        'BlueprintsFilters': 'filters/blueprints',
+        'BlueprintsFiltersId': 'filters/blueprints/<string:filter_id>',
+        'DeploymentsFilters': 'filters/deployments',
+        'DeploymentsFiltersId': 'filters/deployments/<string:filter_id>',
         'DeploymentGroups': 'deployment-groups',
         'DeploymentGroupsId': 'deployment-groups/<string:group_id>',
         'ExecutionGroups': 'execution-groups',

--- a/rest-service/manager_rest/rest/filters_utils.py
+++ b/rest-service/manager_rest/rest/filters_utils.py
@@ -1,24 +1,20 @@
-import re
+from typing import List
 
 from flask import request
 
-from manager_rest import manager_exceptions
+from cloudify._compat import text_type
+
 from manager_rest.rest.rest_utils import validate_inputs
+from manager_rest.manager_exceptions import BadFilterRule, BadParametersError
 from manager_rest.storage import get_storage_manager, models
-from manager_rest.constants import EQUAL, NOT_EQUAL, IS_NULL, IS_NOT_NULL
+from manager_rest.constants import (ATTRS_OPERATORS,
+                                    FilterRuleType,
+                                    LabelsOperator,
+                                    LABELS_OPERATORS,
+                                    FILTER_RULE_TYPES)
 
 
-class BadLabelsFilter(manager_exceptions.BadParametersError):
-    def __init__(self, labels_filter_value):
-        super(BadLabelsFilter, self).__init__(
-            'The labels filter `{0}` is not in the right format. It must be '
-            'one of: <key>=<value>, <key>=[<value1>,<value2>,...], '
-            '<key>!=<value>, <key>!=[<value1>,<value2>,...], <key> is null, '
-            '<key> is not null'.format(labels_filter_value)
-        )
-
-
-def get_filter_rules():
+def get_filter_rules(resource_model: models):
     filter_rules = request.args.get('_filter_rules')
     filter_id = request.args.get('_filter_id')
 
@@ -26,104 +22,117 @@ def get_filter_rules():
         return
 
     if filter_rules and filter_id:
-        raise manager_exceptions.BadParametersError(
-            'Filter rules and filter name cannot be provided together. '
+        raise BadParametersError(
+            'Filter rules and filter ID cannot be provided together. '
             'Please specify one of them or neither.'
         )
 
     if filter_rules:
-        return create_labels_filters_mapping(filter_rules.split(','))
+        return parse_filter_rules(filter_rules, resource_model)
 
     if filter_id:
         validate_inputs({'filter_id': filter_id})
         filter_elem = get_storage_manager().get(models.Filter, filter_id)
-        return filter_elem.value.get('labels', {})
+        return filter_elem.value
 
 
-def create_labels_filters_mapping(labels_filters_list):
-    """Validate and parse a list of labels filters
+def parse_filter_rules(filter_rules: List[dict], resource_model: models):
+    """Validating the filter rules list.
 
-    :param labels_filters_list: A list of labels filters. Labels filters must
-           be one of: <key>=<value>, <key>=[<value1>,<value2>,...],
-           <key>!=<value>, <key>!=[<value1>,<value2>,...], <key> is null,
-           <key> is not null
-
-    :return The labels filters mapping dictionary with the following schema:
-            {NOT_EQUAL: {}, EQUAL: {}, IS_NULL: [], IS_NOT_NULL: []}
+    :param filter_rules: A list of filter rules. A filter rule is a dictionary
+           of the following form:
+           {
+               key: <key>,
+               values: [<list of values>],
+               operator: <LabelsOperator> or <AttrsOperator>,
+               type: <FilterRuleType>
+            }
+    :param resource_model: models.Deployment or models.Blueprint
+    :return: Parsed filter rules list
     """
-    labels_filters_mapping = {}
-    for labels_filter in labels_filters_list:
-        if '!=' in labels_filter:
-            label_key, label_values = _parse_labels_filter(labels_filter, '!=')
-            # a!=b and a!=c <=> a!=[b, c]
-            labels_filters_mapping.setdefault(NOT_EQUAL, {}).setdefault(
-                label_key, []).extend(label_values)
+    parsed_filter_rules = []
+    for filter_rule in filter_rules:
+        _assert_filter_rule_structure(filter_rule)
 
-        elif '=' in labels_filter:
-            label_key, label_values = _parse_labels_filter(labels_filter, '=')
-            labels_filters_mapping.setdefault(EQUAL, {})
-            if label_key in labels_filters_mapping[EQUAL]:
-                raise manager_exceptions.BadParametersError(
-                    'You cannot provide two filter rules with equal sign that '
-                    'have the same key. E.g. `a=b and a=c` is not allowed.')
+        filter_rule_key = filter_rule['key']
+        filter_rule_values = filter_rule['values']
+        filter_rule_type = filter_rule['type']
+        filter_rule_operator = filter_rule['operator']
 
-            labels_filters_mapping[EQUAL][label_key] = label_values
+        if not isinstance(filter_rule_key, text_type):
+            raise BadFilterRule(filter_rule,
+                                'The filter rule key must be of type string')
+        if not isinstance(filter_rule_values, list):
+            raise BadFilterRule(filter_rule,
+                                'The filter rule values must be of type list')
 
-        elif 'null' in labels_filter:
-            match_null = re.match(r'(\S+) is null', labels_filter)
-            match_not_null = re.match(r'(\S+) is not null', labels_filter)
-            if match_null:
-                labels_filters_mapping.setdefault(IS_NULL, []).append(
-                    match_null.group(1).lower())
-            elif match_not_null:
-                labels_filters_mapping.setdefault(IS_NOT_NULL, []).append(
-                    match_not_null.group(1).lower())
+        if filter_rule_type == FilterRuleType.LABEL:
+            null_operators = [LabelsOperator.IS_NULL,
+                              LabelsOperator.IS_NOT_NULL]
+            any_of_operators = [LabelsOperator.ANY_OF,
+                                LabelsOperator.NOT_ANY_OF]
+            if filter_rule_operator not in LABELS_OPERATORS:
+                raise BadFilterRule(
+                    filter_rule, f"The operator for filtering by labels must "
+                                 f"be one of {', '.join(LABELS_OPERATORS)}")
+            if filter_rule_operator in null_operators:
+                if len(filter_rule_values) > 0:
+                    raise BadFilterRule(
+                        filter_rule,
+                        f"Values list must be empty if the operator is one of "
+                        f"{', '.join(null_operators)}")
             else:
-                raise BadLabelsFilter(labels_filter)
+                if len(filter_rule_values) == 0:
+                    raise BadFilterRule(
+                        filter_rule,
+                        f"Values list must include at least one item if the "
+                        f"operator is one of {', '.join(any_of_operators)}")
+
+        elif filter_rule_type == FilterRuleType.ATTRIBUTE:
+            err_attr_msg = f"Allowed attributes to filter " \
+                           f"{resource_model.__tablename__} by are " \
+                           f"{','.join(resource_model.allowed_filter_attrs)}"
+            if filter_rule_operator not in ATTRS_OPERATORS:
+                raise BadFilterRule(
+                    filter_rule,
+                    f"The operator for filtering by attributes must be one"
+                    f" of {', '.join(ATTRS_OPERATORS)}")
+            if filter_rule_key not in resource_model.allowed_filter_attrs:
+                raise BadFilterRule(filter_rule, err_attr_msg)
 
         else:
-            raise BadLabelsFilter(labels_filter)
+            raise BadFilterRule(filter_rule,
+                                f"Filter rule type must be one of "
+                                f"{', '.join(FILTER_RULE_TYPES)}")
 
-    return labels_filters_mapping
+        value_msg_prefix = (None if len(filter_rule_values) == 1 else
+                            'One of the filter rule values')
 
+        parsed_values_list = []
+        for value in filter_rule_values:
+            try:
+                validate_inputs({'filter rule key': filter_rule_key})
+                validate_inputs({'filter rule value': value},
+                                err_prefix=value_msg_prefix)
+            except BadParametersError as e:
+                err_msg = f'The filter rule {filter_rule} is invalid. '
+                raise BadParametersError(err_msg + str(e))
+            parsed_values_list.append(value.lower())
 
-def _parse_labels_filter(labels_filter, sign):
-    """Validate and parse a labels filter
+        parsed_filter_rules.append({'key': filter_rule_key.lower(),
+                                    'values': parsed_values_list,
+                                    'operator': filter_rule_operator,
+                                    'type': filter_rule_type})
 
-    :param labels_filter: One of <key>=<value>, <key>=[<value1>,<value2>,...],
-           <key>!=<value>, <key>!=[<value1>,<value2>,...]
-    :param sign: Either '=' or '!='
-    :return: The labels_filter, with its key and value(s) in lowercase and
-             stripped of whitespaces
-    """
-    try:
-        raw_label_key, raw_label_value = labels_filter.split(sign)
-    except ValueError:  # e.g. a=b=c
-        raise BadLabelsFilter(labels_filter)
-
-    label_key = raw_label_key.strip().lower()
-    label_values = _get_label_value(raw_label_value.strip().lower())
-    value_msg_prefix = (None if len(label_values) == 1 else
-                        'One of the filter values')
-
-    parsed_label_values_list = []
-    for value in label_values:
-        try:
-            parsed_value = value.strip()
-            validate_inputs({'filter key': label_key})
-            validate_inputs({'filter value': parsed_value},
-                            err_prefix=value_msg_prefix)
-        except manager_exceptions.BadParametersError as e:
-            err_msg = 'The filter rule {0} is invalid. '.format(labels_filter)
-            raise manager_exceptions.BadParametersError(err_msg + str(e))
-
-        parsed_label_values_list.append(parsed_value)
-
-    return label_key, parsed_label_values_list
+    return parsed_filter_rules
 
 
-def _get_label_value(raw_label_value):
-    if raw_label_value.startswith('[') and raw_label_value.endswith(']'):
-        return raw_label_value.strip('[]').split(',')
+def _assert_filter_rule_structure(filter_rule):
+    if not isinstance(filter_rule, dict):
+        raise BadFilterRule(filter_rule, 'The filter rule is not a dictionary')
 
-    return [raw_label_value]
+    if not (all(key in filter_rule for key in
+                ['key', 'values', 'operator', 'type'])):
+        raise BadFilterRule(
+            filter_rule, 'At least one of the entries in the filter rule '
+                         'is missing')

--- a/rest-service/manager_rest/rest/resources_v2/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v2/blueprints.py
@@ -68,7 +68,7 @@ class Blueprints(resources_v1.Blueprints):
             sort=sort,
             all_tenants=all_tenants,
             get_all_results=get_all_results,
-            filter_rules=get_filter_rules()
+            filter_rules=get_filter_rules(models.Blueprint)
         )
 
 

--- a/rest-service/manager_rest/rest/resources_v2/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v2/deployments.py
@@ -75,7 +75,7 @@ class Deployments(resources_v1.Deployments):
             sort=sort,
             all_tenants=all_tenants,
             get_all_results=get_all_results,
-            filter_rules=get_filter_rules()
+            filter_rules=get_filter_rules(models.Deployment)
         )
 
         if _include and 'workflows' in _include:

--- a/rest-service/manager_rest/rest/resources_v3_1/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/__init__.py
@@ -118,8 +118,10 @@ from .permissions import (  # NOQA
 )
 
 from .filters import (                           # NOQA
-    Filters,
-    FiltersId,
+    BlueprintsFilters,
+    BlueprintsFiltersId,
+    DeploymentsFilters,
+    DeploymentsFiltersId
 )
 
 from .nodes import (  # NOQA

--- a/rest-service/manager_rest/rest/resources_v3_1/filters.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/filters.py
@@ -9,7 +9,7 @@ from manager_rest.rest import rest_decorators, rest_utils
 from manager_rest.security.authorization import authorize
 from manager_rest.storage import models, get_storage_manager
 from manager_rest.resource_manager import get_resource_manager
-from manager_rest.rest.filters_utils import parse_filter_rules
+from manager_rest.rest.filters_utils import create_filter_rules_list
 
 
 class BlueprintsFilters(SecuredResource):
@@ -68,8 +68,8 @@ class FiltersId(SecuredResource):
         rest_utils.validate_inputs({'filter_id': filter_id})
         request_dict = rest_utils.get_json_and_verify_params(
             {'filter_rules': {'type': list}})
-        filter_rules = parse_filter_rules(request_dict['filter_rules'],
-                                          filtered_resource)
+        filter_rules = create_filter_rules_list(request_dict['filter_rules'],
+                                                filtered_resource)
         visibility = rest_utils.get_visibility_parameter(
             optional=True, valid_values=VisibilityState.STATES)
 
@@ -131,8 +131,8 @@ class FiltersId(SecuredResource):
                 models.Filter, filter_elem, visibility)
             filter_elem.visibility = visibility
         if filter_rules:
-            filter_elem.value = parse_filter_rules(filter_rules,
-                                                   filtered_resource)
+            filter_elem.value = create_filter_rules_list(filter_rules,
+                                                         filtered_resource)
         filter_elem.updated_at = get_formatted_timestamp()
 
         return storage_manager.update(filter_elem)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -34,8 +34,7 @@ from manager_rest import config
 from manager_rest.rest.responses import Workflow, Label
 from manager_rest.utils import (get_rrule,
                                 classproperty,
-                                files_in_folder,
-                                get_filters_list_from_mapping)
+                                files_in_folder)
 from manager_rest.deployment_update.constants import ACTION_TYPES, ENTITY_TYPES
 from manager_rest.constants import (FILE_SERVER_PLUGINS_FOLDER,
                                     FILE_SERVER_RESOURCES_FOLDER)
@@ -117,6 +116,10 @@ class Blueprint(CreatedAtMixin, SQLResourceBase):
         fields['labels'] = flask_fields.List(
             flask_fields.Nested(Label.resource_fields))
         return fields
+
+    @classproperty
+    def allowed_filter_attrs(cls):
+        return ['created_by', 'description']
 
     def to_response(self, **kwargs):
         blueprint_dict = super(Blueprint, self).to_response()
@@ -395,6 +398,11 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         fields['deployment_groups'] = flask_fields.List(flask_fields.String)
         return fields
 
+    @classproperty
+    def allowed_filter_attrs(cls):
+        return ['blueprint_id', 'created_by', 'description', 'site_name',
+                'latest_execution_status']
+
     def to_response(self, **kwargs):
         dep_dict = super(Deployment, self).to_response()
         dep_dict['workflows'] = self._list_workflows(self.workflows)
@@ -526,11 +534,13 @@ class Filter(CreatedAtMixin, SQLResourceBase):
     _extra_fields = {'labels_filters': flask_fields.Raw}
 
     value = db.Column(JSONString, nullable=True)
+    filtered_resource = db.Column(db.Text, nullable=False, index=True)
     updated_at = db.Column(UTCDateTime)
 
     @property
     def labels_filters(self):
-        return get_filters_list_from_mapping(self.value.get('labels', {}))
+        return [filter_rule for filter_rule in self.value
+                if filter_rule['type'] == 'label']
 
 
 class Execution(CreatedAtMixin, SQLResourceBase):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -400,8 +400,7 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
 
     @classproperty
     def allowed_filter_attrs(cls):
-        return ['blueprint_id', 'created_by', 'description', 'site_name',
-                'latest_execution_status']
+        return ['blueprint_id', 'created_by', 'description', 'site_name']
 
     def to_response(self, **kwargs):
         dep_dict = super(Deployment, self).to_response()

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -32,7 +32,7 @@ from manager_rest.utils import (is_administrator,
                                 all_tenants_authorization,
                                 validate_global_modification)
 
-from .filters import add_labels_filters_to_query
+from .filters import add_filter_rules_to_query
 
 from psycopg2 import DatabaseError as Psycopg2DBError
 sql_errors = (SQLAlchemyError, Psycopg2DBError)
@@ -181,7 +181,7 @@ class SQLStorageManager(object):
     def _add_filter_rules(query, model_class, filter_rules):
         if filter_rules:
             if hasattr(model_class, 'labels_model'):
-                return add_labels_filters_to_query(
+                return add_filter_rules_to_query(
                     query, model_class.labels_model, filter_rules)
 
         return query

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -1008,21 +1008,21 @@ class BaseServerTestCase(unittest.TestCase):
 
         return deployment
 
-    def create_filter(self, filter_name, filter_rules,
-                      visibility=VisibilityState.TENANT, filters_client=None):
-        client = filters_client or self.client
-        return client.create(filter_name, filter_rules, visibility)
+    @staticmethod
+    def create_filter(filters_client, filter_id, filter_rules,
+                      visibility=VisibilityState.TENANT):
+        return filters_client.create(filter_id, filter_rules, visibility)
 
-    def update_filter(self, new_filter_rules=None, new_visibility=None,
-                      filters_client=None):
+    def update_filter(self, filters_client, new_filter_rules=None,
+                      new_visibility=None):
         filter_id = 'filter'
         filter_rule = {'key': 'a', 'values': ['b'], 'operator': 'any_of',
                        'type': 'label'}
-        client = filters_client or self.client
-        orig_filter = self.create_filter(filter_id, [filter_rule],
-                                         filters_client=client)
-        updated_filter = client.update(filter_id, new_filter_rules,
-                                       new_visibility)
+        orig_filter = self.create_filter(filters_client,
+                                         filter_id,
+                                         [filter_rule])
+        updated_filter = filters_client.update(filter_id, new_filter_rules,
+                                               new_visibility)
 
         updated_rules = new_filter_rules or self.SIMPLE_RULE
         updated_visibility = new_visibility or VisibilityState.TENANT

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -229,7 +229,8 @@ class BaseServerTestCase(unittest.TestCase):
                         client.inter_deployment_dependencies.api = \
                             mock_http_client
                         client.deployments_labels.api = mock_http_client
-                        client.filters.api = mock_http_client
+                        client.blueprints_filters.api = mock_http_client
+                        client.deployments_filters.api = mock_http_client
                         client.deployment_groups.api = mock_http_client
                         client.execution_groups.api = mock_http_client
                         client.execution_schedules.api = mock_http_client
@@ -1008,15 +1009,20 @@ class BaseServerTestCase(unittest.TestCase):
         return deployment
 
     def create_filter(self, filter_name, filter_rules,
-                      visibility=VisibilityState.TENANT, client=None):
-        client = client or self.client
-        return client.filters.create(filter_name, filter_rules, visibility)
+                      visibility=VisibilityState.TENANT, filters_client=None):
+        client = filters_client or self.client
+        return client.create(filter_name, filter_rules, visibility)
 
-    def update_filter(self, new_filter_rules=None, new_visibility=None):
+    def update_filter(self, new_filter_rules=None, new_visibility=None,
+                      filters_client=None):
         filter_id = 'filter'
-        orig_filter = self.create_filter(filter_id, ['a=b'])
-        updated_filter = self.client.filters.update(
-            filter_id, new_filter_rules, new_visibility)
+        filter_rule = {'key': 'a', 'values': ['b'], 'operator': 'any_of',
+                       'type': 'label'}
+        client = filters_client or self.client
+        orig_filter = self.create_filter(filter_id, [filter_rule],
+                                         filters_client=client)
+        updated_filter = client.update(filter_id, new_filter_rules,
+                                       new_visibility)
 
         updated_rules = new_filter_rules or self.SIMPLE_RULE
         updated_visibility = new_visibility or VisibilityState.TENANT

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -1014,10 +1014,11 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
 
     @attr(client_min_version=3.1,
           client_max_version=base_test.LATEST_API_VERSION)
-    def test_list_deployments_with_filter_name(self):
+    def test_list_deployments_with_filter_id(self):
         self.put_deployment_with_labels(self.LABELS)
         dep2 = self.put_deployment_with_labels(self.LABELS_2)
-        self.create_filter(self.FILTER_ID, self.FILTER_RULES_2)
+        self.create_filter(self.client.deployments_filters,
+                           self.FILTER_ID, self.FILTER_RULES_2)
         deployments = self.client.deployments.list(
             filter_rules={'_filter_id': self.FILTER_ID})
         self.assertEqual(len(deployments), 1)

--- a/rest-service/manager_rest/test/endpoints/test_filters.py
+++ b/rest-service/manager_rest/test/endpoints/test_filters.py
@@ -2,181 +2,242 @@ from cloudify.models_states import VisibilityState
 from cloudify_rest_client.exceptions import CloudifyClientError
 
 from manager_rest.test import base_test
-from manager_rest.constants import EQUAL, NOT_EQUAL, IS_NULL, IS_NOT_NULL
+from manager_rest.storage import models
 from manager_rest.test.attribute import attr
 from manager_rest.storage.models_base import db
-from manager_rest.utils import get_filters_list_from_mapping
-from manager_rest.manager_exceptions import BadParametersError
-from manager_rest.storage.filters import add_labels_filters_to_query
-from manager_rest.rest.filters_utils import (BadLabelsFilter,
-                                             create_labels_filters_mapping)
+from manager_rest.rest.filters_utils import parse_filter_rules
+from manager_rest.storage.filters import add_filter_rules_to_query
 from manager_rest.storage.resource_models import Deployment, DeploymentLabel
+from manager_rest.manager_exceptions import BadFilterRule, BadParametersError
 
 FILTER_ID = 'filter'
-LEGAL_RULES = ['a=b', 'e=[f,g]', 'c!=d', 'h!=[i,j]',
-               'k is null', 'l is not null']
+LABELS_LEGAL_FILTER_RULES = [
+    {'key': 'a', 'values': ['b'], 'operator': 'any_of', 'type': 'label'},
+    {'key': 'e', 'values': ['f', 'g'], 'operator': 'any_of', 'type': 'label'},
+    {'key': 'c', 'values': ['d'], 'operator': 'not_any_of', 'type': 'label'},
+    {'key': 'h', 'values': ['i', 'j'], 'operator': 'not_any_of',
+     'type': 'label'},
+    {'key': 'k', 'values': [], 'operator': 'is_null', 'type': 'label'},
+    {'key': 'l', 'values': [], 'operator': 'is_not_null', 'type': 'label'}
+]
 
 
 class FiltersFunctionalityTest(base_test.BaseServerTestCase):
-
     LABELS = [{'a': 'b'}, {'a': 'z'}, {'c': 'd'}]
     LABELS_2 = [{'a': 'b'}, {'c': 'z'}, {'e': 'f'}]
-    FILTER_RULES = ['a=b', 'p is not null', 'f!=g', 'f!=h', 'c=[d,e]',
-                    'f!=[i,j]', 'k!=l', 'm is null', 'n is not null',
-                    'o is null']
 
-    def test_create_filters_mapping(self):
-        expected_filters_mapping = {
-            EQUAL: {
-                'a': ['b'],
-                'c': ['d', 'e']
-            },
-            NOT_EQUAL: {
-                'f': ['g', 'h', 'i', 'j'],
-                'k': ['l']
-            },
-            IS_NULL: ['m', 'o'],
-            IS_NOT_NULL: ['p', 'n']
-        }
-        filters_mapping = create_labels_filters_mapping(self.FILTER_RULES)
-        self.assertEqual(filters_mapping, expected_filters_mapping)
-
-    def test_create_filters_mapping_fails(self):
-        with self.assertRaisesRegex(BadParametersError,
-                                    '.*have the same key.*'):
-            create_labels_filters_mapping(['a=b', 'b!=c', 'a=c'])
-
-    def test_create_filters_list(self):
-        created_filters_list = get_filters_list_from_mapping(
-            create_labels_filters_mapping(LEGAL_RULES))
-        self.assertEqual(set(created_filters_list), set(LEGAL_RULES))
-
-    def test_filters_applied(self):
+    def test_labels_filters_applied(self):
         dep1 = self.put_deployment_with_labels(self.LABELS)
         dep2 = self.put_deployment_with_labels(self.LABELS_2)
-        self._assert_filters_applied({EQUAL: {'a': ['b']}}, {dep1.id, dep2.id})
-        self._assert_filters_applied({NOT_EQUAL: {'c': ['z']}}, {dep1.id})
-        self._assert_filters_applied({EQUAL: {'a': ['y', 'z'], 'c': ['d']}},
+        self._assert_filters_applied([('a', ['b'], 'any_of', 'label')],
+                                     {dep1.id, dep2.id})
+        self._assert_filters_applied([('c', ['z'], 'not_any_of', 'label')],
                                      {dep1.id})
-        self._assert_filters_applied({EQUAL: {'a': ['b']}, IS_NOT_NULL: ['e']},
+        self._assert_filters_applied([('a', ['y', 'z'], 'any_of', 'label'),
+                                      ('c', ['d'], 'any_of', 'label')],
+                                     {dep1.id})
+        self._assert_filters_applied([('a', ['b'], 'any_of', 'label'),
+                                      ('e', [], 'is_not_null', 'label')],
                                      {dep2.id})
-        self._assert_filters_applied({EQUAL: {'a': ['b']}, IS_NULL: ['e']},
+        self._assert_filters_applied([('a', ['b'], 'any_of', 'label'),
+                                      ('e', [], 'is_null', 'label')],
                                      {dep1.id})
-        self._assert_filters_applied({IS_NULL: ['a']}, set())
+        self._assert_filters_applied([('a', [], 'is_null', 'label')], set())
         self._assert_filters_applied(
-            {EQUAL: {'a': ['b']}, NOT_EQUAL: {'c': ['y', 'z']}}, {dep1.id})
+            [('a', ['b'], 'any_of', 'label'),
+             ('c', ['y', 'z'], 'not_any_of', 'label')], {dep1.id})
 
-    def test_filters_functionality_fails(self):
-        err_filters = ['a null', 'a', 'a!b']
-        for err_filter in err_filters:
-            with self.assertRaisesRegex(BadLabelsFilter,
-                                        '.*not in the right format.*'):
-                create_labels_filters_mapping([err_filter])
+    def test_filter_rule_not_dictionary_fails(self):
+        with self.assertRaisesRegex(BadFilterRule, '.*not a dictionary'):
+            parse_filter_rules(['a'], models.Deployment)
+
+    def test_filter_rule_missing_entry_fails(self):
+        with self.assertRaisesRegex(BadFilterRule,
+                                    '.*one of the entries in the filter rule'
+                                    ' is missing'):
+            parse_filter_rules([{'key': 'key1'}], models.Deployment)
+
+    def test_parse_filter_rules_fails(self):
+        err_filter_rules_params = [
+            ((1, ['b'], 'any_of', 'label'), '.*must be of type string.*'),
+            (('a', 'b', 'any_of', 'label'), '.*must be of type list.*'),
+            (('a', ['b'], 'bad_operator', 'label'),
+             '.*operator for filtering by labels must be one of.*'),
+            (('a', ['b'], 'is_null', 'label'),
+             '.*list must be empty if the operator.*'),
+            (('a', ['b'], 'is_not_null', 'label'),
+             '.*list must be empty if the operator.*'),
+            (('a', [], 'any_of', 'label'),
+             '.*list must include at least one item if the operator.*'),
+            (('blueprint_id', ['b'], 'bad_operator', 'attribute'),
+             '.*The operator for filtering by attributes must be one.*'),
+            (('bad_attribute', ['dep1'], 'any_of', 'attribute'),
+             '.*Allowed attributes to filter deployments by are.*'),
+            (('a', ['b'], 'any_of', 'bad_type'),
+             '.*Filter rule type must be one of.*'),
+            (('bad_attribute', ['dep1'], 'any_of', 'bad_type'),
+             '.*Filter rule type must be one of.*')
+        ]
+        for params, err_msg in err_filter_rules_params:
+            with self.assertRaisesRegex(BadFilterRule, err_msg):
+                parse_filter_rules([_get_filter_rule_from_params(params)],
+                                   models.Deployment)
+
+    def test_key_and_value_validation_fails(self):
+        err_filter_rules_params = [
+            (('a b', ['b'], 'any_of', 'label'), '.*filter rule key.*'),
+            (('a', ['b', 'c d'], 'any_of', 'label'),
+             '.*One of the filter rule values.*')
+        ]
+        for params, err_msg in err_filter_rules_params:
+            with self.assertRaisesRegex(BadParametersError, err_msg):
+                parse_filter_rules([_get_filter_rule_from_params(params)],
+                                   models.Deployment)
 
     @staticmethod
-    def _assert_filters_applied(filter_labels, deployments_ids_set):
+    def _assert_filters_applied(filter_rules_params, deployments_ids_set):
         """Asserts the right deployments return when filter labels are applied
 
-        :param filter_labels: The list of filter labels
+        :param filter_rules_params: List of filter rules parameters
         :param deployments_ids_set: The corresponding deployments' IDs set
         """
+        filter_rules = [_get_filter_rule_from_params(params)
+                        for params in filter_rules_params]
         query = db.session.query(Deployment)
-        query = add_labels_filters_to_query(query,
-                                            DeploymentLabel,
-                                            filter_labels)
+        query = add_filter_rules_to_query(query,
+                                          DeploymentLabel,
+                                          filter_rules)
         deployments = query.all()
 
         assert deployments_ids_set == set(dep.id for dep in deployments)
 
 
-@attr(client_min_version=3.1, client_max_version=base_test.LATEST_API_VERSION)
-class FiltersTestCase(base_test.BaseServerTestCase):
-    SIMPLE_RULE = ['a=b']
+class FiltersBaseCase(base_test.BaseServerTestCase):
+    SIMPLE_RULE = [{'key': 'a', 'values': ['b'], 'operator': 'any_of',
+                    'type': 'label'}]
+    NEW_RULE = [{'key': 'c', 'values': ['d'], 'operator': 'any_of',
+                 'type': 'label'}]
+
+    def setUp(self, filters_resource):
+        super().setUp()
+        self.filters_client = getattr(self.client, filters_resource)
 
     def test_create_legal_filter(self):
-        new_filter = self.create_filter(FILTER_ID, LEGAL_RULES)
-        self.assertEqual(new_filter.labels_filter, LEGAL_RULES)
+        new_filter = self.create_filter(FILTER_ID,
+                                        LABELS_LEGAL_FILTER_RULES,
+                                        filters_client=self.filters_client)
+        self.assertEqual(new_filter.labels_filter,
+                         LABELS_LEGAL_FILTER_RULES)
 
     def test_list_filters(self):
         for i in range(3):
             self.create_filter('{0}{1}'.format(FILTER_ID, i),
-                               ['a{0}=b{0}'.format(i)])
-        filters_list = self.client.filters.list()
+                               [{'key': f'a{i}',
+                                 'values': [f'b{i}'],
+                                 'operator': 'any_of',
+                                 'type': 'label'}],
+                               filters_client=self.filters_client)
+        filters_list = self.filters_client.list()
 
         self.assertEqual(len(filters_list.items), 3)
         for i in range(3):
             self.assertEqual(filters_list.items[i].labels_filter,
-                             ['a{0}=b{0}'.format(i)])
+                             [{'key': f'a{i}',
+                               'values': [f'b{i}'],
+                               'operator': 'any_of',
+                               'type': 'label'}])
 
     def test_list_filters_sort(self):
         filter_names = ['a_filter', 'c_filter', 'b_filter']
         for filter_name in filter_names:
-            self.create_filter(filter_name, self.SIMPLE_RULE)
+            self.create_filter(filter_name, self.SIMPLE_RULE,
+                               filters_client=self.filters_client)
 
-        sorted_asc_filters_list = self.client.filters.list(sort='id')
+        sorted_asc_filters_list = self.filters_client.list(sort='id')
         self.assertEqual(
             [filter_elem.id for filter_elem in sorted_asc_filters_list],
             sorted(filter_names)
         )
 
-        sorted_dsc_filters_list = self.client.filters.list(
-            sort='id', is_descending=True)
+        sorted_dsc_filters_list = self.filters_client.list(sort='id',
+                                                           is_descending=True)
         self.assertEqual(
             [filter_elem.id for filter_elem in sorted_dsc_filters_list],
             sorted(filter_names, reverse=True)
         )
 
     def test_filter_create_lowercase(self):
-        legal_rules_uppercase = (
-                [rule.upper() for rule in LEGAL_RULES[:4]] +
-                ['K is null', 'L is not null'])
-        new_filter = self.create_filter(FILTER_ID, legal_rules_uppercase)
-        self.assertEqual(new_filter.labels_filter, LEGAL_RULES)
-
-    def test_filter_create_strip(self):
-        legal_rules_whitespace = ['a = b', 'c != d', 'e= [f , g]',
-                                  'h !=[ i,j ]', 'k is null', 'l is not null']
-        new_filter = self.create_filter(FILTER_ID, legal_rules_whitespace)
-        self.assertEqual(new_filter.labels_filter, LEGAL_RULES)
+        # This test only handles one case in order to verify an exception is
+        # thrown during a filter creation. All cases are tested in the
+        # FiltersFunctionalityTest::test_parse_filter_rules_fails test.
+        simple_rule_uppercase = [{'key': 'A',
+                                  'values': ['B'],
+                                  'operator': 'any_of',
+                                  'type': 'label'}]
+        new_filter = self.create_filter(FILTER_ID, simple_rule_uppercase,
+                                        filters_client=self.filters_client)
+        self.assertEqual(new_filter.labels_filter, self.SIMPLE_RULE)
 
     def test_filter_create_fails(self):
-        err_rules = [
-            (['a= '], '.*is empty.*'),
-            (['a!=b]'], '.*illegal characters.*'),
-            (['a'], '.*not in the right format.*'),
-            (['a null'], '.*not in the right format.*'),
-            (['a=b=c'], '.*not in the right format.*'),
-        ]
-
-        for err_rule, err_msg in err_rules:
-            with self.assertRaisesRegex(CloudifyClientError, err_msg):
-                self.create_filter(FILTER_ID, err_rule)
+        err_filter_rule = [{'key': 'a', 'values': 'b', 'operator': 'any_of',
+                            'type': 'label'}]
+        with self.assertRaisesRegex(CloudifyClientError,
+                                    '.*must be of type list.*'):
+            self.create_filter(FILTER_ID, err_filter_rule,
+                               filters_client=self.filters_client)
 
     def test_get_filter(self):
-        self.create_filter(FILTER_ID, self.SIMPLE_RULE)
-        fetched_filter = self.client.filters.get(FILTER_ID)
+        self.create_filter(FILTER_ID, self.SIMPLE_RULE,
+                           filters_client=self.filters_client)
+        fetched_filter = self.filters_client.get(FILTER_ID)
         self.assertEqual(fetched_filter.labels_filter, self.SIMPLE_RULE)
 
     def test_delete_filter(self):
-        self.create_filter(FILTER_ID, ['a=b'])
-        self.assertEqual(len(self.client.filters.list().items), 1)
-        self.client.filters.delete(FILTER_ID)
-        self.assertEqual(len(self.client.filters.list().items), 0)
+        self.create_filter(FILTER_ID, self.SIMPLE_RULE,
+                           filters_client=self.filters_client)
+        self.assertEqual(len(self.filters_client.list().items), 1)
+        self.filters_client.delete(FILTER_ID)
+        self.assertEqual(len(self.filters_client.list().items), 0)
 
     def test_update_filter(self):
-        self.update_filter(['c=d'], VisibilityState.GLOBAL)
+        self.update_filter(self.NEW_RULE, VisibilityState.GLOBAL,
+                           filters_client=self.filters_client)
 
     def test_update_filter_only_visibility(self):
-        self.update_filter(new_visibility=VisibilityState.GLOBAL)
+        self.update_filter(new_visibility=VisibilityState.GLOBAL,
+                           filters_client=self.filters_client)
 
     def test_update_filter_only_filter_rules(self):
-        self.update_filter(new_filter_rules=['c=d'])
+        self.update_filter(new_filter_rules=self.NEW_RULE,
+                           filters_client=self.filters_client)
 
     def test_update_filter_no_args_fails(self):
         with self.assertRaisesRegex(RuntimeError, '.*to update a filter.*'):
-            self.update_filter()
+            self.update_filter(filters_client=self.filters_client)
 
     def test_update_filter_narrower_visibility_fails(self):
         with self.assertRaisesRegex(CloudifyClientError,
                                     '.*has wider visibility.*'):
-            self.update_filter(new_visibility=VisibilityState.PRIVATE)
+            self.update_filter(new_visibility=VisibilityState.PRIVATE,
+                               filters_client=self.filters_client)
+
+
+@attr(client_min_version=3.1, client_max_version=base_test.LATEST_API_VERSION)
+class BlueprintsFiltersCase(FiltersBaseCase):
+    def setUp(self):
+        super().setUp('blueprints_filters')
+
+
+@attr(client_min_version=3.1, client_max_version=base_test.LATEST_API_VERSION)
+class DeploymentsFiltersCase(FiltersBaseCase):
+    def setUp(self):
+        super().setUp('blueprints_filters')
+
+
+def _get_filter_rule_from_params(params):
+    return {'key': params[0], 'values': params[1],
+            'operator': params[2], 'type': params[3]}
+
+
+# This way we avoid running it too
+del FiltersBaseCase

--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -39,7 +39,6 @@ from cloudify.models_states import VisibilityState
 from cloudify.amqp_client import create_events_publisher, get_client
 
 from manager_rest import constants, config, manager_exceptions
-from manager_rest.constants import EQUAL, NOT_EQUAL, IS_NULL, IS_NOT_NULL
 
 
 def check_allowed_endpoint(allowed_endpoints):
@@ -324,36 +323,6 @@ def get_amqp_client():
         ssl_cert_path=config.instance.amqp_ca_path,
         connect_timeout=3,
     )
-
-
-def get_filters_list_from_mapping(filters_mapping):
-    """ Returns a filters list based on the filters mapping """
-    filters_list = []
-    for item in EQUAL, NOT_EQUAL:
-        labels = sorted(filters_mapping.get(item, {}).items())
-        for label_key, label_value in labels:
-            filters_list.append(_get_label_filter_rule(
-                item, label_key, label_value))
-
-    for item in IS_NULL, IS_NOT_NULL:
-        for label_key in filters_mapping.get(item, []):
-            filters_list.append(_get_label_filter_rule(item, label_key))
-
-    return filters_list
-
-
-def _get_label_filter_rule(mapping_key, label_key, label_values_list=None):
-    mapping = {EQUAL: '=', NOT_EQUAL: '!=',
-               IS_NULL: ' is null', IS_NOT_NULL: ' is not null'}
-
-    if mapping_key in (EQUAL, NOT_EQUAL):
-        label_values_str = (label_values_list[0] if len(label_values_list) == 1
-                            else '[' + ','.join(label_values_list) + ']')
-
-        return label_key + mapping[mapping_key] + label_values_str
-
-    else:  # mapping_key in (IS_NULL, IS_NOT_NULL)
-        return label_key + mapping[mapping_key]
 
 
 def parse_frequency(expr):


### PR DESCRIPTION
This PR modifies the filters value column to be of the following form:
```
[
           {
               key: <key>,
               values: [<list of values>],
               operator: <LabelsOperator> or <AttrsOperator>,
               type: <label or attribute>
            }
]
```

For this change to take place, some changes were made to the code: 

- Adding the `filtered_resource` column to the `filters` table. Since we introduce the ability to filter by a model's attributes, we need to determine which model is being filtered. This column was added to support this. 
- Changing the `equal` and `not_equal` operators to `any_of` and `not_any_of` respectively, based on some comments that were raised during the design of the feature. 
- Splitting the `/filters` endpoint to `/filters/blueprints` and `/filters/deployments`. This was done for the same reason specified in the first bullet. 
- Modifying the filters unit-tests based on the changes. 

Important note: According to Ofer, the filters feature will not be mentioned in the docs and changelog of v5.2, so there is no need to implement the logic for backwards compatibility. 

Complementary PRs:
https://github.com/cloudify-cosmo/cloudify-common/pull/692
https://github.com/cloudify-cosmo/cloudify-premium/pull/739