### PR TITLE
RD-1520 Create post searches endpoint

### DIFF
--- a/amqp-postgres/test-requirements.txt
+++ b/amqp-postgres/test-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common[dispatcher]
+git+https://github.com/cloudify-cosmo/cloudify-common@RD-1520-create-post-searches-endpoint#egg=cloudify-common[dispatcher]
 -e ../rest-service
 mock
 pytest

--- a/rest-service/dev-requirements.txt
+++ b/rest-service/dev-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cloudify-cosmo/cloudify-common@master#egg=cloudify-common[dispatcher]
+git+https://github.com/cloudify-cosmo/cloudify-common@RD-1520-create-post-searches-endpoint#egg=cloudify-common[dispatcher]
 
 # For dealing with the binary leftovers of psycopg2 in the 2.7.x version
 psycopg2==2.7.4 --no-binary psycopg2

--- a/rest-service/manager_rest/rest/endpoint_mapper.py
+++ b/rest-service/manager_rest/rest/endpoint_mapper.py
@@ -145,6 +145,8 @@ def setup_resources(api):
         'ExecutionGroupsId': 'execution-groups/<string:group_id>',
         'BlueprintsLabels': 'labels/blueprints',
         'BlueprintsLabelsKey': 'labels/blueprints/<string:key>',
+        'DeploymentsSearches': 'searches/deployments',
+        'BlueprintsSearches': 'searches/blueprints'
     }
 
     # Set version endpoint as a non versioned endpoint

--- a/rest-service/manager_rest/rest/filters_utils.py
+++ b/rest-service/manager_rest/rest/filters_utils.py
@@ -20,17 +20,12 @@ class FilterRule(dict):
         self['operator'] = operator
         self['type'] = filter_rule_type
 
-    def __key(self):
+    def _key(self):
         return (self['key'], tuple(self['values']),
                 self['operator'], self['type'])
 
     def __hash__(self):
-        return hash(self.__key())
-
-    def __eq__(self, other):
-        if isinstance(other, FilterRule):
-            return self.__key() == other.__key()
-        return NotImplemented
+        return hash(self._key())
 
 
 FilteredModels = NewType('FilteredModels',

--- a/rest-service/manager_rest/rest/filters_utils.py
+++ b/rest-service/manager_rest/rest/filters_utils.py
@@ -34,11 +34,6 @@ def get_filter_rules_from_filter_id(filter_id):
     return filter_elem.value
 
 
-def get_filter_rule_tuple(filter_rule):
-    return (filter_rule['key'], tuple(filter_rule['values']),
-            filter_rule['operator'], filter_rule['type'])
-
-
 def create_filter_rules_list(raw_filter_rules: List[dict],
                              resource_model: FilteredModels):
     """Validate the raw filter rules list and return a FilterRule items list.
@@ -55,7 +50,6 @@ def create_filter_rules_list(raw_filter_rules: List[dict],
     :return: A list of FilterRule items
     """
     filter_rules_list = []
-    filter_rules_set = set()
     for filter_rule in raw_filter_rules:
         _assert_filter_rule_structure(filter_rule)
 
@@ -126,12 +120,6 @@ def create_filter_rules_list(raw_filter_rules: List[dict],
                                      filter_rule_values,
                                      filter_rule_operator,
                                      filter_rule_type)
-        new_filter_rule_tuple = get_filter_rule_tuple(new_filter_rule)
-        if new_filter_rule_tuple in filter_rules_set:
-            raise BadParametersError(
-                f'Filter rules must be unique. The filter rule {filter_rule} '
-                f'is not unique')
-        filter_rules_set.add(new_filter_rule_tuple)
         filter_rules_list.append(new_filter_rule)
 
     return filter_rules_list

--- a/rest-service/manager_rest/rest/filters_utils.py
+++ b/rest-service/manager_rest/rest/filters_utils.py
@@ -20,6 +20,18 @@ class FilterRule(dict):
         self['operator'] = operator
         self['type'] = filter_rule_type
 
+    def __key(self):
+        return (self['key'], tuple(self['values']),
+                self['operator'], self['type'])
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        if isinstance(other, FilterRule):
+            return self.__key() == other.__key()
+        return NotImplemented
+
 
 FilteredModels = NewType('FilteredModels',
                          Union[models.Deployment, models.Blueprint])
@@ -120,6 +132,8 @@ def create_filter_rules_list(raw_filter_rules: List[dict],
                                      filter_rule_values,
                                      filter_rule_operator,
                                      filter_rule_type)
+        if new_filter_rule in filter_rules_list:
+            continue
         filter_rules_list.append(new_filter_rule)
 
     return filter_rules_list

--- a/rest-service/manager_rest/rest/resources_v2/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v2/blueprints.py
@@ -18,9 +18,9 @@ from flask import request
 from flask_restful_swagger import swagger
 
 from manager_rest.security.authorization import authorize
-from manager_rest.rest.filters_utils import get_filter_rules
 from manager_rest.storage import get_storage_manager, models
 from manager_rest.utils import create_filter_params_list_description
+from manager_rest.rest.filters_utils import get_filter_rules_from_filter_id
 from manager_rest.rest import (resources_v1,
                                rest_decorators,
                                rest_utils)
@@ -45,8 +45,9 @@ class Blueprints(resources_v1.Blueprints):
     @rest_decorators.sortable(models.Blueprint)
     @rest_decorators.all_tenants
     @rest_decorators.search('id')
+    @rest_decorators.filter_id
     def get(self, _include=None, filters=None, pagination=None, sort=None,
-            all_tenants=None, search=None, **kwargs):
+            all_tenants=None, search=None, filter_id=None, **kwargs):
         """
         List uploaded blueprints
         """
@@ -54,11 +55,9 @@ class Blueprints(resources_v1.Blueprints):
             '_get_all_results',
             request.args.get('_get_all_results', False)
         )
-        if _include and 'labels' in _include:
-            _include = None
-        if not filters:
-            filters = {}
-        filters.setdefault('is_hidden', False)
+        filters, _include = rest_utils.modify_blueprints_list_args(filters,
+                                                                   _include)
+        filter_rules = get_filter_rules_from_filter_id(filter_id)
         return get_storage_manager().list(
             models.Blueprint,
             include=_include,
@@ -68,7 +67,7 @@ class Blueprints(resources_v1.Blueprints):
             sort=sort,
             all_tenants=all_tenants,
             get_all_results=get_all_results,
-            filter_rules=get_filter_rules(models.Blueprint)
+            filter_rules=filter_rules
         )
 
 

--- a/rest-service/manager_rest/rest/resources_v2/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v2/deployments.py
@@ -27,8 +27,8 @@ from manager_rest.storage import (
     models,
 )
 from manager_rest.security.authorization import authorize
-from manager_rest.rest.filters_utils import get_filter_rules
 from manager_rest.utils import create_filter_params_list_description
+from manager_rest.rest.filters_utils import get_filter_rules_from_filter_id
 
 
 class Deployments(resources_v1.Deployments):
@@ -50,8 +50,9 @@ class Deployments(resources_v1.Deployments):
     @rest_decorators.sortable(models.Deployment)
     @rest_decorators.all_tenants
     @rest_decorators.search('id')
+    @rest_decorators.filter_id
     def get(self, _include=None, filters=None, pagination=None, sort=None,
-            all_tenants=None, search=None, **kwargs):
+            all_tenants=None, search=None, filter_id=None, **kwargs):
         """
         List deployments
         """
