### PR TITLE
Use the regular executor for dep-env workflows

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -865,7 +865,7 @@ class ResourceManager(object):
             handler=send_handler,
         )
 
-        workflow = execution.deployment.workflows[execution.workflow_id]
+        workflow = execution.get_workflow()
         is_cascading_workflow = workflow.get('is_cascading', False)
         if is_cascading_workflow:
             components_dep_ids = self._find_all_components_deployment_id(

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -497,10 +497,7 @@ class ResourceManager(object):
             status=ExecutionState.PENDING,
         )
         self.sm.put(execution)
-        return self._execute_system_workflow(
-            execution,
-            verify_no_executions=False,
-        )
+        return self.execute_workflow(execution)
 
     def publish_blueprint(self,
                           application_dir,
@@ -842,9 +839,10 @@ class ResourceManager(object):
                          bypass_maintenance=None, wait_after_fail=600,
                          allow_overlapping_running_wf=False,
                          send_handler: 'SendHandler' = None):
-        self._check_allow_global_execution(execution.deployment)
-        self._verify_dependencies_not_affected(
-            execution.workflow_id, execution.deployment, force)
+        if execution.deployment:
+            self._check_allow_global_execution(execution.deployment)
+            self._verify_dependencies_not_affected(
+                execution.workflow_id, execution.deployment, force)
 
         should_queue = queue
         if not allow_overlapping_running_wf:
@@ -905,7 +903,7 @@ class ResourceManager(object):
         """
         system_exec_running = self._check_for_active_system_wide_execution(
             queue, execution)
-        if force:
+        if force or not execution.deployment:
             return system_exec_running
         else:
             execution_running = self._check_for_active_executions(

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -938,11 +938,10 @@ class ResourceManager(object):
 
     def _check_for_active_system_wide_execution(self, execution, queue):
         should_queue = False
-        for e in self.list_executions(
-                is_include_system_workflows=True,
-                filters={'status': ExecutionState.ACTIVE_STATES},
-                all_tenants=True,
-                get_all_results=True).items:
+        for e in self.sm.list(models.Execution, filters={
+                    'is_system_workflow': True,
+                    'status': ExecutionState.ACTIVE_STATES,
+                }, get_all_results=True, all_tenants=True).items:
             # When `queue` or `schedule` options are used no need to
             # raise an exception (the execution will run later)
             if e.deployment_id is None and (queue or execution.scheduled_for):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -711,7 +711,9 @@ class Execution(CreatedAtMixin, SQLResourceBase):
             'upload_blueprint': 'cloudify_system_workflows.blueprint.upload'
         }.get(wf_id)
 
-    def get_workflow(self, deployment, workflow_id):
+    def get_workflow(self, deployment=None, workflow_id=None):
+        deployment = deployment or self.deployment
+        workflow_id = workflow_id or self.workflow_id
         system_task_name = self._system_workflow_task_name(workflow_id)
         if system_task_name:
             self.allow_custom_parameters = True
@@ -786,7 +788,7 @@ class Execution(CreatedAtMixin, SQLResourceBase):
             return param
 
     def render_context(self):
-        workflow = self.get_workflow(self.deployment, self.workflow_id)
+        workflow = self.get_workflow()
         context = {
             'type': 'workflow',
             'task_id': self.id,


### PR DESCRIPTION
They used to be called via `._execute_system_workflow`, but this seems more correct