### PR TITLE
CYBL-1114 Reevaluate deployment update statuses

### DIFF
--- a/rest-service/manager_rest/deployment_update/manager.py
+++ b/rest-service/manager_rest/deployment_update/manager.py
@@ -87,6 +87,10 @@ class DeploymentUpdateManager(object):
                                 preview=False,
                                 runtime_only_evaluation=False,
                                 auto_correct_types=False):
+
+        # validate no active updates are running for a deployment_id
+        self.validate_no_active_updates_per_deployment(deployment_id)
+
         # enables reverting to original blueprint resources
         deployment = self.sm.get(models.Deployment, deployment_id)
         old_blueprint = deployment.blueprint

--- a/rest-service/manager_rest/deployment_update/manager.py
+++ b/rest-service/manager_rest/deployment_update/manager.py
@@ -19,8 +19,8 @@ from datetime import datetime
 
 from flask import current_app
 
+from cloudify.models_states import ExecutionState
 from cloudify.utils import extract_and_merge_plugins
-
 
 from dsl_parser import constants, tasks
 
@@ -86,9 +86,12 @@ class DeploymentUpdateManager(object):
                                 new_blueprint_id=None,
                                 preview=False,
                                 runtime_only_evaluation=False,
-                                auto_correct_types=False):
+                                auto_correct_types=False,
+                                reevaluate_active_statuses=False):
 
         # validate no active updates are running for a deployment_id
+        if reevaluate_active_statuses:
+            self.reevaluate_updates_statuses_per_deployment(deployment_id)
         self.validate_no_active_updates_per_deployment(deployment_id)
 
         # enables reverting to original blueprint resources
@@ -130,6 +133,23 @@ class DeploymentUpdateManager(object):
             deployment_update.new_blueprint = new_blueprint
         self.sm.put(deployment_update)
         return deployment_update
+
+    def reevaluate_updates_statuses_per_deployment(self, deployment_id: str):
+        for active_update in self.list_deployment_updates(
+                filters={'blueprint_id': deployment_id,
+                         'state': [STATES.UPDATING,
+                                   STATES.EXECUTING_WORKFLOW,
+                                   STATES.FINALIZING]}):
+            reevaluated_state = _map_execution_to_deployment_update_status(
+                active_update.execution.status)
+            if reevaluated_state and active_update.state != reevaluated_state:
+                current_app.logger.info("Deployment update %s status "
+                                        "reevaluation: `%s` -> `%s`",
+                                        active_update.id,
+                                        active_update.state,
+                                        reevaluated_state)
+                active_update.state = reevaluated_state
+                self.sm.update(active_update)
 
     def create_deployment_update_step(self,
                                       deployment_update,
@@ -680,3 +700,14 @@ def get_deployment_updates_manager(preview=False):
         'deployment_updates_manager',
         DeploymentUpdateManager(get_storage_manager())
     )
+
+
+def _map_execution_to_deployment_update_status(execution_status: str) -> str:
+    if execution_status == ExecutionState.TERMINATED:
+        return STATES.SUCCESSFUL
+    if execution_status in [ExecutionState.FAILED,
+                            ExecutionState.CANCELLED,
+                            ExecutionState.CANCELLING,
+                            ExecutionState.FORCE_CANCELLING,
+                            ExecutionState.KILL_CANCELLING]:
+        return STATES.FAILED

