### PR TITLE
RD-1506 Blueprint upload: wait for the execution

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -132,7 +132,8 @@ class BlueprintsId(resources_v2.BlueprintsId):
                                   labels=labels)
         if not async_upload:
             sm = get_storage_manager()
-            response = rest_utils.get_uploaded_blueprint(sm, blueprint_id)
+            blueprint, _ = response
+            response = rest_utils.get_uploaded_blueprint(sm, blueprint)
         return response
 
     @staticmethod

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -23,7 +23,11 @@ from dsl_parser.constants import INTER_DEPLOYMENT_FUNCTIONS
 
 from cloudify._compat import urlquote, text_type
 from cloudify.snapshots import SNAPSHOT_RESTORE_FLAG_FILE
-from cloudify.models_states import VisibilityState, BlueprintUploadState
+from cloudify.models_states import (
+    VisibilityState,
+    BlueprintUploadState,
+    ExecutionState,
+)
 
 from manager_rest.storage import models
 from manager_rest.constants import (REST_SERVICE_NAME,
@@ -637,20 +641,21 @@ def verify_blueprint_uploaded_state(blueprint):
             .format(blueprint.id, blueprint.state))
 
 
-def retry_if_upload_not_ended(result):
-    return result.state not in BlueprintUploadState.END_STATES
+def _execution_ended(result):
+    return result.status not in ExecutionState.END_STATES
 
 
 @retry(wait_fixed=1000, stop_max_attempt_number=60,
-       retry_on_result=retry_if_upload_not_ended)
-def wait_for_blueprint_upload(sm, blueprint_id):
-    blueprint = sm.get(models.Blueprint, blueprint_id)
+       retry_on_result=_execution_ended)
+def wait_for_execution(sm, execution_id):
+    execution = sm.get(models.Execution, execution_id)
     sm._safe_commit()
-    return blueprint
+    return execution
 
 
-def get_uploaded_blueprint(sm, blueprint_id):
-    blueprint = wait_for_blueprint_upload(sm, blueprint_id)
+def get_uploaded_blueprint(sm, blueprint):
+    wait_for_execution(sm, blueprint.upload_execution.id)
+    blueprint = sm.get(models.Blueprint, blueprint.id)
     if blueprint.state in BlueprintUploadState.FAILED_STATES:
         if blueprint.state == BlueprintUploadState.INVALID:
             state_display = 'is invalid'


### PR DESCRIPTION
This ports the idea from #2700 into master, using the FKs
introduced in #2726
Rather than polling on blueprint state, wait on the execution instead.
Blueprint state can unfortunately change several times, but the
execution status is actually reliable.