### PR TITLE
Rd 1485 update deployment apis

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
+++ b/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
@@ -80,7 +80,8 @@ def _add_deployment_sub_statuses_and_counters():
         sa.Column(
             'sub_environments_count',
             sa.Integer(),
-            nullable=True
+            nullable=False,
+            default=0,
         )
     )
     op.add_column(
@@ -101,7 +102,8 @@ def _add_deployment_sub_statuses_and_counters():
         sa.Column(
             'sub_services_count',
             sa.Integer(),
-            nullable=True
+            nullable=False,
+            default=0,
         )
     )
     op.add_column(
@@ -115,86 +117,6 @@ def _add_deployment_sub_statuses_and_counters():
                     ),
             nullable=True
         )
-    )
-
-
-def _create_deployment_labels_dependencies_table():
-    op.create_table(
-        'deployment_labels_dependencies',
-        sa.Column('_storage_id', sa.Integer(), autoincrement=True,
-                  nullable=False),
-        sa.Column('id', sa.Text(), nullable=True),
-        sa.Column('visibility', VISIBILITY_ENUM, nullable=True),
-        sa.Column('created_at', UTCDateTime(), nullable=False),
-        sa.Column('_source_deployment', sa.Integer(),
-                  nullable=False),
-        sa.Column('_target_deployment', sa.Integer(),
-                  nullable=False),
-        sa.Column('_tenant_id', sa.Integer(), nullable=False),
-        sa.Column('_creator_id', sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(
-            ['_creator_id'], ['users.id'],
-            name=op.f('deployment_labels_dependencies__creator_id_fkey'),
-            ondelete='CASCADE'
-        ),
-        sa.ForeignKeyConstraint(
-            ['_tenant_id'], ['tenants.id'],
-            name=op.f('deployment_labels_dependencies__tenant_id_fkey'),
-            ondelete='CASCADE'
-        ),
-        sa.ForeignKeyConstraint(
-            ['_source_deployment'], ['deployments._storage_id'],
-            name=op.f(
-                'deployment_labels_dependencies__source_deployment_fkey'
-            ), ondelete='CASCADE'
-        ),
-        sa.ForeignKeyConstraint(
-            ['_target_deployment'], ['deployments._storage_id'],
-            name=op.f(
-                'deployment_labels_dependencies__target_deployment_fkey'
-            ), ondelete='CASCADE'
-        ),
-        sa.PrimaryKeyConstraint(
-            '_storage_id', name=op.f('deployment_labels_dependencies_pkey')
-        ),
-
-        sa.UniqueConstraint(
-            '_source_deployment',
-            '_target_deployment',
-            name=op.f(
-                'deployment_labels_dependencies__source_deployment_key'
-            )
-        )
-    )
-    op.create_index(
-        op.f('deployment_labels_dependencies__creator_id_idx'),
-        'deployment_labels_dependencies', ['_creator_id'], unique=False
-    )
-    op.create_index(
-        op.f('deployment_labels_dependencies__tenant_id_idx'),
-        'deployment_labels_dependencies', ['_tenant_id'], unique=False
-    )
-    op.create_index(
-        op.f('deployment_labels_dependencies_created_at_idx'),
-        'deployment_labels_dependencies', ['created_at'], unique=False
-    )
-    op.create_index(
-        op.f('deployment_labels_dependencies_id_idx'),
-        'deployment_labels_dependencies', ['id'], unique=False
-    )
-    op.create_index(
-        op.f('deployment_labels_dependencies__source_deployment_idx'),
-        'deployment_labels_dependencies', ['_source_deployment'],
-        unique=False
-    )
-    op.create_index(
-        op.f('deployment_labels_dependencies__target_deployment_idx'),
-        'deployment_labels_dependencies', ['_target_deployment'],
-        unique=False
-    )
-    op.create_index(
-        op.f('deployment_labels_dependencies_visibility_idx'),
-        'deployment_labels_dependencies', ['visibility'], unique=False
     )
 
 

--- a/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
+++ b/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
@@ -198,6 +198,78 @@ def _create_deployment_labels_dependencies_table():
     )
 
 