--- a/rest-service/manager_rest/plugins_update/manager.py
+++ b/rest-service/manager_rest/plugins_update/manager.py
@@ -162,7 +162,8 @@ class PluginsUpdateManager(object):
 
         plugins_update.execution = \
             get_resource_manager(self.sm).update_plugins(
-                plugins_update, not changes_required, auto_correct_types)
+                plugins_update, not changes_required, auto_correct_types,
+                reevaluate_active_statuses)
         plugins_update.state = (STATES.EXECUTING_WORKFLOW if changes_required
                                 else STATES.NO_CHANGES_REQUIRED)
         return self.sm.update(plugins_update)

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -344,7 +344,8 @@ class ResourceManager(object):
 
     def update_plugins(self, plugins_update,
                        no_changes_required=False,
-                       auto_correct_types=False):
+                       auto_correct_types=False,
+                       reevaluate_active_statuses=False):
         """Executes the plugin update workflow.
 
         :param plugins_update: a PluginUpdate object.
@@ -360,6 +361,7 @@ class ResourceManager(object):
                 'temp_blueprint_id': plugins_update.temp_blueprint_id,
                 'force': plugins_update.forced,
                 'auto_correct_types': auto_correct_types,
+                'reevaluate_active_statuses': reevaluate_active_statuses,
             },
             verify_no_executions=False,
             fake_execution=no_changes_required)

--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -118,6 +118,7 @@ class DeploymentUpdate(SecuredResource):
             ignore_failure, install_first, _, update_plugins, \
             runtime_eval, _, force = self._parse_args(
                 deployment_id, request_json, using_post_request=True)
+        manager.validate_no_active_updates_per_deployment(deployment_id)
         deployment_update, _ = \
             UploadedBlueprintsDeploymentUpdateManager(). \
             receive_uploaded_data(
@@ -193,7 +194,6 @@ class DeploymentUpdate(SecuredResource):
             request_json.get('force', False)
         )
         manager = get_deployment_updates_manager(preview)
-        manager.validate_no_active_updates_per_deployment(deployment_id)
         return (manager,
                 skip_install,
                 skip_uninstall,

--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -83,7 +83,8 @@ class DeploymentUpdate(SecuredResource):
         """
         manager, skip_install, skip_uninstall, skip_reinstall, workflow_id, \
             ignore_failure, install_first, preview, update_plugins, \
-            runtime_eval, auto_correct_args, force = \
+            runtime_eval, auto_correct_args, reevaluate_active_statuses, \
+            force = \
             self._parse_args(id, request.json)
         blueprint, inputs, reinstall_list = \
             self._get_and_validate_blueprint_and_inputs(id, request.json)
@@ -99,7 +100,8 @@ class DeploymentUpdate(SecuredResource):
         deployment_update = manager.stage_deployment_update(
             id, deployment_dir, file_name, inputs, blueprint.id, preview,
             runtime_only_evaluation=runtime_eval,
-            auto_correct_types=auto_correct_args)
+            auto_correct_types=auto_correct_args,
+            reevaluate_active_statuses=reevaluate_active_statuses)
         manager.extract_steps_from_deployment_update(deployment_update)
         return manager.commit_deployment_update(deployment_update,
                                                 skip_install,
@@ -116,7 +118,7 @@ class DeploymentUpdate(SecuredResource):
         request_json = request.args
         manager, skip_install, skip_uninstall, _, workflow_id, \
             ignore_failure, install_first, _, update_plugins, \
-            runtime_eval, _, force = self._parse_args(
+            runtime_eval, _, _, force = self._parse_args(
                 deployment_id, request_json, using_post_request=True)
         manager.validate_no_active_updates_per_deployment(deployment_id)
         deployment_update, _ = \
@@ -189,6 +191,10 @@ class DeploymentUpdate(SecuredResource):
             'auto_correct_types',
             request_json.get('auto_correct_types', False)
         )
+        reevaluate_active_statuses = verify_and_convert_bool(
+            'reevaluate_active_statuses',
+            request_json.get('reevaluate_active_statuses', False)
+        )
         force = verify_and_convert_bool(
             'force',
             request_json.get('force', False)
@@ -205,6 +211,7 @@ class DeploymentUpdate(SecuredResource):
                 update_plugins,
                 runtime_only_evaluation,
                 auto_correct_types,
+                reevaluate_active_statuses,
                 force)
 
 

--- a/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
@@ -144,7 +144,8 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
              'deployments_to_update': ['d1', 'd2'],
              'temp_blueprint_id': plugins_update.temp_blueprint_id,
              'force': False,
-             'auto_correct_types': False})
+             'auto_correct_types': False,
+             'reevaluate_active_statuses': False})
 
     def test_plugins_update_auto_correct_types_flag(self):
         self.put_blueprint(blueprint_id='hello_world')
@@ -154,13 +155,8 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
             'hello_world', auto_correct_types=True)
         self.assertEqual(['dep'], plugins_update.deployments_to_update)
         execution = self.client.executions.get(plugins_update.execution_id)
-        self.assertEqual(
-            execution.parameters,
-            {'update_id': plugins_update.id,
-             'deployments_to_update': ['dep'],
-             'temp_blueprint_id': plugins_update.temp_blueprint_id,
-             'force': False,
-             'auto_correct_types': True})
+        self.assertIn('auto_correct_types', execution.parameters)
+        self.assertEquals(True, execution.parameters.get('auto_correct_types'))
 
     def test_raises_while_plugins_updates_are_active(self):
         self.put_blueprint(blueprint_id='hello_world')

