### PR TITLE
RD-1521 Implement attributes filter rules

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -122,7 +122,7 @@ class Blueprint(CreatedAtMixin, SQLResourceBase):
 
     @classproperty
     def allowed_filter_attrs(cls):
-        return ['created_by', 'description']
+        return ['created_by']
 
     def to_response(self, **kwargs):
         blueprint_dict = super(Blueprint, self).to_response()
@@ -406,7 +406,7 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
 
     @classproperty
     def allowed_filter_attrs(cls):
-        return ['blueprint_id', 'created_by', 'description', 'site_name']
+        return ['blueprint_id', 'created_by', 'site_name']
 
     def to_response(self, **kwargs):
         dep_dict = super(Deployment, self).to_response()

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -18,7 +18,7 @@ from functools import wraps
 from collections import OrderedDict
 from contextlib import contextmanager
 from flask_security import current_user
-from sqlalchemy import or_ as sql_or, func, inspect
+from sqlalchemy import or_ as sql_or, inspect, func
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from flask import current_app, has_request_context
 from sqlalchemy.orm.attributes import flag_modified
@@ -26,12 +26,13 @@ from sqlalchemy.orm.attributes import flag_modified
 from cloudify._compat import text_type
 from cloudify.models_states import VisibilityState
 
-from manager_rest.storage.models_base import db, is_orm_attribute
+from manager_rest.storage.models_base import db
 from manager_rest import manager_exceptions, config, utils
 from manager_rest.utils import (is_administrator,
                                 all_tenants_authorization,
                                 validate_global_modification)
 
+from .utils import get_column, get_joins
 from .filters import add_filter_rules_to_query
 
 from psycopg2 import DatabaseError as Psycopg2DBError
@@ -182,7 +183,7 @@ class SQLStorageManager(object):
         if filter_rules:
             if hasattr(model_class, 'labels_model'):
                 return add_filter_rules_to_query(
-                    query, model_class.labels_model, filter_rules)
+                    query, model_class, filter_rules)
 
         return query
 
@@ -306,28 +307,6 @@ class SQLStorageManager(object):
         )
         return query.filter(user_filter)
 