+def _create_deployment_labels_dependencies_table():
+    op.create_table(
+        'deployment_labels_dependencies',
+        sa.Column('_storage_id', sa.Integer(), autoincrement=True,
+                  nullable=False),
+        sa.Column('id', sa.Text(), nullable=True),
+        sa.Column('visibility', VISIBILITY_ENUM, nullable=True),
+        sa.Column('created_at', UTCDateTime(), nullable=False),
+        sa.Column('_source_deployment', sa.Integer(),
+                  nullable=False),
+        sa.Column('_target_deployment', sa.Integer(),
+                  nullable=False),
+        sa.Column('_tenant_id', sa.Integer(), nullable=False),
+        sa.Column('_creator_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['_creator_id'], ['users.id'],
+            name=op.f('deployment_labels_dependencies__creator_id_fkey'),
+            ondelete='CASCADE'
+        ),
+        sa.ForeignKeyConstraint(
+            ['_tenant_id'], ['tenants.id'],
+            name=op.f('deployment_labels_dependencies__tenant_id_fkey'),
+            ondelete='CASCADE'
+        ),
+        sa.ForeignKeyConstraint(
+            ['_source_deployment'], ['deployments._storage_id'],
+            name=op.f(
+                'deployment_labels_dependencies__source_deployment_fkey'
+            ), ondelete='CASCADE'
+        ),
+        sa.ForeignKeyConstraint(
+            ['_target_deployment'], ['deployments._storage_id'],
+            name=op.f(
+                'deployment_labels_dependencies__target_deployment_fkey'
+            ), ondelete='CASCADE'
+        ),
+        sa.PrimaryKeyConstraint(
+            '_storage_id', name=op.f('deployment_labels_dependencies_pkey')
+        ),
+    )
+    op.create_index(
+        op.f('deployment_labels_dependencies__creator_id_idx'),
+        'deployment_labels_dependencies', ['_creator_id'], unique=False
+    )
+    op.create_index(
+        op.f('deployment_labels_dependencies__tenant_id_idx'),
+        'deployment_labels_dependencies', ['_tenant_id'], unique=False
+    )
+    op.create_index(
+        op.f('deployment_labels_dependencies_created_at_idx'),
+        'deployment_labels_dependencies', ['created_at'], unique=False
+    )
+    op.create_index(
+        op.f('deployment_labels_dependencies_id_idx'),
+        'deployment_labels_dependencies', ['id'], unique=False
+    )
+    op.create_index(
+        op.f('deployment_labels_dependencies__source_deployment_idx'),
+        'deployment_labels_dependencies', ['_source_deployment'],
+        unique=False
+    )
+    op.create_index(
+        op.f('deployment_labels_dependencies__target_deployment_idx'),
+        'deployment_labels_dependencies', ['_target_deployment'],
+        unique=False
+    )
+    op.create_index(
+        op.f('deployment_labels_dependencies_visibility_idx'),
+        'deployment_labels_dependencies', ['visibility'], unique=False
+    )
+
+
 def _add_deployment_statuses():
     installation_status.create(op.get_bind())
     deployment_status.create(op.get_bind())

--- a/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
+++ b/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
@@ -237,6 +237,14 @@ def _create_deployment_labels_dependencies_table():
         sa.PrimaryKeyConstraint(
             '_storage_id', name=op.f('deployment_labels_dependencies_pkey')
         ),
+
+        sa.UniqueConstraint(
+            '_source_deployment',
+            '_target_deployment',
+            name=op.f(
+                'deployment_labels_dependencies__source_deployment_key'
+            )
+        )
     )
     op.create_index(
         op.f('deployment_labels_dependencies__creator_id_idx'),

--- a/rest-service/manager_rest/manager_exceptions.py
+++ b/rest-service/manager_rest/manager_exceptions.py
@@ -124,6 +124,19 @@ class DependentExistsError(ManagerException):
             *args, **kwargs)
 
 
