### PR TITLE
RD-1488 Adding statuses and counter to sub service and envs

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
+++ b/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
@@ -5,6 +5,7 @@
 - Add installation_status to the deployment table
 - Add deployment_status to the deployment table
 - Add latest execution FK to the deployment table
+- Add statuses and counters for sub-services and sub-environments
 
 Revision ID: 396303c07e35
 Revises: 9d261e90b1f3
@@ -53,9 +54,11 @@ def upgrade():
     _add_execgroups_concurrency()
     _add_execution_operations_columns()
     _create_deployment_labels_dependencies_table()
+    _add_deployment_sub_statuses_and_counters()
 
 
 def downgrade():
+    _drop_deployment_sub_statuses_and_counters()
     _drop_deployment_labels_dependencies_table()
     _drop_execgroups_concurrency()
     _drop_deployment_statuses()
@@ -64,6 +67,51 @@ def downgrade():
     _revert_changes_to_deployments_labels_table()
     _drop_blueprints_labels_table()
     _drop_execution_operations_columns()
+    _drop_deployment_statuses_enum_types()
+
+
+def _add_deployment_sub_statuses_and_counters():
+    op.add_column(
+        'deployments',
+        sa.Column(
+            'sub_environments_count',
+            sa.Integer(),
+            nullable=True
+        )
+    )
+    op.add_column(
+        'deployments',
+        sa.Column(
+            'sub_environments_status',
+            sa.Enum(
+                'good',
+                'in_progress',
+                'require_attention',
+                name='deployment_status'
+            ),
+            nullable=True
+        )
+    )
+    op.add_column(
+        'deployments',
+        sa.Column(
+            'sub_services_count',
+            sa.Integer(),
+            nullable=True
+        )
+    )
+    op.add_column(
+        'deployments',
+        sa.Column(
+            'sub_services_status',
+            sa.Enum('good',
+                    'in_progress',
+                    'require_attention',
+                    name='deployment_status'
+                    ),
+            nullable=True
+        )
+    )
 
 
 def _create_deployment_labels_dependencies_table():
@@ -105,6 +153,14 @@ def _create_deployment_labels_dependencies_table():
         sa.PrimaryKeyConstraint(
             '_storage_id', name=op.f('deployment_labels_dependencies_pkey')
         ),
+
+        sa.UniqueConstraint(
+            '_source_deployment',
+            '_target_deployment',
+            name=op.f(
+                'deployment_labels_dependencies__source_deployment_key'
+            )
+        )
     )
     op.create_index(
         op.f('deployment_labels_dependencies__creator_id_idx'),
@@ -411,9 +467,6 @@ def _drop_deployment_statuses():
     op.drop_column('deployments', 'installation_status')
     op.drop_column('deployments', 'deployment_status')
 
-    installation_status.drop(op.get_bind())
-    deployment_status.drop(op.get_bind())
-
 
 def _add_execgroups_concurrency():
     op.add_column(
@@ -477,3 +530,15 @@ def _drop_deployment_labels_dependencies_table():
         table_name='deployment_labels_dependencies'
     )
     op.drop_table('deployment_labels_dependencies')
+
+
+def _drop_deployment_sub_statuses_and_counters():
+    op.drop_column('deployments', 'sub_services_status')
+    op.drop_column('deployments', 'sub_services_count')
+    op.drop_column('deployments', 'sub_environments_status')
+    op.drop_column('deployments', 'sub_environments_count')
+
+
+def _drop_deployment_statuses_enum_types():
+    installation_status.drop(op.get_bind())
+    deployment_status.drop(op.get_bind())

--- a/rest-service/manager_rest/storage/models.py
+++ b/rest-service/manager_rest/storage/models.py
@@ -56,6 +56,7 @@ from .resource_models import (
     Site,
     PluginsUpdate,
     InterDeploymentDependencies,
+    DeploymentLabelsDependencies,
     _PluginState,
     DeploymentLabel,
     Filter,

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -366,6 +366,20 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
             name='deployment_status'
         )
     )
