### PR TITLE
RD-1514 plugins update decoupling

### DIFF
--- a/rest-service/manager_rest/plugins_update/manager.py
+++ b/rest-service/manager_rest/plugins_update/manager.py
@@ -15,6 +15,8 @@
 
 import os
 import uuid
+import shutil
+from datetime import datetime
 
 from flask import current_app
 
@@ -44,7 +46,8 @@ from manager_rest.plugins_update.constants import (STATES,
 from manager_rest.manager_exceptions import (ConflictError,
                                              PluginsUpdateError,
                                              IllegalActionError)
-from manager_rest.constants import FILE_SERVER_BLUEPRINTS_FOLDER
+from manager_rest.constants import (FILE_SERVER_BLUEPRINTS_FOLDER,
+                                    FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER)
 
 
 PLUGIN_VERSION_CONSTRAINTS = 'plugin_version_constraints'
@@ -68,7 +71,17 @@ class PluginsUpdateManager(object):
             '{0}'.format(', '.join(u.id for u in active_updates)))
 
     def _create_temp_blueprint_from(self, blueprint, temp_plan):
-        temp_blueprint_id = str(uuid.uuid4())
+
+        def description(description: str, orig_blueprint_id: str) -> str:
+            ts = utils.get_formatted_timestamp()
+            comment = f'copied from {orig_blueprint_id} at {ts} on ' \
+                      'plugins update'
+            if description:
+                return f'{description}\n{comment}'
+            return comment
+
+        timestamp = datetime.now().strftime('%Y%m%dT%H%M%S.%f')
+        temp_blueprint_id = f'plugins-update-{timestamp}-{blueprint.id}'
         kwargs = {
             'application_file_name': blueprint.main_file_name,
             'blueprint_id': temp_blueprint_id,
@@ -83,6 +96,8 @@ class PluginsUpdateManager(object):
             kwargs['visibility'] = None
             kwargs['private_resource'] = blueprint.private_resource
         temp_blueprint = self.rm.publish_blueprint_from_plan(**kwargs)
+        temp_blueprint.description = description(temp_blueprint.description,
+                                                 blueprint.id)
         temp_blueprint.is_hidden = True
         return self.sm.update(temp_blueprint)
 
@@ -148,6 +163,30 @@ class PluginsUpdateManager(object):
         plugins_update.state = STATES.FINALIZING
         self.sm.update(plugins_update)
 
+        updated_deployments = self._get_deployments_to_update(
+            plugins_update.temp_blueprint_id)
+
+        not_updated_deployments = self._get_deployments_to_update(
+            plugins_update.blueprint_id)
+
+        if not_updated_deployments:
+            current_app.logger.error(
+                "These deployments were not updated during plugins update "
+                "ID %s, execution ID %s: %s",
+                plugins_update_id, plugins_update.execution.id,
+                ', '.join(dep.id for dep in not_updated_deployments))
+
+            if updated_deployments:
+                # instantiate the updated blueprint (temp_blueprint)
+                self._copy_blueprint_files(plugins_update.blueprint,
+                                           plugins_update.temp_blueprint)
+                plugins_update.temp_blueprint.is_hidden = False
+                self.sm.update(plugins_update.temp_blueprint)
+            else:
+                self.sm.delete(plugins_update.temp_blueprint)
+
+            self._raise_error(plugins_update)
+
         plugins_update.blueprint.plan = plugins_update.temp_blueprint.plan
         self.sm.update(plugins_update.blueprint)
 
@@ -176,12 +215,55 @@ class PluginsUpdateManager(object):
         execution = self.sm.get(models.Execution, plugins_update.execution_id)
         if (execution.status in ExecutionState.END_STATES
                 and execution.status != ExecutionState.TERMINATED):
-            plugins_update.state = STATES.FAILED
-            self.sm.update(plugins_update)
-            raise PluginsUpdateError(
-                'The execution of plugins update {0} {1}.'.format(
-                    plugins_update.id,
-                    execution.status.lower()))
+            self._raise_error(plugins_update, execution)
+
+    def _raise_error(self, plugins_update, execution=None):
+        if execution is None:
+            execution = self.sm.get(models.Execution,
+                                    plugins_update.execution_id)
+        plugins_update.state = STATES.FAILED
+        self.sm.update(plugins_update)
+        raise PluginsUpdateError(
+            'The execution of plugins update {0} {1}.'.format(
+                plugins_update.id,
+                execution.status.lower()))
+
+    def _copy_blueprint_files(self, src_blueprint, dst_blueprint):
+        """Duplicate a blueprint files on disk."""
+        # copy a blueprint archive
+        dst_dir = os.path.join(config.instance.file_server_root,
+                               FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER,
+                               dst_blueprint.tenant.name,
+                               dst_blueprint.id)
+        shutil.copytree(
+            os.path.join(config.instance.file_server_root,
+                         FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER,
+                         src_blueprint.tenant.name,
+                         src_blueprint.id),
+            dst_dir,
+        )
+        src_archive_filename = os.listdir(dst_dir)[0]
+        dst_archive_filename = src_archive_filename.replace(
+            src_blueprint.id, dst_blueprint.id, 1)
+        shutil.move(
+            os.path.join(config.instance.file_server_root,
+                         FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER,
+                         dst_blueprint.tenant.name,
+                         dst_blueprint.id,
+                         src_archive_filename),
+            os.path.join(dst_dir, dst_archive_filename)
+        )
+        # copy a blueprint
+        shutil.copytree(
+            os.path.join(config.instance.file_server_root,
+                         FILE_SERVER_BLUEPRINTS_FOLDER,
+                         src_blueprint.tenant.name,
+                         src_blueprint.id),
+            os.path.join(config.instance.file_server_root,
+                         FILE_SERVER_BLUEPRINTS_FOLDER,
+                         dst_blueprint.tenant.name,
+                         dst_blueprint.id)
+        )
 
     def _get_deployments_to_update(self, blueprint_id):
         return self.sm.list(models.Deployment,

--- a/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
@@ -283,7 +283,7 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
             self._sm.get(models.Blueprint, plugins_update.temp_blueprint_id)
 
     def test_finalize_error_if_deployments_not_updated(self):
-        self.put_blueprint(blueprint_id='bp')
+        self.put_file(*self.put_blueprint_args(blueprint_id='bp'))
         self.client.deployments.create('bp', 'dep')
         self.wait_for_deployment_creation(self.client, 'dep')
         plugins_update = self.client.plugins_update.update_plugins('bp')
@@ -296,7 +296,7 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
             self.assertIn(str(ex), plugins_update.id)
 
     def test_finalize_no_deployments_updated(self):
-        self.put_blueprint(blueprint_id='bp')
+        self.put_file(*self.put_blueprint_args(blueprint_id='bp'))
         self.client.deployments.create('bp', 'dep')
         self.wait_for_deployment_creation(self.client, 'dep')
         plugins_update = self.client.plugins_update.update_plugins('bp')
@@ -316,7 +316,7 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
 
     def test_deployments_partially_updated(self):
         """Test the case where only a part of deployments was updated."""
-        self.put_blueprint(blueprint_id='bp')
+        self.put_file(*self.put_blueprint_args(blueprint_id='bp'))
         self.client.deployments.create('bp', 'dep1')
         self.wait_for_deployment_creation(self.client, 'dep1')
         self.client.deployments.create('bp', 'dep2')

--- a/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
@@ -244,6 +244,7 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
         plan[DEPLOYMENT_PLUGINS_TO_INSTALL].append('dummy')
         blueprint.plan = plan
         self._sm.update(blueprint)
+        self.pretend_deployments_updated(plugins_update_id)
         # Sanity check
         self.assertIn(
             'dummy',
@@ -263,6 +264,7 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
         plugins_update = self.client.plugins_update.update_plugins(
             'hello_world')
         self.assertNotEqual(plugins_update.state, STATES.SUCCESSFUL)
+        self.pretend_deployments_updated(plugins_update.id)
         plugins_update = self.client.plugins_update.finalize_plugins_update(
             plugins_update.id)
         self.assertEqual(plugins_update.state, STATES.SUCCESSFUL)
@@ -274,10 +276,76 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
         plugins_update = self.client.plugins_update.update_plugins(
             'hello_world')
         self._sm.get(models.Blueprint, plugins_update.temp_blueprint_id)
-        plugins_update = self.client.plugins_update.finalize_plugins_update(
-            plugins_update.id)
+        with self.assertRaises(CloudifyClientError):
+            plugins_update = self.client.plugins_update.\
+                finalize_plugins_update(plugins_update.id)
         with self.assertRaises(NotFoundError):
             self._sm.get(models.Blueprint, plugins_update.temp_blueprint_id)
+
+    def test_finalize_error_if_deployments_not_updated(self):
+        self.put_blueprint(blueprint_id='bp')
+        self.client.deployments.create('bp', 'dep')
+        self.wait_for_deployment_creation(self.client, 'dep')
+        plugins_update = self.client.plugins_update.update_plugins('bp')
+        self._sm.get(models.Blueprint, plugins_update.temp_blueprint_id)
+        with self.assertRaises(CloudifyClientError) as ex:
+            plugins_update = self.client.plugins_update.\
+                finalize_plugins_update(plugins_update.id)
+            self.assertEqual(STATES.FAILED, plugins_update.state)
+            self.assertEqual(ex.status_code, 400)
+            self.assertIn(str(ex), plugins_update.id)
+
+    def test_finalize_no_deployments_updated(self):
+        self.put_blueprint(blueprint_id='bp')
+        self.client.deployments.create('bp', 'dep')
+        self.wait_for_deployment_creation(self.client, 'dep')
+        plugins_update = self.client.plugins_update.update_plugins('bp')
+        self._sm.get(models.Blueprint, plugins_update.temp_blueprint_id)
+        with self.assertRaises(CloudifyClientError):
+            plugins_update = self.client.plugins_update.\
+                finalize_plugins_update(plugins_update.id)
+        self.assertRegex(plugins_update['temp_blueprint_id'],
+                         r'^plugins-update\-.*\-bp$')
+        self.assertEmpty(self._sm.list(
+            models.Deployment,
+            filters={'blueprint_id': plugins_update['temp_blueprint_id']},
+        ).items)
+        updated_deployment = self._sm.get(
+            models.Deployment, plugins_update.deployments_to_update[0])
+        self.assertEqual('bp', updated_deployment.blueprint.id)
+
+    def test_deployments_partially_updated(self):
+        """Test the case where only a part of deployments was updated."""
+        self.put_blueprint(blueprint_id='bp')
+        self.client.deployments.create('bp', 'dep1')
+        self.wait_for_deployment_creation(self.client, 'dep1')
+        self.client.deployments.create('bp', 'dep2')
+        self.wait_for_deployment_creation(self.client, 'dep2')
+        plugins_update = self.client.plugins_update.update_plugins('bp')
+        self.pretend_deployments_updated(plugins_update.id, ['dep1'])
+        with self.assertRaises(CloudifyClientError):
+            plugins_update = self.client.plugins_update.\
+                finalize_plugins_update(plugins_update.id)
+        # Check "updated" deployment
+        dep1 = self._sm.get(models.Deployment, 'dep1')
+        self.assertEqual(plugins_update.temp_blueprint_id, dep1.blueprint.id)
+        # Check not update deployment
+        dep2 = self._sm.get(models.Deployment, 'dep2')
+        self.assertEqual(plugins_update.blueprint_id, dep2.blueprint.id)
+
+    def pretend_deployments_updated(self, plugins_update_id: str,
+                                    deployment_ids: list = None):
+        """Pretend those deployments were updated."""
+        plugins_update = self._sm.get(models.PluginsUpdate,
+                                      plugins_update_id)
+        temp_blueprint = self._sm.get(models.Blueprint,
+                                      plugins_update.temp_blueprint.id)
+        if deployment_ids is None:
+            deployment_ids = plugins_update.deployments_to_update
+        for deployment_id in deployment_ids:
+            deployment = self._sm.get(models.Deployment, deployment_id)
+            deployment.blueprint = temp_blueprint
+            self._sm.update(deployment)
 
 
 @attr(client_min_version=3.1,

--- a/workflows/cloudify_system_workflows/plugins.py
+++ b/workflows/cloudify_system_workflows/plugins.py
@@ -17,6 +17,7 @@ from cloudify.utils import wait_for
 from cloudify.decorators import workflow
 from cloudify.manager import get_rest_client
 from cloudify.models_states import ExecutionState
+from cloudify_rest_client.exceptions import CloudifyClientError
 
 
 @workflow(system_wide=True)
@@ -78,29 +79,33 @@ def update(ctx, update_id, temp_blueprint_id, deployments_to_update,
     for dep in deployments_to_update:
         ctx.send_event('Executing deployment update for deployment '
                        '{}...'.format(dep))
-        execution_id = client.deployment_updates \
-            .update_with_existing_blueprint(
-                deployment_id=dep,
-                blueprint_id=temp_blueprint_id,
-                skip_install=True,
-                skip_uninstall=True,
-                skip_reinstall=True,
-                auto_correct_types=auto_correct_types) \
-            .execution_id
+        try:
+            execution_id = client.deployment_updates \
+                .update_with_existing_blueprint(
+                    deployment_id=dep,
+                    blueprint_id=temp_blueprint_id,
+                    skip_install=True,
+                    skip_uninstall=True,
+                    skip_reinstall=True,
+                    auto_correct_types=auto_correct_types) \
+                .execution_id
+        except CloudifyClientError:
+            execution_id = None
+            execution_status = ExecutionState.FAILED
+        else:
+            wait_for(client.executions.get,
+                     execution_id,
+                     'status',
+                     lambda x: x in ExecutionState.END_STATES,
+                     RuntimeError,
+                     get_wait_for_execution_message(execution_id))
+            execution_status = client.executions.get(execution_id).status
 
-        wait_for(client.executions.get,
-                 execution_id,
-                 'status',
-                 lambda x: x in ExecutionState.END_STATES,
-                 RuntimeError,
-                 get_wait_for_execution_message(execution_id))
-        execution_status = client.executions.get(execution_id).status
-        if execution_status in (ExecutionState.FAILED,
-                                ExecutionState.CANCELLED):
-            raise RuntimeError("Deployment update of deployment {0} with "
-                               "execution ID {1} failed, stopped this "
-                               "plugins update (id="
-                               "'{2}').".format(dep, execution_id, update_id))
+        msg = f'Deployment update of deployment {dep} {execution_status}. ' \
+            f'Plugins update ID {update_id}.'
+        if execution_id:
+            msg += f' Execution ID {execution_id}.'
+        ctx.send_event(msg)
 
     ctx.send_event('Finalizing plugins update...')
     client.plugins_update.finalize_plugins_update(update_id)

--- a/workflows/cloudify_system_workflows/tests/test_plugins.py
+++ b/workflows/cloudify_system_workflows/tests/test_plugins.py
@@ -91,7 +91,7 @@ class TestPluginsUpdate(unittest.TestCase):
     def _update_with_existing_blueprint_mock(deployment_id, *_, **__):
         return PropertyMock(execution_id=deployment_id)
 
-    def test_plugins_update_stops_when_one_deployment_update_fails(self):
+    def test_plugins_update_continues_when_one_deployment_update_fails(self):
         def get_execution_mock(execution_id):
             """
             :return: a mock of an execution object where its status is
@@ -103,33 +103,17 @@ class TestPluginsUpdate(unittest.TestCase):
                     status=execution_status['curr_exec_status'])
             return PropertyMock(status=ExecutionState.TERMINATED)
 
-        def _assert_update_func_raises():
-            with self.assertRaisesRegexp(
-                    RuntimeError,
-                    "Deployment update of deployment {0} with execution ID {0}"
-                    " failed, stopped this plugins update "
-                    "\\(id='my_update_id'\\)\\.".format(failed_execution_id)):
-                update_func(MagicMock(), 'my_update_id', None,
-                            dep_ids, False)
+        def _assert_update_func():
+            update_func(MagicMock(), 'my_update_id', None,
+                        dep_ids, False)
             should_call_these = [call(deployment_id=i,
                                       blueprint_id=None,
                                       skip_install=True,
                                       skip_uninstall=True,
                                       skip_reinstall=True,
                                       auto_correct_types=False)
-                                 for i in range(failed_execution_id)]
+                                 for i in dep_ids]
             self.deployment_update_mock.assert_has_calls(should_call_these)
-
-            should_not_call_these = [call(deployment_id=i,
-                                          blueprint_id=None,
-                                          skip_install=True,
-                                          skip_uninstall=True,
-                                          skip_reinstall=True,
-                                          auto_correct_types=False)
-                                     for i in range(
-                    failed_execution_id + 1, len(dep_ids))]
-            for _call in self.deployment_update_mock.mock_calls:
-                self.assertNotIn(_call, should_not_call_these)
 
         execution_status = {'curr_exec_status': ExecutionState.FAILED}
 
@@ -138,9 +122,9 @@ class TestPluginsUpdate(unittest.TestCase):
         self.mock_rest_client.executions.get \
             .side_effect = get_execution_mock
 
-        _assert_update_func_raises()
+        _assert_update_func()
         execution_status['curr_exec_status'] = ExecutionState.CANCELLED
-        _assert_update_func_raises()
+        _assert_update_func()
 
     def test_doesnt_stop_updating(self):
         finalize_update_mock = MagicMock()


### PR DESCRIPTION
* Easier to read temporary blueprint metadata

While updating plugins a temporary blueprint is created.  This patch
makes its `id` and `description` more descriptive, which will help to
find the original blueprint from which the copy was created.

* No RuntimeError on failed deployment update

Do not raise RuntimeError in case one of the deployments to update fails
to be updated.  Instead just send event/log and continue.

* Make manual update or continuation possible

In case there were deployments which failed to be updated during plugin
update flow, make the temporary blueprint visible and log the deployment
IDs for reference.

* Make a blueprint duplicate for updated deployments

If some of the updated deployments were successful and others were not,
let's make a copy of the original blueprint (and its archive).  Updated
deployments will refer to the copy, and unupdated deployments will refer
to the original.

* Fix PluginsUpdateTest for finalize_plugins_update

The solution includes pretending a deployment was updated during plugins
update procedure.

* Add test for partial only plugins update

* Update plugins_update workflow test

Test the workflow for continuation of the update, regardess of
deployment update failure(s).

* Don't use str.format() in logger

* plugins-update-[TIMESTAMP] prefix, not suffix

Adding a prefix to blueprint.id is a cleaner solution.