+class DeploymentParentNotFound(ManagerException):
+    DEPLOYMENT_PARENT_NOT_FOUND_ERROR_CODE = \
+        'deployment_parent_not_found_error'
+
+    def __init__(self, *args, **kwargs):
+        super(DeploymentParentNotFound, self).__init__(
+            400,
+            DeploymentParentNotFound.DEPLOYMENT_PARENT_NOT_FOUND_ERROR_CODE,
+            *args,
+            **kwargs
+        )
+
+
 class NonexistentWorkflowError(ManagerException):
     NONEXISTENT_WORKFLOW_ERROR_CODE = 'nonexistent_workflow_error'
 

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -1094,3 +1094,35 @@ class BaseServerTestCase(unittest.TestCase):
         self.client.users.create(username, password, role='default')
         self.client.tenants.add_user(username, tenant, role=role)
         return self.create_client_with_tenant(username, password)
+
+    def _put_mock_blueprint(self):
+        blueprint_id = str(uuid.uuid4())
+        now = utils.get_formatted_timestamp()
+        return self.sm.put(
+            models.Blueprint(
+                id=blueprint_id,
+                created_at=now,
+                updated_at=now,
+                main_file_name='abcd',
+                plan={})
+        )
+
+    @staticmethod
+    def _get_mock_deployment(deployment_id, blueprint):
+        now = utils.get_formatted_timestamp()
+        deployment = models.Deployment(
+            id=deployment_id,
+            created_at=now,
+            updated_at=now,
+        )
+        deployment.blueprint = blueprint
+        return deployment
+
+    def put_mock_deployments(self, source_deployment, target_deployment):
+        blueprint = self._put_mock_blueprint()
+        source_deployment = self._get_mock_deployment(source_deployment,
+                                                      blueprint)
+        self.sm.put(source_deployment)
+        target_deployment = self._get_mock_deployment(target_deployment,
+                                                      blueprint)
+        self.sm.put(target_deployment)