+    sub_services_status = db.Column(db.Enum(
+            DeploymentState.GOOD,
+            DeploymentState.IN_PROGRESS,
+            DeploymentState.REQUIRE_ATTENTION,
+            name='deployment_status'
+        ))
+    sub_environments_status = db.Column(db.Enum(
+            DeploymentState.GOOD,
+            DeploymentState.IN_PROGRESS,
+            DeploymentState.REQUIRE_ATTENTION,
+            name='deployment_status'
+        ))
+    sub_services_count = db.Column(db.Integer, nullable=True)
+    sub_environments_count = db.Column(db.Integer, nullable=True)
     _blueprint_fk = foreign_key(Blueprint._storage_id)
     _site_fk = foreign_key(Site._storage_id,
                            nullable=True,
@@ -456,29 +470,127 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
             return None
         return DeploymentState.EXECUTION_STATES_SUMMARY.get(_execution.status)
 
+    def compare_between_statuses(
+            self,
+            first_status,
+            second_status
+    ):
+        """
+        Compare between two deployment statuses so that we can tell which
+        one is worst than others. If first_status > second_status then
+        return the first status otherwise return the second_status
+        :param first_status: The first deployment status
+        :rtype str
+        :param second_status: The second deployment status
+        :rtype str
+        :return: Return the end result status
+        :rtype str
+        """
+        class _DeploymentStatus(object):
+            def __init__(self, status):
+                self.status = status
+
+            def __gt__(self, other):
+                if not self.status:
+                    return False
+                elif self.status and not other.status:
+                    return True
+                elif (self.status == DeploymentState.REQUIRE_ATTENTION and
+                      other.status in [
+                          DeploymentState.GOOD,
+                          DeploymentState.IN_PROGRESS
+                      ]):
+                    return True
+                elif (
+                        self.status == DeploymentState.IN_PROGRESS
+                        and other.status == DeploymentState.GOOD):
+                    return True
+                return False
+
+        _source = _DeploymentStatus(first_status)
+        _target = _DeploymentStatus(second_status)
+        return _source.status if _source > _target else _target.status
+
+    def evaluate_sub_deployments_statuses(self):
+        """
+        Evaluate the deployment statuses per deployment using the following
+        three statuses
+        1. sub_environments_status
+        2. sub_services_status
+        3. deployment_status
+        This is useful and prerequisite before propagate the source
+        deployments statuses to the target
+        :return: Tuple of end result of `sub_environments_status`
+         & `sub_services_status`
+        :rtype Tuple
+        """
+        _sub_environments_status = self.sub_environments_status
+        _sub_services_status = self.sub_services_status
+        if self.is_environment:
+            _sub_environments_status = \
+                self.compare_between_statuses(
+                    self.sub_environments_status,
+                    self.deployment_status
+                )
+
+        else:
+            _sub_services_status = \
+                self.compare_between_statuses(
+                    self.sub_services_status,
+                    self.deployment_status
+                )
+        return _sub_services_status, _sub_environments_status
+
     def evaluate_deployment_status(self):
         """
         Evaluate the overall deployment status based on installation status
         and latest execution object
         :return: deployment_status: Overall deployment status
         """
-        # TODO we need to cover also aggregated statuses for deployment
-        #  children later on
         if self.latest_execution_status == DeploymentState.CANCELLED:
             if self.installation_status == DeploymentState.ACTIVE:
-                return DeploymentState.GOOD
-            return DeploymentState.REQUIRE_ATTENTION
+                deployment_status = DeploymentState.GOOD
+            else:
+                deployment_status = DeploymentState.REQUIRE_ATTENTION
         elif self.latest_execution_status == DeploymentState.IN_PROGRESS and \
                 self.installation_status == DeploymentState.INACTIVE:
-            return DeploymentState.IN_PROGRESS
+            deployment_status = DeploymentState.IN_PROGRESS
         elif self.latest_execution_status == DeploymentState.FAILED or \
                 self.installation_status == DeploymentState.INACTIVE:
-            return DeploymentState.REQUIRE_ATTENTION
+            deployment_status = DeploymentState.REQUIRE_ATTENTION
         elif self.latest_execution_status == DeploymentState.COMPLETED and \
                 self.installation_status == DeploymentState.ACTIVE:
-            return DeploymentState.GOOD
+            deployment_status = DeploymentState.GOOD
         else:
-            return DeploymentState.IN_PROGRESS
+            deployment_status = DeploymentState.IN_PROGRESS
+        if not (self.sub_services_status or self.sub_environments_status):
+            return deployment_status
+
+        # Check whether or not deployment has services or environments
+        # attached to it, so that we can consider that while evaluating the
+        # deployment status
+        if self.sub_services_status:
+            deployment_status = \
+                self.compare_between_statuses(
+                    self.sub_services_status,
+                    deployment_status
+                )
+        if self.sub_environments_status:
+            deployment_status = \
+                self.compare_between_statuses(
+                    self.sub_environments_status,
+                    deployment_status
+                )
+        return deployment_status
+
+    @property
+    def is_environment(self):
+        target_key = 'csys-obj-type'
+        target_value = 'environment'
+        for label in self.labels:
+            if label.key == target_key and label.value.lower() == target_value:
+                return True
+        return False
 
 
 class DeploymentGroup(CreatedAtMixin, SQLResourceBase):
@@ -1547,6 +1659,10 @@ class InterDeploymentDependencies(BaseDeploymentDependencies):
 
 class DeploymentLabelsDependencies(BaseDeploymentDependencies):
     __tablename__ = 'deployment_labels_dependencies'
+    __table_args__ = (
+        db.UniqueConstraint(
+            '_source_deployment', '_target_deployment'),
+    )
 
     _source_backref_name = 'source_of_dependency_labels'
     _target_backref_name = 'target_of_dependency_labels'

--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -157,7 +157,7 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         self.sm.put(dep)
 
         serialized_dep = dep.to_response()
-        self.assertEqual(26, len(serialized_dep))
+        self.assertEqual(30, len(serialized_dep))
         self.assertEqual(dep.id, serialized_dep['id'])
         self.assertEqual(dep.created_at, serialized_dep['created_at'])
         self.assertEqual(dep.updated_at, serialized_dep['updated_at'])


### PR DESCRIPTION
This PR is created in order to do the following:
1. Add sub statuses columns for both services and environments 
2. Add sub counters columns for both services and environments
3. Add support to check cyclic dependencies between deployment labels
4. Add support propagate deployment statuses in created graph
5. Add support to  propagate counters for deployment when add/remove node from grap  