-    @staticmethod
-    def _get_joins(model_class, columns):
-        """Get a list of all the attributes on which we need to join
-
-        :param columns: A set of all columns involved in the query
-        """
-        # Using an ordered dict because the order of the joins is important
-        joins = OrderedDict()
-        for column_name in columns:
-            column = getattr(model_class, column_name)
-            while not is_orm_attribute(column):
-                join_attr = column.local_attr
-
-                # This is a hack, to deal with the fact that SQLA doesn't
-                # fully support doing something like: `if join_attr in joins`,
-                # because some SQLA elements have their own comparators
-                join_attr_name = str(join_attr)
-                if join_attr_name not in joins:
-                    joins[join_attr_name] = join_attr
-                column = column.remote_attr
-        return joins.values()
-
     def _get_joins_and_converted_columns(self,
                                          model_class,
                                          include,
@@ -346,7 +325,7 @@ class SQLStorageManager(object):
         distinct = distinct or []
 
         all_columns = set(include) | set(filters.keys()) | set(sort.keys())
-        joins = self._get_joins(model_class, all_columns)
+        joins = get_joins(model_class, all_columns)
 
         include, filters, substr_filters, sort, distinct = \
             self._get_columns_from_field_names(model_class,
@@ -408,33 +387,14 @@ class SQLStorageManager(object):
         """Go over the optional parameters (include, filters, sort), and
         replace column names with actual SQLA column objects
         """
-        include = [self._get_column(model_class, c) for c in include]
-        filters = {self._get_column(model_class, c): filters[c]
-                   for c in filters}
-        substr_filters = {self._get_column(model_class, c): substr_filters[c]
+        include = [get_column(model_class, c) for c in include]
+        filters = {get_column(model_class, c): filters[c] for c in filters}
+        substr_filters = {get_column(model_class, c): substr_filters[c]
                           for c in substr_filters}
-        sort = OrderedDict((self._get_column(model_class, c), sort[c])
-                           for c in sort)
-        distinct = [self._get_column(model_class, c) for c in distinct]
+        sort = OrderedDict((get_column(model_class, c), sort[c]) for c in sort)
+        distinct = [get_column(model_class, c) for c in distinct]
 
         return include, filters, substr_filters, sort, distinct
-
-    @staticmethod
-    def _get_column(model_class, column_name):
-        """Return the column on which an action (filtering, sorting, etc.)
-        would need to be performed. Can be either an attribute of the class,
-        or an association proxy linked to a relationship the class has
-        """
-        column = getattr(model_class, column_name)
-        if is_orm_attribute(column):
-            return column
-        else:
-            # We need to get to the underlying attribute, so we move on to the
-            # next remote_attr until we reach one
-            while not is_orm_attribute(column.remote_attr):
-                column = column.remote_attr
-            # Put a label on the remote attribute with the name of the column
-            return column.remote_attr.label(column_name)
 
     @staticmethod
     def _paginate(query, pagination, get_all_results=False):
@@ -673,11 +633,11 @@ class SQLStorageManager(object):
 
     def summarize(self, target_field, sub_field, model_class,
                   pagination, get_all_results, all_tenants, filters):
-        f = self._get_column(model_class, target_field)
+        f = get_column(model_class, target_field)
         fields = [f]
         string_fields = [target_field]
         if sub_field:
-            fields.append(self._get_column(model_class, sub_field))
+            fields.append(get_column(model_class, sub_field))
             string_fields.append(sub_field)
         entities = fields + [db.func.count('*')]
         query = self._get_query(

--- a/rest-service/manager_rest/storage/storage_utils.py
+++ b/rest-service/manager_rest/storage/storage_utils.py
@@ -18,8 +18,8 @@ from flask_security.utils import hash_password
 
 from manager_rest import constants
 from manager_rest.storage.models import Node
-from manager_rest.manager_exceptions import NotFoundError
 from manager_rest.storage import user_datastore, db, get_storage_manager
+from manager_rest.manager_exceptions import NotFoundError
 from manager_rest.storage.management_models import (
     Tenant, UserTenantAssoc, Role
 )

--- a/rest-service/manager_rest/storage/utils.py
+++ b/rest-service/manager_rest/storage/utils.py
@@ -1,0 +1,42 @@
+from collections import OrderedDict
+
+from manager_rest.storage.models_base import is_orm_attribute
+
+
+def get_column(model_class, column_name):
+    """Return the column on which an action (filtering, sorting, etc.)
+    would need to be performed. Can be either an attribute of the class,
+    or an association proxy linked to a relationship the class has
+    """
+    column = getattr(model_class, column_name)
+    if is_orm_attribute(column):
+        return column
+    else:
+        # We need to get to the underlying attribute, so we move on to the
+        # next remote_attr until we reach one
+        while not is_orm_attribute(column.remote_attr):
+            column = column.remote_attr
+        # Put a label on the remote attribute with the name of the column
+        return column.remote_attr.label(column_name)
+
+
+def get_joins(model_class, columns):
+    """Get a list of all the attributes on which we need to join
+
+    :param columns: A set of all columns involved in the query
+    """
+    # Using an ordered dict because the order of the joins is important
+    joins = OrderedDict()
+    for column_name in columns:
+        column = getattr(model_class, column_name)
+        while not is_orm_attribute(column):
+            join_attr = column.local_attr
+
+            # This is a hack, to deal with the fact that SQLA doesn't
+            # fully support doing something like: `if join_attr in joins`,
+            # because some SQLA elements have their own comparators
+            join_attr_name = str(join_attr)
+            if join_attr_name not in joins:
+                joins[join_attr_name] = join_attr
+            column = column.remote_attr
+    return joins.values()

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -51,8 +51,11 @@ from cloudify.cluster_status import (
 from manager_rest import server
 from manager_rest.rest import rest_utils
 from manager_rest.test.attribute import attr
+from manager_rest.storage.models_base import db
+from manager_rest.rest.filters_utils import FilterRule
 from manager_rest.resource_manager import get_resource_manager
 from manager_rest.flask_utils import set_admin_current_user
+from manager_rest.storage.filters import add_filter_rules_to_query
 from manager_rest.test.security_utils import (get_admin_user,
                                               get_status_reporters)
 from manager_rest import utils, config, constants, archiving
@@ -166,6 +169,23 @@ class BaseServerTestCase(unittest.TestCase):
             compared_labels_set.add((key, value))
 
         self.assertEqual(simplified_labels, compared_labels_set)
+
+    @staticmethod
+    def assert_filters_applied(filter_rules_params, resource_ids_set,
+                               resource_model=models.Deployment):
+        """Asserts the right resources return when filter rules are applied
+
+        :param filter_rules_params: List of filter rules parameters
+        :param resource_ids_set: The corresponding deployments' IDs set
+        :param resource_model: The resource model to filter.
+               Can be Deployment or Blueprint
+        """
+        filter_rules = [FilterRule(*params) for params in filter_rules_params]
+        query = db.session.query(resource_model)
+        query = add_filter_rules_to_query(query, resource_model, filter_rules)
+        results = query.all()
+
+        assert resource_ids_set == set(res.id for res in results)
 
     @classmethod
     def create_client_with_tenant(cls,
@@ -909,7 +929,11 @@ class BaseServerTestCase(unittest.TestCase):
         if plan.get('description'):
             update_dict['description'] = plan['description']
         if labels:
-            update_dict['labels'] = labels
+            parsed_labels_list = []
+            for label in labels:
+                [(label_key, label_value)] = label.items()
+                parsed_labels_list.append([label_key, label_value])
+            update_dict['labels'] = parsed_labels_list
         return client.blueprints.update(blueprint_id, update_dict=update_dict)
 
     def _add_blueprint(self, blueprint_id=None):
@@ -996,7 +1020,7 @@ class BaseServerTestCase(unittest.TestCase):
         )
 
     def put_deployment_with_labels(self, labels, resource_id=None,
-                                   client=None):
+                                   client=None, **deployment_kwargs):
         client = client or self.client
         resource_id = resource_id or 'i{0}'.format(uuid.uuid4())
         _, _, _, deployment = self.put_deployment(
@@ -1004,9 +1028,13 @@ class BaseServerTestCase(unittest.TestCase):
             blueprint_id=resource_id,
             deployment_id=resource_id,
             labels=labels,
-            client=client)
+            client=client,
+            **deployment_kwargs)
 
         return deployment
+
+    def put_blueprint_with_labels(self, labels, **blueprint_kwargs):
+        return self.put_blueprint(labels=labels, **blueprint_kwargs)
 
     @staticmethod
     def create_filter(filters_client, filter_id, filter_rules,

--- a/rest-service/manager_rest/test/endpoints/test_blueprints.py
+++ b/rest-service/manager_rest/test/endpoints/test_blueprints.py
@@ -32,6 +32,7 @@ from .test_utils import generate_progress_func
 
 @attr(client_min_version=1, client_max_version=base_test.LATEST_API_VERSION)
 class BlueprintsTestCase(base_test.BaseServerTestCase):
+    LABELS = [{'key1': 'val1'}, {'key2': 'val2'}]
 
     def test_get_empty(self):
         result = self.client.blueprints.list()
@@ -497,7 +498,7 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
           client_max_version=base_test.LATEST_API_VERSION)
     def test_update_blueprint_labels(self):
         new_labels = [{'key2': 'val2'}, {'key3': 'val3'}]
-        blueprint = self._put_blueprint_with_labels()
+        blueprint = self.put_blueprint_with_labels(self.LABELS)
         updated_bp = self.client.blueprints.update(blueprint['id'],
                                                    {'labels': new_labels})
         self.assert_resource_labels(updated_bp['labels'], new_labels)
@@ -505,7 +506,7 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
     @attr(client_min_version=3.1,
           client_max_version=base_test.LATEST_API_VERSION)
     def test_update_empty_blueprint_labels(self):
-        blueprint = self._put_blueprint_with_labels()
+        blueprint = self.put_blueprint_with_labels(self.LABELS)
         updated_bp = self.client.blueprints.update(blueprint['id'],
                                                    {'labels': []})
         self.assert_resource_labels(updated_bp['labels'], [])
@@ -514,8 +515,8 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
           client_max_version=base_test.LATEST_API_VERSION)
     def test_blueprint_update_failure_with_duplicate_labels(self):
         update_dict = {'labels': [{'key3': 'val3'}, {'key3': 'val3'}]}
-        blueprint = self._put_blueprint_with_labels()
-        error_msg = '400: .*You cannot define the same label twice.*'
+        blueprint = self.put_blueprint_with_labels(self.LABELS)
+        error_msg = '400: .*You cannot define the same label twice'
         self.assertRaisesRegex(exceptions.CloudifyClientError,
                                error_msg,
                                self.client.blueprints.update,
@@ -528,6 +529,3 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
         updated_bp = self.client.blueprints.update(blueprint['id'],
                                                    {'labels': new_labels})
         self.assert_resource_labels(updated_bp['labels'], new_labels)
-
-    def _put_blueprint_with_labels(self):
-        return self.put_blueprint(labels=[{'key1': 'val1', 'key2': 'val2'}])


### PR DESCRIPTION
This PR implements the logic for filtering deployments and blueprints by allowed attributes, which are:
For blueprint: `created_by`. 
For deployments: `blueprint_id`, `created_by`, `site_name`.

Complementary PR https://github.com/cloudify-cosmo/cloudify-premium/pull/742