--- a/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
@@ -1,0 +1,334 @@
+
+from mock import patch
+
+from cloudify_rest_client.exceptions import CloudifyClientError
+
+from manager_rest.rest.rest_utils import RecursiveDeploymentLabelsDependencies
+from manager_rest.test import base_test
+from manager_rest.test.attribute import attr
+from manager_rest.test.base_test import BaseServerTestCase
+
+
+@attr(client_min_version=3.1, client_max_version=base_test.LATEST_API_VERSION)
+class DeploymentLabelsDependenciesTest(BaseServerTestCase):
+
+    def _create_deployment_objects(self, parent_name, deployment_type, size):
+        for service in range(1, size + 1):
+            self.put_deployment_with_labels(
+                [
+                    {
+                        'csys-obj-parent': parent_name
+                    },
+                    {
+                        'csys-obj-type': deployment_type,
+                    }
+                ],
+                resource_id='{0}_{1}_{2}'.format(
+                    deployment_type, service, parent_name)
+            )
+
+    def _populate_deployment_labels_dependencies(self):
+        self.put_mock_deployments('dep_0', 'dep_1')
+        self.put_mock_deployments('dep_2', 'dep_3')
+        self.put_mock_deployments('dep_4', 'dep_5')
+
+        self.client.deployments.update_labels('dep_0', [
+                {
+                    'csys-obj-parent': 'dep_1'
+                }
+            ]
+        )
+
+        self.client.deployments.update_labels('dep_2', [
+                {
+                    'csys-obj-parent': 'dep_3'
+                }
+            ]
+        )
+
+        self.client.deployments.update_labels('dep_4', [
+                {
+                    'csys-obj-parent': 'dep_5'
+                }
+            ]
+        )
+
+    @patch('manager_rest.resource_manager.ResourceManager'
+           '.handle_deployment_labels_graph')
+    @patch('manager_rest.resource_manager.ResourceManager'
+           '.verify_deployment_parent_labels')
+    def test_deployment_with_empty_labels(self,
+                                          verify_parents_mock,
+                                          handle_labels_graph_mock):
+        self.put_deployment('deployment_with_no_labels')
+        verify_parents_mock.assert_not_called()
+        handle_labels_graph_mock.assert_not_called()
+
+    @patch('manager_rest.resource_manager.ResourceManager'
+           '.handle_deployment_labels_graph')
+    @patch('manager_rest.resource_manager.ResourceManager'
+           '.verify_deployment_parent_labels')
+    def test_deployment_with_non_parent_labels(self,
+                                               verify_parents_mock,
+                                               handle_labels_graph_mock):
+        self.put_deployment_with_labels([{'env': 'aws'}, {'arch': 'k8s'}])
+        verify_parents_mock.assert_not_called()
+        handle_labels_graph_mock.assert_not_called()
+
+    def test_deployment_with_single_parent_label(self):
+        self.put_deployment('parent')
+        self.put_deployment_with_labels([{'csys-obj-parent': 'parent'}])
+
+        # deployment response
+        deployment = self.client.deployments.get('parent')
+        self.assertEqual(deployment.sub_services_count, 1)
+        self.assertEqual(deployment.sub_environments_count, 0)
+
+    def test_deployment_with_multiple_parent_labels(self):
+        self.put_deployment(deployment_id='parent_1',
+                            blueprint_id='blueprint_1')
+        self.put_deployment(deployment_id='parent_2',
+                            blueprint_id='blueprint_2')
+        self.put_deployment_with_labels(
+            [
+                {
+                    'csys-obj-parent': 'parent_1'
+                },
+                {
+                    'csys-obj-parent': 'parent_2'
+                }
+            ]
+        )
+        deployment_1 = self.client.deployments.get('parent_1')
+        deployment_2 = self.client.deployments.get('parent_2')
+        self.assertEqual(deployment_1.sub_services_count, 1)
+        self.assertEqual(deployment_1.sub_environments_count, 0)
+        self.assertEqual(deployment_2.sub_services_count, 1)
+        self.assertEqual(deployment_2.sub_environments_count, 0)
+
+    def test_deployment_with_invalid_parent_label(self):
+        error_message = 'label `csys-obj-parent` that does not exist'
+        with self.assertRaisesRegex(CloudifyClientError, error_message):
+            self.put_deployment_with_labels(
+                [
+                    {
+                        'csys-obj-parent': 'notexist'
+                    }
+                ],
+                resource_id='invalid_label_dep'
+            )
+
+    def test_deployment_with_valid_and_invalid_parent_labels(self):
+        self.put_deployment(deployment_id='parent_1')
+        error_message = 'label `csys-obj-parent` that does not exist'
+        with self.assertRaisesRegex(CloudifyClientError, error_message):
+            self.put_deployment_with_labels(
+                [
+                    {
+                        'csys-obj-parent': 'parent_1'
+                    },
+                    {
+                        'csys-obj-parent': 'notexist'
+                    }
+                ],
+                resource_id='invalid_label_dep'
+            )
+
+    def test_add_valid_label_parent_to_created_deployment(self):
+        self.put_deployment(deployment_id='parent_1',
+                            blueprint_id='blueprint_1')
+        self.put_deployment(deployment_id='parent_2',
+                            blueprint_id='blueprint_2')
+        self.put_deployment_with_labels([{'csys-obj-parent': 'parent_1'}],
+                                        resource_id='label_dep')
+
+        self.client.deployments.update_labels('label_dep', [
+                {
+                    'csys-obj-parent': 'parent_1'
+                },
+                {
+                    'csys-obj-parent': 'parent_2'
+                }
+            ]
+        )
+        deployment_1 = self.client.deployments.get('parent_1')
+        deployment_2 = self.client.deployments.get('parent_2')
+        self.assertEqual(deployment_1.sub_services_count, 1)
+        self.assertEqual(deployment_1.sub_environments_count, 0)
+        self.assertEqual(deployment_2.sub_services_count, 1)
+        self.assertEqual(deployment_2.sub_environments_count, 0)
+
+    def test_add_invalid_label_parent_to_created_deployment(self):
+        error_message = 'label `csys-obj-parent` that does not exist'
+        self.put_deployment(deployment_id='parent_1',
+                            blueprint_id='blueprint_1')
+        self.put_deployment_with_labels([{'csys-obj-parent': 'parent_1'}],
+                                        resource_id='invalid_label_dep')
+
+        with self.assertRaisesRegex(CloudifyClientError, error_message):
+            self.client.deployments.update_labels('invalid_label_dep', [
+                    {
+                        'csys-obj-parent': 'parent_1'
+                    },
+                    {
+                        'csys-obj-parent': 'notexist'
+                    }
+                ]
+            )
+
+    def test_cyclic_dependencies_between_deployments(self):
+        error_message = 'cyclic deployment-labels dependencies.'
+        self.put_deployment(deployment_id='deployment_1',
+                            blueprint_id='deployment_1')
+        self.put_deployment_with_labels(
+            [
+                {
+                    'csys-obj-parent': 'deployment_1'
+                }
+            ],
+            resource_id='deployment_2'
+        )
+        with self.assertRaisesRegex(CloudifyClientError, error_message):
+            self.client.deployments.update_labels('deployment_1', [
+                {
+                    'csys-obj-parent': 'deployment_2'
+                }
+            ])
+
+    def test_number_of_direct_services_deployed_inside_environment(self):
+        self.put_deployment(deployment_id='env',
+                            blueprint_id='env')
+        self._create_deployment_objects('env', 'service', 2)
+        deployment = self.client.deployments.get(
+            'env', all_sub_deployments=False)
+        self.assertEqual(deployment.sub_services_count, 2)
+
+    def test_number_of_total_services_deployed_inside_environment(self):
+        self.put_deployment(deployment_id='env',
+                            blueprint_id='env')
+        self._create_deployment_objects('env', 'service', 2)
+        self.put_deployment_with_labels(
+            [
+                {
+                    'csys-obj-parent': 'env'
+                },
+                {
+                    'csys-obj-type': 'Environment',
+                }
+            ],
+            resource_id='env_1'
+        )
+
+        self._create_deployment_objects('env_1', 'service', 2)
+        deployment = self.client.deployments.get('env')
+        self.assertEqual(deployment.sub_services_count, 4)
+        deployment = self.client.deployments.get('env',
+                                                 all_sub_deployments=False)
+        self.assertEqual(deployment.sub_services_count, 2)
+
+    def test_number_of_direct_environments_deployed_inside_environment(self):
+        self.put_deployment(deployment_id='env',
+                            blueprint_id='env')
+        self._create_deployment_objects('env', 'environment', 2)
+        deployment = self.client.deployments.get(
+            'env', all_sub_deployments=False)
+        self.assertEqual(deployment.sub_environments_count, 2)
+
+    def test_number_of_total_environments_deployed_inside_environment(self):
+        self.put_deployment(deployment_id='env',
+                            blueprint_id='env')
+        self._create_deployment_objects('env', 'environment', 2)
+        self.put_deployment_with_labels(
+            [
+                {
+                    'csys-obj-parent': 'env'
+                },
+                {
+                    'csys-obj-type': 'Environment',
+                }
+            ],
+            resource_id='env_1'
+        )
+
+        self._create_deployment_objects('env_1', 'environment', 2)
+        deployment = self.client.deployments.get('env')
+        self.assertEqual(deployment.sub_environments_count, 5)
+        deployment = self.client.deployments.get('env',
+                                                 all_sub_deployments=False)
+        self.assertEqual(deployment.sub_environments_count, 3)
+
+    def test_create_deployment_labels_dependencies_graph(self):
+        self._populate_deployment_labels_dependencies()
+        dep_graph = RecursiveDeploymentLabelsDependencies(self.sm)
+        dep_graph.create_dependencies_graph()
+        self.assertEqual(dep_graph.graph['dep_1'], {'dep_0'})
+        self.assertEqual(dep_graph.graph['dep_3'], {'dep_2'})
+        self.assertEqual(dep_graph.graph['dep_5'], {'dep_4'})
+
+    def test_add_to_deployment_labels_dependencies_graph(self):
+        self._populate_deployment_labels_dependencies()
+        dep_graph = RecursiveDeploymentLabelsDependencies(self.sm)
+        dep_graph.create_dependencies_graph()
+        dep_graph.add_dependency_to_graph('dep_00', 'dep_1')
+        dep_graph.add_dependency_to_graph('dep_1', 'dep_6')
+        self.assertEqual(dep_graph.graph['dep_1'], {'dep_0', 'dep_00'})
+        self.assertEqual(dep_graph.graph['dep_6'], {'dep_1'})
+
+    def test_remove_deployment_labels_dependencies_from_graph(self):
+        self._populate_deployment_labels_dependencies()
+        dep_graph = RecursiveDeploymentLabelsDependencies(self.sm)
+        dep_graph.create_dependencies_graph()
+        dep_graph.remove_dependency_from_graph('dep_0', 'dep_1')
+        self.assertNotIn('dep_1', dep_graph.graph)
+
+    def test_find_recursive_deployments_from_graph(self):
+        self._populate_deployment_labels_dependencies()
+
+        self.client.deployments.update_labels('dep_0', [
+                {
+                    'csys-obj-parent': 'dep_1'
+                }
+            ]
+        )
+
+        self.put_deployment(deployment_id='dep_11', blueprint_id='dep_11')
+        self.put_deployment(deployment_id='dep_12', blueprint_id='dep_12')
+        self.put_deployment(deployment_id='dep_13', blueprint_id='dep_13')
+        self.put_deployment(deployment_id='dep_14', blueprint_id='dep_14')
+
+        self.client.deployments.update_labels('dep_1', [
+                {
+                    'csys-obj-parent': 'dep_11'
+                }
+            ]
+        )
+
+        self.client.deployments.update_labels('dep_11', [
+                {
+                    'csys-obj-parent': 'dep_12'
+                }
+            ]
+        )
+
+        self.client.deployments.update_labels('dep_12', [
+                {
+                    'csys-obj-parent': 'dep_13'
+                }
+            ]
+        )
+
+        self.client.deployments.update_labels('dep_13', [
+                {
+                    'csys-obj-parent': 'dep_14'
+                }
+            ]
+        )
+        dep_graph = RecursiveDeploymentLabelsDependencies(self.sm)
+        dep_graph.create_dependencies_graph()
+        targets = dep_graph.find_recursive_deployments('dep_0')
+        self.assertEqual(len(targets), 5)
+        self.assertIn('dep_1', targets)
+        self.assertIn('dep_11', targets)
+        self.assertIn('dep_12', targets)
+        self.assertIn('dep_13', targets)
+        self.assertIn('dep_14', targets)

