### PR TITLE
RD-1700 Add operation counts on the execution model

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
+++ b/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
@@ -42,6 +42,7 @@ def upgrade():
     _add_specialized_execution_fk()
     _add_deployment_statuses()
     _add_execgroups_concurrency()
+    _add_execution_operations_columns()
 
 
 def downgrade():
@@ -51,6 +52,7 @@ def downgrade():
     _revert_changes_to_execution_schedules_table()
     _revert_changes_to_deployments_labels_table()
     _drop_blueprints_labels_table()
+    _drop_execution_operations_columns()
 
 
 def _add_deployment_statuses():
@@ -344,3 +346,19 @@ def _add_execgroups_concurrency():
 
 def _drop_execgroups_concurrency():
     op.drop_column('execution_groups', 'concurrency')
+
+
+def _add_execution_operations_columns():
+    op.add_column(
+        'executions',
+        sa.Column('finished_operations', sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        'executions',
+        sa.Column('total_operations', sa.Integer(), nullable=True)
+    )
+
+
+def _drop_execution_operations_columns():
+    op.drop_column('executions', 'total_operations')
+    op.drop_column('executions', 'finished_operations')

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1941,6 +1941,14 @@ class ResourceManager(object):
             type=type,
         )
         self.sm.put(operation)
+        execution = graph.execution
+        if execution.total_operations is None:
+            execution.total_operations = 0
+            execution.finished_operations = 0
+        execution.total_operations += 1
+        self.sm.update(
+            execution,
+            modified_attrs=('total_operations', 'finished_operations'))
         return operation
 
     def create_tasks_graph(self, name, execution_id, operations=None):
@@ -1969,6 +1977,13 @@ class ResourceManager(object):
                     **operation)
                 db.session.add(op)
             self.sm._safe_commit()
+        if execution.total_operations is None:
+            execution.total_operations = 0
+            execution.finished_operations = 0
+        execution.total_operations += len(operations)
+        self.sm.update(
+            execution,
+            modified_attrs=('total_operations', 'finished_operations'))
         return graph
 
     @staticmethod

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -627,6 +627,9 @@ class Execution(CreatedAtMixin, SQLResourceBase):
 
     _deployment_fk = foreign_key(Deployment._storage_id, nullable=True)
 
+    total_operations = db.Column(db.Integer, nullable=True)
+    finished_operations = db.Column(db.Integer, nullable=True)
+
     @declared_attr
     def deployment(cls):
         return one_to_many_relationship(

--- a/rest-service/manager_rest/test/endpoints/test_operations.py
+++ b/rest-service/manager_rest/test/endpoints/test_operations.py
@@ -92,7 +92,7 @@ class OperationsTestCase(base_test.BaseServerTestCase):
         }
         assert self.execution.finished_operations is None
         assert self.execution.total_operations is None
-        tg = self.client.tasks_graphs.create(
+        self.client.tasks_graphs.create(
             self.execution.id, name='workflow', operations=[op1, op2])
         self.sm.refresh(self.execution)
         assert self.execution.finished_operations == 0

--- a/rest-service/manager_rest/test/endpoints/test_operations.py
+++ b/rest-service/manager_rest/test/endpoints/test_operations.py
@@ -17,6 +17,9 @@ from datetime import datetime
 from faker import Faker
 
 from flask import g
+
+from cloudify import constants
+
 from manager_rest import server
 from manager_rest.test import base_test
 from manager_rest.storage import models
@@ -69,7 +72,31 @@ class OperationsTestCase(base_test.BaseServerTestCase):
         tg = self.client.tasks_graphs.create(
             self.execution.id, name='workflow', operations=[op1, op2])
         ops = self.client.operations.list(tg.id)
-        self.assertEqual(len(ops), 2)
-        self.assertEqual(
-            {op['id'] for op in ops},
-            {op1['id'], op2['id']})
+        assert len(ops) == 2
+        assert {op['id'] for op in ops} == {op1['id'], op2['id']}
+
+    def test_operation_counts(self):
+        op1 = {
+            'id': self.fake.uuid4(),
+            'name': 'op1',
+            'dependencies': [],
+            'parameters': {},
+            'type': 'RemoteWorkflowTask'
+        }
+        op2 = {
+            'id': self.fake.uuid4(),
+            'name': 'op2',
+            'dependencies': [],
+            'parameters': {},
+            'type': 'RemoteWorkflowTask'
+        }
+        assert self.execution.finished_operations is None
+        assert self.execution.total_operations is None
+        tg = self.client.tasks_graphs.create(
+            self.execution.id, name='workflow', operations=[op1, op2])
+        self.sm.refresh(self.execution)
+        assert self.execution.finished_operations == 0
+        assert self.execution.total_operations == 2
+        self.client.operations.update(op1['id'], constants.TASK_SUCCEEDED)
+        self.sm.refresh(self.execution)
+        assert self.execution.finished_operations == 1


### PR DESCRIPTION
Make the execution track its total and finished operation counts.
The operation endpoints deal with keeping that count up to date.