### PR TITLE
RD-1106 Add get users to allowed endpoints

### DIFF
--- a/rest-service/manager_rest/constants.py
+++ b/rest-service/manager_rest/constants.py
@@ -60,7 +60,7 @@ ALLOWED_MAINTENANCE_ENDPOINTS = ALLOWED_ENDPOINTS + [
     'snapshot-status',
 ]
 ALLOWED_LICENSE_ENDPOINTS = ALLOWED_ENDPOINTS + [
-    'tokens', 'tenants',
+    'tokens', 'tenants', ('users', 'get')
 ]
 CLOUDIFY_AUTH_HEADER = 'Authorization'
 CLOUDIFY_AUTH_TOKEN_HEADER = 'Authentication-Token'

--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -51,7 +51,16 @@ def check_allowed_endpoint(allowed_endpoints):
     endpoint_parts = request.endpoint.split('/')
     request_endpoint = endpoint_parts[1] if len(endpoint_parts) > 1 else \
         endpoint_parts[0]
-    return request_endpoint in allowed_endpoints
+    request_method = request.method.lower()
+    for allowed_endpoint in allowed_endpoints:
+        if isinstance(allowed_endpoint, tuple):
+            if request_endpoint == allowed_endpoint[0]:
+                return request_method == allowed_endpoint[1]
+        else:
+            if request_endpoint == allowed_endpoint:
+                return True
+
+    return False
 
 
 def is_sanity_mode():

--- a/tests/integration_tests/tests/agentless_tests/test_license.py
+++ b/tests/integration_tests/tests/agentless_tests/test_license.py
@@ -73,6 +73,14 @@ class TestLicense(AgentlessTestCase):
         self.client.license.list()
         self.client.manager.get_status()
 
+    def test_no_error_when_using_get_user(self):
+        self.client.users.get('admin', _get_data=True)
+
+    def test_error_when_using_allowed_endpoint_and_forbidden_method(self):
+        self.assertRaises(MissingCloudifyLicense,
+                          self.client.users.create,
+                          username='user', password='password', role='default')
+
     def test_upload_valid_paying_license(self):
         self._upload_license('test_valid_paying_license.yaml')
         self._verify_license(expired=False, trial=False)


### PR DESCRIPTION
The UI needs to use the endpoint `GET /users/<user-name>?_get_data=true` before a valid license is uploaded. 
The current implementation that allows calling endpoints without a valid license, allows calling all methods of the endpoint. 

This PR modifies this implementation to allow only a specific method of an endpoint, so e.g. the user will be able to call `GET /users/<user-name>`, but won't be able to call `PUT /users/<user-name>` without a valid license. 