### PR TITLE
Drop labels attribute from deployments model

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -410,11 +410,6 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
 
     site_name = association_proxy('site', 'name')
 
-    @declared_attr
-    def labels(cls):
-        # labels are defined as `backref` in DeploymentsLabel model
-        return None
-
     @classproperty
     def response_fields(cls):
         fields = super(Deployment, cls).response_fields


### PR DESCRIPTION
The `labels` attribute in the `deployments` model is defined as a backref from the `labels` model. Therefore, there is no need to define it as a `declared_attr`.