@@ -59,13 +60,9 @@ class Deployments(resources_v1.Deployments):
             '_get_all_results',
             request.args.get('_get_all_results', False)
         )
-        if '_group_id' in request.args:
-            filters['deployment_groups'] = lambda col: col.any(
-                models.DeploymentGroup.id == request.args['_group_id']
-            )
-        if _include:
-            if {'labels', 'deployment_groups'}.intersection(_include):
-                _include = None
+        filters, _include = rest_utils.modify_deployments_list_args(filters,
+                                                                    _include)
+        filter_rules = get_filter_rules_from_filter_id(filter_id)
         result = get_storage_manager().list(
             models.Deployment,
             include=_include,
@@ -75,7 +72,7 @@ class Deployments(resources_v1.Deployments):
             sort=sort,
             all_tenants=all_tenants,
             get_all_results=get_all_results,
-            filter_rules=get_filter_rules(models.Deployment)
+            filter_rules=filter_rules
         )
 
         if _include and 'workflows' in _include:

--- a/rest-service/manager_rest/rest/resources_v3_1/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/__init__.py
@@ -128,3 +128,8 @@ from .nodes import (  # NOQA
     Nodes,
     NodeInstances,
 )
+
+from .searches import (  # NOQA
+    DeploymentsSearches,
+    BlueprintsSearches
+)

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -39,6 +39,7 @@ from manager_rest.manager_exceptions import (BadParametersError,
 from manager_rest.resource_manager import get_resource_manager
 from manager_rest.maintenance import is_bypass_maintenance_mode
 from manager_rest.dsl_functions import evaluate_deployment_capabilities
+from manager_rest.rest.filters_utils import get_filter_rules_from_filter_id
 from manager_rest.rest import (
     rest_utils,
     resources_v1,
@@ -540,10 +541,9 @@ class DeploymentGroupsId(SecuredResource):
 
         filter_id = request_dict.get('filter_id')
         if filter_id is not None:
-            filter_elem = sm.get(models.Filter, filter_id)
             deployments = sm.list(
                 models.Deployment,
-                filter_rules=filter_elem.value.get('labels', {})
+                filter_rules=get_filter_rules_from_filter_id(filter_id)
             )
             for dep in deployments:
                 group.deployments.append(dep)
@@ -576,10 +576,9 @@ class DeploymentGroupsId(SecuredResource):
 
         filter_id = request_dict.get('filter_id')
         if filter_id is not None:
-            filter_elem = sm.get(models.Filter, filter_id)
             deployments = sm.list(
                 models.Deployment,
-                filter_rules=filter_elem.value.get('labels', {})
+                filter_rules=get_filter_rules_from_filter_id(filter_id)
             )
             for dep in deployments:
                 group.deployments.remove(dep)

--- a/rest-service/manager_rest/rest/resources_v3_1/searches.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/searches.py
@@ -1,133 +1,94 @@
-from collections import OrderedDict
+from flask import request
 
-from cloudify._compat import text_type
-
-from manager_rest import manager_exceptions
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
 from manager_rest.storage import models, get_storage_manager
+from manager_rest.manager_exceptions import BadParametersError
 
 from ..responses_v2 import ListResponse
 from .. import rest_decorators, rest_utils
-from ..filters_utils import create_filter_rules_list
+from ..filters_utils import (create_filter_rules_list,
+                             get_filter_rule_tuple,
+                             get_filter_rules_from_filter_id)
 
 
 class ResourceSearches(SecuredResource):
-    def post(self, resource_model, _include):
-        """List resource items
-
-        The payload for this request is of the following form:
-        {
-          include = [<list of columns to include in the response>],
-          filters = {<column_name>: <}
-          A dictionary where keys are column names to
-                        filter by, and values are values applicable for those
-                        columns (or lists of such values)
-          filter_rules = [<list of filter rules>],
-          filter_id = <The ID of an existing filter>,
-          order = [{attribute: <resource attribute>, sort: <'asc' or 'desc'>}],
-          pagination = {'size': <size>, 'offset': <offset>},
-          all_tenants = <True or False>,
-          get_all_results = <True or False>
-        }
-        """
-        request_schema = {
-            'include': {'optional': True, 'type': list},
-            'filter_rules': {'optional': True, 'type': list},
-            'filter_id': {'optional': True, 'type': text_type},
-            'order': {'optional': True, 'type': list},
-            'pagination': {'optional': True, 'type': dict},
-            'all_tenants': {'optional': True, 'type': bool},
-            'get_all_results': {'optional': True, 'type': bool}
-        }
+    def post(self, resource_model, _include, filters, pagination, sort,
+             all_tenants, search, filter_id, **kwargs):
+        """List resource items"""
+        get_all_results = rest_utils.verify_and_convert_bool(
+            '_get_all_results',
+            request.args.get('_get_all_results', False)
+        )
+        request_schema = {'filter_rules': {'optional': False, 'type': list}}
         request_dict = rest_utils.get_json_and_verify_params(request_schema)
 
-        if _include and {'labels', 'deployment_groups'}.intersection(_include):
-            _include = None
-        filter_rules = _get_filter_rules(request_dict, resource_model)
-        order_dict = _get_order_dict(request_dict, resource_model)
-        pagination = _get_pagination(request_dict)
+        filter_rules = _get_filter_rules(request_dict['filter_rules'],
+                                         resource_model, filter_id)
 
         result = get_storage_manager().list(
             resource_model,
             include=_include,
-            filter_rules=filter_rules,
+            filters=filters,
+            substr_filters=search,
             pagination=pagination,
-            sort=order_dict,
-            all_tenants=request_dict.get('all_tenants'),
-            get_all_results=request_dict.get('get_all_results')
+            sort=sort,
+            all_tenants=all_tenants,
+            get_all_results=get_all_results,
+            filter_rules=filter_rules
         )
 
         return ListResponse(items=result.items, metadata=result.metadata)
 
 
-def _get_filter_rules(request_dict, resource_model):
-    filter_rules = []
-    filter_id = request_dict.get('filter_id')
-    raw_filter_rules = request_dict.get('filter_rules')
-
-    if raw_filter_rules:
-        filter_rules = create_filter_rules_list(raw_filter_rules,
-                                                resource_model)
+def _get_filter_rules(raw_filter_rules, resource_model, filter_id):
+    filter_rules = create_filter_rules_list(raw_filter_rules, resource_model)
     if filter_id:
-        rest_utils.validate_inputs({'filter_id': filter_id})
-        filter_elem = get_storage_manager().get(models.Filter, filter_id)
-        filter_rules.extend(filter_elem.value)
+        filter_rules_set = set(get_filter_rule_tuple(filter_rule) for
+                               filter_rule in filter_rules)
+        existing_filter_rules = get_filter_rules_from_filter_id(filter_id)
+        for existing_filter_rule in existing_filter_rules:
+            err_msg = f'The filter rule {existing_filter_rule} is part of ' \
+                      f'the filter `{filter_id}` and therefore cannot be ' \
+                      f'part of the filter rules list'
+            if get_filter_rule_tuple(existing_filter_rule) in filter_rules_set:
+                raise BadParametersError(err_msg)
+        filter_rules.extend(existing_filter_rules)
 
     return filter_rules
-
-
-def _get_pagination(request_dict):
-    pagination_dict = request_dict.get('pagination')
-    if pagination_dict is None:
-        return
-
-    err_msg = "The `pagination` value must be a dictionary of the form " \
-              "{'size': <a positive integer>, 'offset': <a positive integer>}"
-    if pagination_dict.keys() != {'size', 'offset'}:
-        raise manager_exceptions.BadParametersError(err_msg)
-    size, offset = pagination_dict['size'], pagination_dict['offset']
-    if not isinstance(size, int) or not isinstance(offset, int):
-        raise manager_exceptions.BadParametersError(err_msg)
-    if pagination_dict['size'] <= 0 or pagination_dict['offset'] <= 0:
-        raise manager_exceptions.BadParametersError(err_msg)
-
-    return pagination_dict
-
-
-def _get_order_dict(request_dict, resource_model):
-    order_list = request_dict.get('order')
-    if order_list is None:
-        return
-
-    err_msg = "The `sort` value must be a list of dictionaries of the form " \
-              "{'attribute': <resource attribute>, 'sort':<'asc' or 'desc'>}"
-    order_dict = OrderedDict()
-    for order in order_list:
-        if order.keys() != {'attribute', 'sort'}:
-            raise manager_exceptions.BadParametersError(err_msg)
-        order_by = order['sort']
-        if order_by not in ('asc', 'desc'):
-            raise manager_exceptions.BadParametersError(err_msg)
-        order_dict[order['attribute']] = order_by
-
-    if any(attr not in resource_model.resource_fields for attr in order_dict):
-        raise manager_exceptions.BadParametersError(err_msg)
-
-    return order_dict
 
 
 class DeploymentsSearches(ResourceSearches):
     @authorize('deployment_list', allow_all_tenants=True)
     @rest_decorators.marshal_with(models.Deployment)
-    def post(self, _include=None):
+    @rest_decorators.create_filters(models.Deployment)
+    @rest_decorators.paginate
+    @rest_decorators.sortable(models.Deployment)
+    @rest_decorators.all_tenants
+    @rest_decorators.search('id')
+    @rest_decorators.filter_id
+    def post(self, _include=None, filters=None, pagination=None, sort=None,
+             all_tenants=None, search=None, filter_id=None, **kwargs):
         """List Deployments"""
-        return super().post(models.Deployment, _include)
+        filters, _include = rest_utils.modify_deployments_list_args(filters,
+                                                                    _include)
+        return super().post(models.Deployment, _include, filters, pagination,
+                            sort, all_tenants, search, filter_id, **kwargs)
 
 
 class BlueprintsSearches(ResourceSearches):
     @authorize('blueprint_list', allow_all_tenants=True)
     @rest_decorators.marshal_with(models.Blueprint)
-    def post(self, _include=None):
+    @rest_decorators.create_filters(models.Blueprint)
+    @rest_decorators.paginate
+    @rest_decorators.sortable(models.Blueprint)
+    @rest_decorators.all_tenants
+    @rest_decorators.search('id')
+    @rest_decorators.filter_id
+    def post(self, _include=None, filters=None, pagination=None, sort=None,
+             all_tenants=None, search=None, filter_id=None, **kwargs):
         """List Blueprints"""
-        return super().post(models.Blueprint, _include)
+        filters, _include = rest_utils.modify_blueprints_list_args(filters,
+                                                                   _include)
+        return super().post(models.Blueprint, _include, filters, pagination,
+                            sort, all_tenants, search, filter_id, **kwargs)

--- a/rest-service/manager_rest/rest/resources_v3_1/searches.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/searches.py
@@ -13,7 +13,7 @@ from ..filters_utils import (create_filter_rules_list,
 
 class ResourceSearches(SecuredResource):
     def post(self, resource_model, _include, filters, pagination, sort,
-             all_tenants, search, filter_id, **kwargs):
+             all_tenants, filter_id, **kwargs):
         """List resource items"""
         get_all_results = rest_utils.verify_and_convert_bool(
             '_get_all_results',
@@ -29,7 +29,6 @@ class ResourceSearches(SecuredResource):
             resource_model,
             include=_include,
             filters=filters,
-            substr_filters=search,
             pagination=pagination,
             sort=sort,
             all_tenants=all_tenants,
@@ -59,34 +58,30 @@ def get_filter_rules(raw_filter_rules, resource_model, filter_id):
 class DeploymentsSearches(ResourceSearches):
     @authorize('deployment_list', allow_all_tenants=True)
     @rest_decorators.marshal_with(models.Deployment)
-    @rest_decorators.create_filters(models.Deployment)
     @rest_decorators.paginate
     @rest_decorators.sortable(models.Deployment)
     @rest_decorators.all_tenants
-    @rest_decorators.search('id')
     @rest_decorators.filter_id
-    def post(self, _include=None, filters=None, pagination=None, sort=None,
-             all_tenants=None, search=None, filter_id=None, **kwargs):
+    def post(self, _include=None, pagination=None, sort=None,
+             all_tenants=None, filter_id=None, **kwargs):
         """List Deployments using filter rules"""
-        filters, _include = rest_utils.modify_deployments_list_args(filters,
+        filters, _include = rest_utils.modify_deployments_list_args({},
                                                                     _include)
         return super().post(models.Deployment, _include, filters, pagination,
-                            sort, all_tenants, search, filter_id, **kwargs)
+                            sort, all_tenants, filter_id, **kwargs)
 
 
 class BlueprintsSearches(ResourceSearches):
     @authorize('blueprint_list', allow_all_tenants=True)
     @rest_decorators.marshal_with(models.Blueprint)
-    @rest_decorators.create_filters(models.Blueprint)
     @rest_decorators.paginate
     @rest_decorators.sortable(models.Blueprint)
     @rest_decorators.all_tenants
-    @rest_decorators.search('id')
     @rest_decorators.filter_id
-    def post(self, _include=None, filters=None, pagination=None, sort=None,
-             all_tenants=None, search=None, filter_id=None, **kwargs):
+    def post(self, _include=None, pagination=None, sort=None,
+             all_tenants=None, filter_id=None, **kwargs):
         """List Blueprints using filter rules"""
-        filters, _include = rest_utils.modify_blueprints_list_args(filters,
+        filters, _include = rest_utils.modify_blueprints_list_args({},
                                                                    _include)
         return super().post(models.Blueprint, _include, filters, pagination,
-                            sort, all_tenants, search, filter_id, **kwargs)
+                            sort, all_tenants, filter_id, **kwargs)

--- a/rest-service/manager_rest/rest/resources_v3_1/searches.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/searches.py
@@ -1,0 +1,133 @@
+from collections import OrderedDict
+
+from cloudify._compat import text_type
+
+from manager_rest import manager_exceptions
+from manager_rest.security import SecuredResource
+from manager_rest.security.authorization import authorize
+from manager_rest.storage import models, get_storage_manager
+
+from ..responses_v2 import ListResponse
+from .. import rest_decorators, rest_utils
+from ..filters_utils import create_filter_rules_list
+
+
+class ResourceSearches(SecuredResource):
+    def post(self, resource_model, _include):
+        """List resource items
+
+        The payload for this request is of the following form:
+        {
+          include = [<list of columns to include in the response>],
+          filters = {<column_name>: <}
+          A dictionary where keys are column names to
+                        filter by, and values are values applicable for those
+                        columns (or lists of such values)
+          filter_rules = [<list of filter rules>],
+          filter_id = <The ID of an existing filter>,
+          order = [{attribute: <resource attribute>, sort: <'asc' or 'desc'>}],
+          pagination = {'size': <size>, 'offset': <offset>},
+          all_tenants = <True or False>,
+          get_all_results = <True or False>
+        }
+        """
+        request_schema = {
+            'include': {'optional': True, 'type': list},
+            'filter_rules': {'optional': True, 'type': list},
+            'filter_id': {'optional': True, 'type': text_type},
+            'order': {'optional': True, 'type': list},
+            'pagination': {'optional': True, 'type': dict},
+            'all_tenants': {'optional': True, 'type': bool},
+            'get_all_results': {'optional': True, 'type': bool}
+        }
+        request_dict = rest_utils.get_json_and_verify_params(request_schema)
+
+        if _include and {'labels', 'deployment_groups'}.intersection(_include):
+            _include = None
+        filter_rules = _get_filter_rules(request_dict, resource_model)
+        order_dict = _get_order_dict(request_dict, resource_model)
+        pagination = _get_pagination(request_dict)
+
+        result = get_storage_manager().list(
+            resource_model,
+            include=_include,
+            filter_rules=filter_rules,
+            pagination=pagination,
+            sort=order_dict,
+            all_tenants=request_dict.get('all_tenants'),
+            get_all_results=request_dict.get('get_all_results')
+        )
+
+        return ListResponse(items=result.items, metadata=result.metadata)
+
+
+def _get_filter_rules(request_dict, resource_model):
+    filter_rules = []
+    filter_id = request_dict.get('filter_id')
+    raw_filter_rules = request_dict.get('filter_rules')
+
+    if raw_filter_rules:
+        filter_rules = create_filter_rules_list(raw_filter_rules,
+                                                resource_model)
+    if filter_id:
+        rest_utils.validate_inputs({'filter_id': filter_id})
+        filter_elem = get_storage_manager().get(models.Filter, filter_id)
+        filter_rules.extend(filter_elem.value)
+
+    return filter_rules
+
+
+def _get_pagination(request_dict):
+    pagination_dict = request_dict.get('pagination')
+    if pagination_dict is None:
+        return
+
+    err_msg = "The `pagination` value must be a dictionary of the form " \
+              "{'size': <a positive integer>, 'offset': <a positive integer>}"
+    if pagination_dict.keys() != {'size', 'offset'}:
+        raise manager_exceptions.BadParametersError(err_msg)
+    size, offset = pagination_dict['size'], pagination_dict['offset']
+    if not isinstance(size, int) or not isinstance(offset, int):
+        raise manager_exceptions.BadParametersError(err_msg)
+    if pagination_dict['size'] <= 0 or pagination_dict['offset'] <= 0:
+        raise manager_exceptions.BadParametersError(err_msg)
+
+    return pagination_dict
+
+
+def _get_order_dict(request_dict, resource_model):
+    order_list = request_dict.get('order')
+    if order_list is None:
+        return
+
+    err_msg = "The `sort` value must be a list of dictionaries of the form " \
+              "{'attribute': <resource attribute>, 'sort':<'asc' or 'desc'>}"
+    order_dict = OrderedDict()
+    for order in order_list:
+        if order.keys() != {'attribute', 'sort'}:
+            raise manager_exceptions.BadParametersError(err_msg)
+        order_by = order['sort']
+        if order_by not in ('asc', 'desc'):
+            raise manager_exceptions.BadParametersError(err_msg)
+        order_dict[order['attribute']] = order_by
+
+    if any(attr not in resource_model.resource_fields for attr in order_dict):
+        raise manager_exceptions.BadParametersError(err_msg)
+
+    return order_dict
+
+
+class DeploymentsSearches(ResourceSearches):
+    @authorize('deployment_list', allow_all_tenants=True)
+    @rest_decorators.marshal_with(models.Deployment)
+    def post(self, _include=None):
+        """List Deployments"""
+        return super().post(models.Deployment, _include)
+
+
+class BlueprintsSearches(ResourceSearches):
+    @authorize('blueprint_list', allow_all_tenants=True)
+    @rest_decorators.marshal_with(models.Blueprint)
+    def post(self, _include=None):
+        """List Blueprints"""
+        return super().post(models.Blueprint, _include)

--- a/rest-service/manager_rest/rest/resources_v3_1/searches.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/searches.py
@@ -3,12 +3,10 @@ from flask import request
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
 from manager_rest.storage import models, get_storage_manager
-from manager_rest.manager_exceptions import BadParametersError
 
 from ..responses_v2 import ListResponse
 from .. import rest_decorators, rest_utils
 from ..filters_utils import (create_filter_rules_list,
-                             get_filter_rule_tuple,
                              get_filter_rules_from_filter_id)
 
 
@@ -44,15 +42,7 @@ class ResourceSearches(SecuredResource):
 def _get_filter_rules(raw_filter_rules, resource_model, filter_id):
     filter_rules = create_filter_rules_list(raw_filter_rules, resource_model)
     if filter_id:
-        filter_rules_set = set(get_filter_rule_tuple(filter_rule) for
-                               filter_rule in filter_rules)
         existing_filter_rules = get_filter_rules_from_filter_id(filter_id)
-        for existing_filter_rule in existing_filter_rules:
-            err_msg = f'The filter rule {existing_filter_rule} is part of ' \
-                      f'the filter `{filter_id}` and therefore cannot be ' \
-                      f'part of the filter rules list'
-            if get_filter_rule_tuple(existing_filter_rule) in filter_rules_set:
-                raise BadParametersError(err_msg)
         filter_rules.extend(existing_filter_rules)
 
     return filter_rules

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -796,3 +796,24 @@ def _verify_weekdays(weekdays, frequency):
                 "complex weekday expression {} can only be used with a months|"
                 "years frequency, but got {}.".format(weekday, frequency))
     return weekdays_caps
+
+
+def modify_blueprints_list_args(filters, _include):
+    if _include and 'labels' in _include:
+        _include = None
+    if filters is None:
+        filters = {}
+    filters.setdefault('is_hidden', False)
+    return filters, _include
+
+
+def modify_deployments_list_args(filters, _include):
+    if '_group_id' in request.args:
+        filters['deployment_groups'] = lambda col: col.any(
+            models.DeploymentGroup.id == request.args['_group_id']
+        )
+    if _include:
+        if {'labels', 'deployment_groups'}.intersection(_include):
+            _include = None
+
+    return filters, _include

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -799,6 +799,11 @@ def _verify_weekdays(weekdays, frequency):
 
 
 def modify_blueprints_list_args(filters, _include):
+    """
+    As blueprints list can be retrieved both using `POST /searches/blueprints`
+    and `GET /blueprints`, we need a function to serve both endpoints to modify
+    the `filters` and `_include` arguments.
+    """
     if _include and 'labels' in _include:
         _include = None
     if filters is None:
@@ -808,6 +813,11 @@ def modify_blueprints_list_args(filters, _include):
 
 
 def modify_deployments_list_args(filters, _include):
+    """
+    As blueprints list can be retrieved both using `POST /searches/blueprints`
+    and `GET /blueprints`, we need a function to serve both endpoints to modify
+    the `filters` and `_include` arguments.
+    """
     if '_group_id' in request.args:
         filters['deployment_groups'] = lambda col: col.any(
             models.DeploymentGroup.id == request.args['_group_id']

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -597,10 +597,7 @@ class SQLStorageManager(object):
                                 prevent consumption of too much memory
         :param distinct: An optional list of columns names to get distinct
                          results by.
-        :param filter_rules: A dictionary of filter rules. The keys in the
-                             dictionary specify the relevant filters, and
-                             the values are lists of rules.
-                             E.g. {'labels': ['a=b', 'c!=d']}
+        :param filter_rules: A list of filter rules.
         :return: A (possibly empty) list of `model_class` results
         """
         self._validate_available_memory()

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -255,6 +255,8 @@ class BaseServerTestCase(unittest.TestCase):
                         client.execution_groups.api = mock_http_client
                         client.execution_schedules.api = mock_http_client
                         client.blueprints_labels.api = mock_http_client
+                        client.deployments_search.api = mock_http_client
+                        client.blueprints_search.api = mock_http_client
 
         return client
 

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -147,6 +147,15 @@ class TestClient(FlaskClient):
 class BaseServerTestCase(unittest.TestCase):
     # hack for running tests with py2's unnitest, but using py3's
     # assert method name; to be removed once we run unittests on py3 only
+    LABELS = [{'env': 'aws'}, {'arch': 'k8s'}]
+    LABELS_2 = [{'env': 'gcp'}, {'arch': 'k8s'}]
+    FILTER_ID = 'filter'
+    FILTER_RULES = [FilterRule('env', ['aws'], 'not_any_of', 'label'),
+                    FilterRule('arch', ['k8s'], 'any_of', 'label')]
+
+    FILTER_RULES_2 = [FilterRule('env', ['aws'], 'any_of', 'label'),
+                      FilterRule('arch', ['k8s'], 'any_of', 'label')]
+
     def assertRaisesRegex(self, *a, **kw):
         return self.assertRaisesRegexp(*a, **kw)
 
@@ -255,8 +264,6 @@ class BaseServerTestCase(unittest.TestCase):
                         client.execution_groups.api = mock_http_client
                         client.execution_schedules.api = mock_http_client
                         client.blueprints_labels.api = mock_http_client
-                        client.deployments_search.api = mock_http_client
-                        client.blueprints_search.api = mock_http_client
 
         return client
 

--- a/rest-service/manager_rest/test/endpoints/test_blueprints.py
+++ b/rest-service/manager_rest/test/endpoints/test_blueprints.py
@@ -478,6 +478,19 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
 
     @attr(client_min_version=3.1,
           client_max_version=base_test.LATEST_API_VERSION)
+    def test_list_blueprints_with_filter_id(self):
+        self.put_blueprint_with_labels(self.LABELS, blueprint_id='bp1')
+        bp2 = self.put_blueprint_with_labels(self.LABELS_2, blueprint_id='bp2')
+        self.create_filter(self.client.deployments_filters,
+                           self.FILTER_ID, self.FILTER_RULES)
+        blueprints = self.client.blueprints.list(
+            filter_id=self.FILTER_ID)
+        self.assertEqual(len(blueprints), 1)
+        self.assertEqual(blueprints[0], bp2)
+        self.assert_metadata_filtered(blueprints, 1)
+
+    @attr(client_min_version=3.1,
+          client_max_version=base_test.LATEST_API_VERSION)
     def test_update_blueprint_labels(self):
         new_labels = [{'key2': 'val2'}, {'key3': 'val3'}]
         blueprint = self.put_blueprint_with_labels(self.LABELS)

--- a/rest-service/manager_rest/test/endpoints/test_blueprints.py
+++ b/rest-service/manager_rest/test/endpoints/test_blueprints.py
@@ -478,24 +478,6 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
 
     @attr(client_min_version=3.1,
           client_max_version=base_test.LATEST_API_VERSION)
-    def test_list_blueprints_with_filter_rules(self):
-        for i in range(1, 3):
-            bp_file_name = 'blueprint_with_labels_{0}.yaml'.format(i)
-            bp_id = 'blueprint_{0}'.format(i)
-            self.put_blueprint(blueprint_id=bp_id,
-                               blueprint_file_name=bp_file_name)
-        all_blueprints = self.client.blueprints.list(
-            filter_rules={'_filter_rules': ['bp_key1=bp_key1_val1']})
-        second_blueprint = self.client.blueprints.list(
-            filter_rules={'_filter_rules': ['bp_key2=bp_2_val1',
-                                            'bp_key1 is not null']})
-        self.assertEqual(len(all_blueprints), 2)
-        self.assert_metadata_filtered(all_blueprints, 0)
-        self.assertEqual(len(second_blueprint), 1)
-        self.assert_metadata_filtered(second_blueprint, 1)
-
-    @attr(client_min_version=3.1,
-          client_max_version=base_test.LATEST_API_VERSION)
     def test_update_blueprint_labels(self):
         new_labels = [{'key2': 'val2'}, {'key3': 'val3'}]
         blueprint = self.put_blueprint_with_labels(self.LABELS)

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -280,8 +280,9 @@ class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
         self.client.deployments.update_labels('dep1', [
             {'label1': 'value1'}
         ])
-        self.client.filters.create('filter1', [
-            'label1=value1'
+        self.client.deployments_filters.create('filter1', [
+            {'key': 'label1', 'values': ['value1'],
+             'operator': 'any_of', 'type': 'label'}
         ])
         self.client.deployment_groups.put(
             'group1',
@@ -295,8 +296,9 @@ class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
         self.client.deployments.update_labels('dep1', [
             {'label1': 'value1'}
         ])
-        self.client.filters.create('filter1', [
-            'label1=value1'
+        self.client.deployments_filters.create('filter1', [
+            {'key': 'label1', 'values': ['value1'],
+             'operator': 'any_of', 'type': 'label'}
         ])
         self.client.deployment_groups.put('group1')
         self.client.deployment_groups.add_deployments(
@@ -311,8 +313,9 @@ class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
         self.client.deployments.update_labels('dep1', [
             {'label1': 'value1'}
         ])
-        self.client.filters.create('filter1', [
-            'label1=value1'
+        self.client.deployments_filters.create('filter1', [
+            {'key': 'label1', 'values': ['value1'],
+             'operator': 'any_of', 'type': 'label'}
         ])
         self.client.deployment_groups.put(
             'group1',

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -46,9 +46,6 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
     UPPERCASE_LABELS = [{'EnV': 'aWs'}, {'aRcH': 'k8s'}]
     DUPLICATE_LABELS = [{'env': 'aws'}, {'env': 'aws'}]
     INVALID_LABELS = [{'env': 'aws', 'aRcH': 'k8s'}]
-    FILTER_ID = 'filter'
-    FILTER_RULES = ['env=aws']
-    FILTER_RULES_2 = ['env!=aws', 'arch=k8s']
 
     def test_get_empty(self):
         result = self.client.deployments.list()
@@ -1000,40 +997,6 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
                                blueprint_id=resource_id,
                                deployment_id=resource_id,
                                labels=[{'csys-blah': 'val1'}])
-
-    @attr(client_min_version=3.1,
-          client_max_version=base_test.LATEST_API_VERSION)
-    def test_list_deployments_with_filter_rules(self):
-        dep1 = self.put_deployment_with_labels(self.LABELS)
-        self.put_deployment_with_labels(self.LABELS_2)
-        deployments = self.client.deployments.list(
-            filter_rules={'_filter_rules': ['env=aws', 'arch=k8s']})
-        self.assertEqual(len(deployments), 1)
-        self.assertEqual(deployments[0], dep1)
-        self.assert_metadata_filtered(deployments, 1)
-
-    @attr(client_min_version=3.1,
-          client_max_version=base_test.LATEST_API_VERSION)
-    def test_list_deployments_with_filter_id(self):
-        self.put_deployment_with_labels(self.LABELS)
-        dep2 = self.put_deployment_with_labels(self.LABELS_2)
-        self.create_filter(self.client.deployments_filters,
-                           self.FILTER_ID, self.FILTER_RULES_2)
-        deployments = self.client.deployments.list(
-            filter_rules={'_filter_id': self.FILTER_ID})
-        self.assertEqual(len(deployments), 1)
-        self.assertEqual(deployments[0], dep2)
-        self.assert_metadata_filtered(deployments, 1)
-
-    @attr(client_min_version=3.1,
-          client_max_version=base_test.LATEST_API_VERSION)
-    def test_list_deployments_with_filter_rules_upper(self):
-        self.put_deployment_with_labels(self.LABELS)
-        self.put_deployment_with_labels(self.LABELS_2)
-        deployments = self.client.deployments.list(
-            filter_rules={'_filter_rules': ['aRcH=k8S']})
-        self.assertEqual(len(deployments), 2)
-        self.assert_metadata_filtered(deployments, 0)
 
     def test_update_attributes(self):
         self.put_blueprint()

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -39,8 +39,6 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
 
     DEPLOYMENT_ID = 'deployment'
     SITE_NAME = 'test_site'
-    LABELS = [{'env': 'aws'}, {'arch': 'k8s'}]
-    LABELS_2 = [{'env': 'gcp'}, {'arch': 'k8s'}]
     UPDATED_LABELS = [{'env': 'gcp'}, {'arch': 'k8s'}]
     UPDATED_UPPERCASE_LABELS = [{'env': 'GCp'}, {'ArCh': 'k8s'}]
     UPPERCASE_LABELS = [{'EnV': 'aWs'}, {'aRcH': 'k8s'}]
@@ -997,6 +995,19 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
                                blueprint_id=resource_id,
                                deployment_id=resource_id,
                                labels=[{'csys-blah': 'val1'}])
+
+    @attr(client_min_version=3.1,
+          client_max_version=base_test.LATEST_API_VERSION)
+    def test_list_deployments_with_filter_id(self):
+        self.put_deployment_with_labels(self.LABELS)
+        dep2 = self.put_deployment_with_labels(self.LABELS_2)
+        self.create_filter(self.client.deployments_filters,
+                           self.FILTER_ID, self.FILTER_RULES)
+        deployments = self.client.deployments.list(
+            filter_id=self.FILTER_ID)
+        self.assertEqual(len(deployments), 1)
+        self.assertEqual(deployments[0], dep2)
+        self.assert_metadata_filtered(deployments, 1)
 
     def test_update_attributes(self):
         self.put_blueprint()

--- a/rest-service/manager_rest/test/endpoints/test_filters.py
+++ b/rest-service/manager_rest/test/endpoints/test_filters.py
@@ -266,13 +266,6 @@ class FiltersBaseCase(base_test.BaseServerTestCase):
         with self.assertRaisesRegex(CloudifyClientError, 'must be a list'):
             self.create_filter(self.filters_client, FILTER_ID, err_filter_rule)
 
-    def test_create_filter_with_duplicate_filter_rules_fails(self):
-        with self.assertRaisesRegex(CloudifyClientError,
-                                    'Filter rules must be unique'):
-            self.create_filter(self.filters_client, FILTER_ID,
-                               [FilterRule('a', ['b'], 'any_of', 'label'),
-                                FilterRule('a', ['b'], 'any_of', 'label')])
-
     def test_get_filter(self):
         self.create_filter(self.filters_client, FILTER_ID, self.SIMPLE_RULE)
         fetched_filter = self.filters_client.get(FILTER_ID)

--- a/rest-service/manager_rest/test/endpoints/test_filters.py
+++ b/rest-service/manager_rest/test/endpoints/test_filters.py
@@ -266,6 +266,13 @@ class FiltersBaseCase(base_test.BaseServerTestCase):
         with self.assertRaisesRegex(CloudifyClientError, 'must be a list'):
             self.create_filter(self.filters_client, FILTER_ID, err_filter_rule)
 
+    def test_create_filter_with_duplicate_filter_rules_fails(self):
+        with self.assertRaisesRegex(CloudifyClientError,
+                                    'Filter rules must be unique'):
+            self.create_filter(self.filters_client, FILTER_ID,
+                               [FilterRule('a', ['b'], 'any_of', 'label'),
+                                FilterRule('a', ['b'], 'any_of', 'label')])
+
     def test_get_filter(self):
         self.create_filter(self.filters_client, FILTER_ID, self.SIMPLE_RULE)
         fetched_filter = self.filters_client.get(FILTER_ID)

--- a/rest-service/manager_rest/test/endpoints/test_filters.py
+++ b/rest-service/manager_rest/test/endpoints/test_filters.py
@@ -266,6 +266,12 @@ class FiltersBaseCase(base_test.BaseServerTestCase):
         with self.assertRaisesRegex(CloudifyClientError, 'must be a list'):
             self.create_filter(self.filters_client, FILTER_ID, err_filter_rule)
 
+    def test_create_filter_with_duplicate_filter_rules(self):
+        filter_rule = FilterRule('a', ['b'], 'any_of', 'label')
+        new_filter = self.create_filter(self.filters_client, FILTER_ID,
+                                        [filter_rule, filter_rule])
+        self.assertEqual(new_filter.labels_filter, [filter_rule])
+
     def test_get_filter(self):
         self.create_filter(self.filters_client, FILTER_ID, self.SIMPLE_RULE)
         fetched_filter = self.filters_client.get(FILTER_ID)

--- a/rest-service/manager_rest/test/endpoints/test_searches.py
+++ b/rest-service/manager_rest/test/endpoints/test_searches.py
@@ -1,50 +1,42 @@
-from manager_rest.test.attribute import attr
+from cloudify_rest_client.exceptions import CloudifyClientError
+
 from manager_rest.test import base_test
+from manager_rest.test.attribute import attr
+from manager_rest.rest.filters_utils import FilterRule
 
 
 @attr(client_min_version=3.1, client_max_version=base_test.LATEST_API_VERSION)
 class SearchesTestCase(base_test.BaseServerTestCase):
-    LABELS = [{'env': 'aws'}, {'arch': 'k8s'}]
-    LABELS_2 = [{'env': 'gcp'}, {'arch': 'k8s'}]
-    FILTER_ID = 'filter'
-    FILTER_RULES = [{'key': 'env', 'values': ['aws'],
-                     'operator': 'not_any_of', 'type': 'label'},
-                    {'key': 'arch', 'values': ['k8s'],
-                     'operator': 'any_of', 'type': 'label'}]
+    LABELS = [{'key1': 'val1'}, {'key1': 'val2'}, {'key2': 'val3'}]
+    LABELS_2 = [{'key1': 'val1'}, {'key1': 'val3'}, {'key3': 'val3'}]
+    LABELS_3 = [{'key2': 'val4'}, {'key1': 'val3'}]
 
-    FILTER_RULES_2 = [{'key': 'env', 'values': ['aws'],
-                       'operator': 'any_of', 'type': 'label'},
-                      {'key': 'arch', 'values': ['k8s'],
-                       'operator': 'any_of', 'type': 'label'}]
+    FILTER_RULES = [FilterRule('key1', ['val1'], 'any_of', 'label'),
+                    FilterRule('key2', [], 'is_not_null', 'label')]
 
     def test_list_deployments_with_filter_rules(self):
         dep1 = self.put_deployment_with_labels(self.LABELS)
         self.put_deployment_with_labels(self.LABELS_2)
-        deployments = self.client.deployments_search.list(
-            filter_rules=self.FILTER_RULES_2)
+        deployments = self.client.deployments.list(
+            filter_rules=self.FILTER_RULES)
         self.assertEqual(len(deployments), 1)
         self.assertEqual(deployments[0], dep1)
-        self.assert_metadata_filtered(deployments, 1)
-
-    def test_list_deployments_with_filter_id(self):
-        self.put_deployment_with_labels(self.LABELS)
-        dep2 = self.put_deployment_with_labels(self.LABELS_2)
-        self.create_filter(self.client.deployments_filters,
-                           self.FILTER_ID, self.FILTER_RULES)
-        deployments = self.client.deployments_search.list(
-            filter_id=self.FILTER_ID)
-        self.assertEqual(len(deployments), 1)
-        self.assertEqual(deployments[0], dep2)
         self.assert_metadata_filtered(deployments, 1)
 
     def test_list_deployments_with_filter_rules_upper(self):
         self.put_deployment_with_labels(self.LABELS)
         self.put_deployment_with_labels(self.LABELS_2)
-        deployments = self.client.deployments_search.list(
-            filter_rules=[{'key': 'aRcH', 'values': ['k8S'],
-                           'operator': 'any_of', 'type': 'label'}])
+        deployments = self.client.deployments.list(
+            filter_rules=[FilterRule('KEy1', ['VaL1'], 'any_of', 'label')])
         self.assertEqual(len(deployments), 2)
         self.assert_metadata_filtered(deployments, 0)
+
+    def test_list_deployments_with_filter_rules_and_filter_id(self):
+        self.put_deployment_with_labels(self.LABELS)
+        self.put_deployment_with_labels(self.LABELS_2)
+        dep3 = self.put_deployment_with_labels(self.LABELS_3)
+        self._test_list_resources_with_filter_rules_and_filter_id(
+            self.client.deployments_filters, self.client.deployments, dep3)
 
     def test_list_blueprints_with_filter_rules(self):
         for i in range(1, 3):
@@ -52,26 +44,48 @@ class SearchesTestCase(base_test.BaseServerTestCase):
             bp_id = 'blueprint_{0}'.format(i)
             self.put_blueprint(blueprint_id=bp_id,
                                blueprint_file_name=bp_file_name)
-        all_blueprints = self.client.blueprints_search.list(
-            filter_rules=[{'key': 'bp_key1', 'values': ['bp_key1_val1'],
-                           'operator': 'any_of', 'type': 'label'}])
-        second_blueprint = self.client.blueprints_search.list(
-            filter_rules=[{'key': 'bp_key2', 'values': ['bp_2_val1'],
-                           'operator': 'any_of', 'type': 'label'},
-                          {'key': 'bp_key1', 'values': [],
-                           'operator': 'is_not_null', 'type': 'label'}])
+        all_blueprints = self.client.blueprints.list(
+            filter_rules=[
+                FilterRule('bp_key1', ['bp_key1_val1'], 'any_of', 'label')])
+        second_blueprint = self.client.blueprints.list(
+            filter_rules=[
+                FilterRule('bp_key2', ['bp_2_val1'], 'any_of', 'label'),
+                FilterRule('bp_key1', [], 'is_not_null', 'label')])
         self.assertEqual(len(all_blueprints), 2)
         self.assert_metadata_filtered(all_blueprints, 0)
         self.assertEqual(len(second_blueprint), 1)
         self.assert_metadata_filtered(second_blueprint, 1)
 
-    def test_list_blueprints_with_filter_id(self):
+    def test_list_blueprints_with_filter_rules_and_filter_id(self):
         self.put_blueprint_with_labels(self.LABELS, blueprint_id='bp1')
-        bp2 = self.put_blueprint_with_labels(self.LABELS_2, blueprint_id='bp2')
-        self.create_filter(self.client.deployments_filters,
-                           self.FILTER_ID, self.FILTER_RULES)
-        blueprints = self.client.blueprints_search.list(
-            filter_id=self.FILTER_ID)
-        self.assertEqual(len(blueprints), 1)
-        self.assertEqual(blueprints[0], bp2)
-        self.assert_metadata_filtered(blueprints, 1)
+        self.put_blueprint_with_labels(self.LABELS_2, blueprint_id='bp2')
+        bp3 = self.put_blueprint_with_labels(self.LABELS_3,
+                                             blueprint_id='bp3')
+        self._test_list_resources_with_filter_rules_and_filter_id(
+            self.client.blueprints_filters, self.client.blueprints, bp3)
+
+    def test_list_deployments_with_duplicate_filter_rules_fails(self):
+        self.put_deployment_with_labels(self.LABELS)
+        self.put_deployment_with_labels(self.LABELS_2)
+        self.create_filter(self.client.deployments_filters, self.FILTER_ID,
+                           self.FILTER_RULES)
+        self.assertRaisesRegex(CloudifyClientError,
+                               'cannot be part of the filter rules list',
+                               self.client.deployments.list,
+                               filter_rules=self.FILTER_RULES,
+                               filter_id=self.FILTER_ID)
+
+    def _test_list_resources_with_filter_rules_and_filter_id(self,
+                                                             filters_client,
+                                                             resource_client,
+                                                             cmp_resource):
+        self.create_filter(filters_client, self.FILTER_ID,
+                           [FilterRule('key2', [], 'is_not_null', 'label')])
+        resources = resource_client.list(
+            filter_rules=[FilterRule('key1', ['val3'], 'any_of', 'label')],
+            filter_id=self.FILTER_ID,
+            _include=['id']
+        )
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0].keys(), {'id'})
+        self.assertEqual(resources[0]['id'], cmp_resource['id'])

--- a/rest-service/manager_rest/test/endpoints/test_searches.py
+++ b/rest-service/manager_rest/test/endpoints/test_searches.py
@@ -1,0 +1,77 @@
+from manager_rest.test.attribute import attr
+from manager_rest.test import base_test
+
+
+@attr(client_min_version=3.1, client_max_version=base_test.LATEST_API_VERSION)
+class SearchesTestCase(base_test.BaseServerTestCase):
+    LABELS = [{'env': 'aws'}, {'arch': 'k8s'}]
+    LABELS_2 = [{'env': 'gcp'}, {'arch': 'k8s'}]
+    FILTER_ID = 'filter'
+    FILTER_RULES = [{'key': 'env', 'values': ['aws'],
+                     'operator': 'not_any_of', 'type': 'label'},
+                    {'key': 'arch', 'values': ['k8s'],
+                     'operator': 'any_of', 'type': 'label'}]
+
+    FILTER_RULES_2 = [{'key': 'env', 'values': ['aws'],
+                       'operator': 'any_of', 'type': 'label'},
+                      {'key': 'arch', 'values': ['k8s'],
+                       'operator': 'any_of', 'type': 'label'}]
+
+    def test_list_deployments_with_filter_rules(self):
+        dep1 = self.put_deployment_with_labels(self.LABELS)
+        self.put_deployment_with_labels(self.LABELS_2)
+        deployments = self.client.deployments_search.list(
+            filter_rules=self.FILTER_RULES_2)
+        self.assertEqual(len(deployments), 1)
+        self.assertEqual(deployments[0], dep1)
+        self.assert_metadata_filtered(deployments, 1)
+
+    def test_list_deployments_with_filter_id(self):
+        self.put_deployment_with_labels(self.LABELS)
+        dep2 = self.put_deployment_with_labels(self.LABELS_2)
+        self.create_filter(self.client.deployments_filters,
+                           self.FILTER_ID, self.FILTER_RULES)
+        deployments = self.client.deployments_search.list(
+            filter_id=self.FILTER_ID)
+        self.assertEqual(len(deployments), 1)
+        self.assertEqual(deployments[0], dep2)
+        self.assert_metadata_filtered(deployments, 1)
+
+    def test_list_deployments_with_filter_rules_upper(self):
+        self.put_deployment_with_labels(self.LABELS)
+        self.put_deployment_with_labels(self.LABELS_2)
+        deployments = self.client.deployments_search.list(
+            filter_rules=[{'key': 'aRcH', 'values': ['k8S'],
+                           'operator': 'any_of', 'type': 'label'}])
+        self.assertEqual(len(deployments), 2)
+        self.assert_metadata_filtered(deployments, 0)
+
+    def test_list_blueprints_with_filter_rules(self):
+        for i in range(1, 3):
+            bp_file_name = 'blueprint_with_labels_{0}.yaml'.format(i)
+            bp_id = 'blueprint_{0}'.format(i)
+            self.put_blueprint(blueprint_id=bp_id,
+                               blueprint_file_name=bp_file_name)
+        all_blueprints = self.client.blueprints_search.list(
+            filter_rules=[{'key': 'bp_key1', 'values': ['bp_key1_val1'],
+                           'operator': 'any_of', 'type': 'label'}])
+        second_blueprint = self.client.blueprints_search.list(
+            filter_rules=[{'key': 'bp_key2', 'values': ['bp_2_val1'],
+                           'operator': 'any_of', 'type': 'label'},
+                          {'key': 'bp_key1', 'values': [],
+                           'operator': 'is_not_null', 'type': 'label'}])
+        self.assertEqual(len(all_blueprints), 2)
+        self.assert_metadata_filtered(all_blueprints, 0)
+        self.assertEqual(len(second_blueprint), 1)
+        self.assert_metadata_filtered(second_blueprint, 1)
+
+    def test_list_blueprints_with_filter_id(self):
+        self.put_blueprint_with_labels(self.LABELS, blueprint_id='bp1')
+        bp2 = self.put_blueprint_with_labels(self.LABELS_2, blueprint_id='bp2')
+        self.create_filter(self.client.deployments_filters,
+                           self.FILTER_ID, self.FILTER_RULES)
+        blueprints = self.client.blueprints_search.list(
+            filter_id=self.FILTER_ID)
+        self.assertEqual(len(blueprints), 1)
+        self.assertEqual(blueprints[0], bp2)
+        self.assert_metadata_filtered(blueprints, 1)

--- a/rest-service/manager_rest/test/endpoints/test_searches.py
+++ b/rest-service/manager_rest/test/endpoints/test_searches.py
@@ -1,5 +1,3 @@
-from cloudify_rest_client.exceptions import CloudifyClientError
-
 from manager_rest.test import base_test
 from manager_rest.test.attribute import attr
 from manager_rest.rest.filters_utils import FilterRule
@@ -64,16 +62,16 @@ class SearchesTestCase(base_test.BaseServerTestCase):
         self._test_list_resources_with_filter_rules_and_filter_id(
             self.client.blueprints_filters, self.client.blueprints, bp3)
 
-    def test_list_deployments_with_duplicate_filter_rules_fails(self):
-        self.put_deployment_with_labels(self.LABELS)
+    def test_list_deployments_with_duplicate_filter_rules(self):
+        dep1 = self.put_deployment_with_labels(self.LABELS)
         self.put_deployment_with_labels(self.LABELS_2)
         self.create_filter(self.client.deployments_filters, self.FILTER_ID,
                            self.FILTER_RULES)
-        self.assertRaisesRegex(CloudifyClientError,
-                               'cannot be part of the filter rules list',
-                               self.client.deployments.list,
-                               filter_rules=self.FILTER_RULES,
-                               filter_id=self.FILTER_ID)
+        deployments = self.client.deployments.list(
+            filter_rules=self.FILTER_RULES, filter_id=self.FILTER_ID)
+        self.assertEqual(len(deployments), 1)
+        self.assertEqual(deployments[0], dep1)
+        self.assert_metadata_filtered(deployments, 1)
 
     def _test_list_resources_with_filter_rules_and_filter_id(self,
                                                              filters_client,

--- a/rest-service/manager_rest/test/endpoints/test_searches.py
+++ b/rest-service/manager_rest/test/endpoints/test_searches.py
@@ -1,6 +1,8 @@
 from manager_rest.test import base_test
+from manager_rest.storage import models
 from manager_rest.test.attribute import attr
 from manager_rest.rest.filters_utils import FilterRule
+from manager_rest.rest.resources_v3_1.searches import get_filter_rules
 
 
 @attr(client_min_version=3.1, client_max_version=base_test.LATEST_API_VERSION)
@@ -73,10 +75,15 @@ class SearchesTestCase(base_test.BaseServerTestCase):
         self.assertEqual(deployments[0], dep1)
         self.assert_metadata_filtered(deployments, 1)
 
-    def _test_list_resources_with_filter_rules_and_filter_id(self,
-                                                             filters_client,
-                                                             resource_client,
-                                                             cmp_resource):
+    def test_searches_get_filter_rules(self):
+        self.create_filter(self.client.deployments_filters, self.FILTER_ID,
+                           self.FILTER_RULES)
+        filter_rules = get_filter_rules(self.FILTER_RULES, models.Deployment,
+                                        self.FILTER_ID)
+        self.assertEqual(filter_rules, self.FILTER_RULES)
+
+    def _test_list_resources_with_filter_rules_and_filter_id(
+            self, filters_client, resource_client, compared_resource):
         self.create_filter(filters_client, self.FILTER_ID,
                            [FilterRule('key2', [], 'is_not_null', 'label')])
         resources = resource_client.list(
@@ -86,4 +93,4 @@ class SearchesTestCase(base_test.BaseServerTestCase):
         )
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0].keys(), {'id'})
-        self.assertEqual(resources[0]['id'], cmp_resource['id'])
+        self.assertEqual(resources[0]['id'], compared_resource['id'])


### PR DESCRIPTION
This PR adds the `POST /searches/<resource>` endpoint. The purpose of this endpoint is to use filter rules when listing deployments or blueprints. 

Complementary PRs:
https://github.com/cloudify-cosmo/cloudify-common/pull/701
https://github.com/cloudify-cosmo/cloudify-manager-install/pull/1087