### PR TITLE
RD-1640 groups: execute up to the concurrency limit

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -203,6 +203,7 @@ class ResourceManager(object):
 
     def start_queued_executions(self, finished_execution):
         for execution in self._get_queued_executions(finished_execution):
+            execution.status = ExecutionState.PENDING
             if self._should_use_system_workflow_executor(execution):
                 self._execute_system_workflow(execution, queue=True)
             else:

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -334,6 +334,7 @@ class ResourceManager(object):
                     'config': self._get_conf_for_snapshots_wf()
                 },
                 is_system_workflow=True,
+                status=ExecutionState.PENDING,
             )
             self.sm.put(execution)
             execution = self._execute_system_workflow(
@@ -378,6 +379,7 @@ class ResourceManager(object):
                 'user_is_bootstrap_admin': current_user.is_bootstrap_admin
             },
             is_system_workflow=True,
+            status=ExecutionState.PENDING,
         )
         self.sm.put(execution)
         execution = self._execute_system_workflow(
@@ -878,6 +880,7 @@ class ResourceManager(object):
                     allow_custom_parameters=execution.allow_custom_parameters,
                     dry_run=execution.dry_run,
                     creator=execution.creator,
+                    status=ExecutionState.PENDING,
                 )
                 self.execute_workflow(
                     component_execution,

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1293,13 +1293,15 @@ class ResourceManager(object):
         for node_instance in node_instances:
             self.sm.put(node_instance)
 
-    def assert_no_snapshot_creation_running_or_queued(self, execution):
+    def assert_no_snapshot_creation_running_or_queued(self, execution=None):
         """
         Make sure no 'create_snapshot' workflow is currently running or queued.
         We do this to avoid DB modifications during snapshot creation.
         """
         status = ExecutionState.ACTIVE_STATES + ExecutionState.QUEUED_STATE
-        filters = {'status': status, 'id': lambda col: col != execution.id}
+        filters = {'status': status}
+        if execution is not None:
+            filters['id'] = lambda col: col != execution.id
         for e in self.list_executions(is_include_system_workflows=True,
                                       filters=filters,
                                       get_all_results=True).items:

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -503,7 +503,7 @@ class ExecutionGroupsTestCase(base_test.BaseServerTestCase):
             models.ExecutionGroup, exc_group.id).executions
         pending_execs = sum(
             exc.status == ExecutionState.PENDING for exc in group_execs)
-        queued_execs = sum(exc.status == ExecutionState.QUEUED
-            for exc in group_execs)
-        assert  pending_execs == exc_group.concurrency
-        assert  queued_execs == len(group_execs) - exc_group.concurrency
+        queued_execs = sum(
+            exc.status == ExecutionState.QUEUED for exc in group_execs)
+        assert pending_execs == exc_group.concurrency
+        assert queued_execs == len(group_execs) - exc_group.concurrency

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -370,7 +370,7 @@ class ExecutionGroupsTestCase(base_test.BaseServerTestCase):
         non_group_execution = self.client.executions.start(
             deployment_id='dep1',
             workflow_id='install',
-            force=True,  # force, because there's on already running
+            force=True,  # force, because there's one already running
         )
         # refetch as ORM objects so we can pass them to Log/Event
         group_execution = self.sm.get(models.Execution, group.execution_ids[0])
@@ -430,7 +430,7 @@ class ExecutionGroupsTestCase(base_test.BaseServerTestCase):
         self.client.executions.start(
             deployment_id='dep1',
             workflow_id='install',
-            force=True,  # force, because there's on already running
+            force=True,  # force, because there's one already running
         )
         executions = self.client.executions.list(
             _group_id=execution_group['id'])


### PR DESCRIPTION
Actually use .concurrency for exec-groups.

Also a bugfix, in the first commit.