--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -157,7 +157,7 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         self.sm.put(dep)
 
         serialized_dep = dep.to_response()
-        self.assertEqual(31, len(serialized_dep))
+        self.assertEqual(34, len(serialized_dep))
         self.assertEqual(dep.id, serialized_dep['id'])
         self.assertEqual(dep.created_at, serialized_dep['created_at'])
         self.assertEqual(dep.updated_at, serialized_dep['updated_at'])
@@ -172,6 +172,9 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         serialized_dep.pop('created_by')
         serialized_dep.pop('site_name')
         serialized_dep.pop('latest_execution_status')
+        serialized_dep.pop('environment_type')
+        serialized_dep.pop('latest_execution_total_operations')
+        serialized_dep.pop('latest_execution_finished_operations')
 
         # Deprecated columns, for backwards compatibility -
         # was added to the response

--- a/workflows/cloudify_system_workflows/deployment_environment.py
+++ b/workflows/cloudify_system_workflows/deployment_environment.py
@@ -107,7 +107,6 @@ def create(ctx, labels=None, inputs=None, skip_plugins_validation=False, **_):
         capabilities=deployment_plan.get('capabilities', {}),
         labels=labels_to_create,
     )
-
     deployment_settings = deployment_plan.get('deployment_settings', {})
     _join_groups(client, ctx.deployment.id,
                  deployment_settings.get('default_groups', []))


### PR DESCRIPTION
This PR created in order to update the following:
1. Add support to attach deployment(services)/environments to deployment object
2. Add support to include new extra fields as part of the deployment response related to environments
3. Add support to update deployments count for sub-deployments (environments && services) in API response 