--- a/workflows/cloudify_system_workflows/plugins.py
+++ b/workflows/cloudify_system_workflows/plugins.py
@@ -56,7 +56,7 @@ def _operate_on_plugin(ctx, plugin, action):
 
 @workflow(system_wide=True)
 def update(ctx, update_id, temp_blueprint_id, deployments_to_update, force,
-           auto_correct_types, **_):
+           auto_correct_types, reevaluate_active_statuses, **_):
     """Execute deployment update for all the given deployments_to_update.
 
     :param update_id: plugins update ID.
@@ -68,6 +68,8 @@ def update(ctx, update_id, temp_blueprint_id, deployments_to_update, force,
     components).
     :param auto_correct_types: update deployments with auto_correct_types flag,
      which will attempt to cast inputs to the types defined by the blueprint.
+    :reevaluate_active_statuses: reevaluate deployment updates states based on
+    relevant executions statuses.
     """
 
     def get_wait_for_execution_message(execution_id):
@@ -91,7 +93,8 @@ def update(ctx, update_id, temp_blueprint_id, deployments_to_update, force,
                     skip_uninstall=True,
                     skip_reinstall=True,
                     force=force,
-                    auto_correct_types=auto_correct_types) \
+                    auto_correct_types=auto_correct_types,
+                    reevaluate_active_statuses=reevaluate_active_statuses) \
                 .execution_id
         except CloudifyClientError:
             execution_id = None

--- a/workflows/cloudify_system_workflows/tests/test_plugins.py
+++ b/workflows/cloudify_system_workflows/tests/test_plugins.py
@@ -135,7 +135,8 @@ class TestPluginsUpdate(unittest.TestCase):
             = finalize_update_mock
         self.mock_rest_client.executions.get \
             .return_value = PropertyMock(status=ExecutionState.TERMINATED)
-        update_func(MagicMock(), '12345678', None, dep_ids, False, False)
+        update_func(MagicMock(),
+                    '12345678', None, dep_ids, False, False, False)
         should_call_these = [call(deployment_id=i,
                                   blueprint_id=None,
                                   skip_install=True,

--- a/workflows/cloudify_system_workflows/tests/test_plugins.py
+++ b/workflows/cloudify_system_workflows/tests/test_plugins.py
@@ -104,15 +104,16 @@ class TestPluginsUpdate(unittest.TestCase):
             return PropertyMock(status=ExecutionState.TERMINATED)
 
         def _assert_update_func():
-            update_func(MagicMock(), 'my_update_id', None,
-                        dep_ids, False, False)
+            update_func(MagicMock(),
+                        'my_update_id', None, dep_ids, False, False, True)
             should_call_these = [call(deployment_id=i,
                                       blueprint_id=None,
                                       skip_install=True,
                                       skip_uninstall=True,
                                       skip_reinstall=True,
                                       force=False,
-                                      auto_correct_types=False)
+                                      auto_correct_types=False,
+                                      reevaluate_active_statuses=True)
                                  for i in dep_ids]
             self.deployment_update_mock.assert_has_calls(should_call_these)
 
@@ -141,7 +142,8 @@ class TestPluginsUpdate(unittest.TestCase):
                                   skip_uninstall=True,
                                   skip_reinstall=True,
                                   force=False,
-                                  auto_correct_types=False)
+                                  auto_correct_types=False,
+                                  reevaluate_active_statuses=False)
                              for i in range(len(dep_ids))]
         self.deployment_update_mock.assert_has_calls(should_call_these)
         finalize_update_mock.assert_called_with('12345678')


### PR DESCRIPTION
The purpose of this modification is to provide the administrator with a tool to reconcile the statuses of deployment updates according to statuses of relevant executions.

The new `reevaluate_active_statuses` flag in the `DeploymentUpdateManager.stage_deployment_update()` will force reevaluation of active deployment-updates' statuses based on following scheme:

```
 execution status | new plugins_update status
------------------+---------------------------
 terminated       | successful
 failed           | failed
 cancelled        | failed
 cancelling       | failed
 force_cancelling | failed
 kill_cancelling  | failed
```

requires: https://github.com/cloudify-cosmo/cloudify-common/pull/702