### PR TITLE
RD-1359 Start group create-dep-envs in an exec-group

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1322,8 +1322,8 @@ class ResourceManager(object):
         if (visibility == VisibilityState.GLOBAL and
                 blueprint.visibility != VisibilityState.GLOBAL):
             raise manager_exceptions.ForbiddenError(
-                "Can't create global deployment {0} because blueprint {1} "
-                "is not global".format(deployment_id, blueprint_id)
+                f"Can't create global deployment {deployment_id} because "
+                f"blueprint {blueprint.id} is not global"
             )
 
         #  validate plugins exists on manager when

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1303,21 +1303,17 @@ class ResourceManager(object):
             self.delete_deployment(dep)
 
     def create_deployment(self,
-                          blueprint_id,
+                          blueprint,
                           deployment_id,
                           private_resource,
                           visibility,
-                          inputs=None,
-                          bypass_maintenance=None,
                           skip_plugins_validation=False,
-                          site_name=None,
+                          site=None,
                           runtime_only_evaluation=False,
                           labels=None):
-        blueprint = self.sm.get(models.Blueprint, blueprint_id)
         verify_blueprint_uploaded_state(blueprint)
         self._cleanup_failed_deployment(deployment_id)
         plan = blueprint.plan
-        site = self.sm.get(models.Site, site_name) if site_name else None
         deployment_labels = self._handle_deployment_labels(labels, plan)
 
         visibility = self.get_resource_visibility(models.Deployment,

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1285,7 +1285,7 @@ class ResourceManager(object):
                     ' while a `create_snapshot` workflow is running or queued'
                     ' (snapshot id: {0})'.format(e.id))
 
-    def _cleanup_failed_deployment(self, deployment_id):
+    def cleanup_failed_deployment(self, deployment_id):
         """If create-dep-env failed, delete the deployment.
 
         This is so that it's possible to retry creating the deployment,
@@ -1312,7 +1312,6 @@ class ResourceManager(object):
                           runtime_only_evaluation=False,
                           labels=None):
         verify_blueprint_uploaded_state(blueprint)
-        self._cleanup_failed_deployment(deployment_id)
         plan = blueprint.plan
         deployment_labels = self._handle_deployment_labels(labels, plan)
 

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -214,7 +214,7 @@ class ResourceManager(object):
         system_executions = self.sm.list(models.Execution, filters={
             'status': ExecutionState.QUEUED_STATE,
             'is_system_workflow': True,
-        }, sort=sort_by, get_all_results=True).items
+        }, sort=sort_by, get_all_results=True, all_tenants=True).items
         if system_executions:
             yield system_executions[0]
             return
@@ -224,17 +224,17 @@ class ResourceManager(object):
             same_dep_executions = self.sm.list(models.Execution, filters={
                 'status': ExecutionState.QUEUED_STATE,
                 'deployment_id': deployment_id,
-            }, sort=sort_by, get_all_results=True).items
+            }, sort=sort_by, get_all_results=True, all_tenants=True).items
             other_queued = self.sm.list(models.Execution, filters={
                 'status': ExecutionState.QUEUED_STATE,
                 'deployment_id': lambda col: col != deployment_id,
-            }, sort=sort_by, get_all_results=True).items
+            }, sort=sort_by, get_all_results=True, all_tenants=True).items
             queued_executions = same_dep_executions + other_queued
         else:
             queued_executions = self.sm.list(models.Execution, filters={
                 'status': ExecutionState.QUEUED_STATE,
                 'is_system_workflow': False,
-            }, sort=sort_by, get_all_results=True).items
+            }, sort=sort_by, get_all_results=True, all_tenants=True).items
 
         # {deployment: whether it can run executions}
         busy_deployments = {}

--- a/rest-service/manager_rest/rest/resources_v1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v1/deployments.py
@@ -18,6 +18,7 @@ from flask_restful_swagger import swagger
 from flask_restful.reqparse import Argument
 from flask_restful.inputs import boolean
 
+from manager_rest import manager_exceptions
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
 from manager_rest.maintenance import is_bypass_maintenance_mode
@@ -107,16 +108,27 @@ class DeploymentsId(SecuredResource):
             [Argument('private_resource', type=boolean,
                       default=False)]
         )
-        deployment = get_resource_manager().create_deployment(
-            blueprint_id,
+        skip_plugins_validation = self.get_skip_plugin_validation_flag(
+            request_dict)
+        rm = get_resource_manager()
+        sm = get_storage_manager()
+        blueprint = sm.get(models.Blueprint, blueprint_id)
+        rm.cleanup_failed_deployment(deployment_id)
+        deployment = rm.create_deployment(
+            blueprint,
             deployment_id,
             private_resource=args.private_resource,
             visibility=None,
-            inputs=request_dict.get('inputs', {}),
-            bypass_maintenance=bypass_maintenance,
-            skip_plugins_validation=self.get_skip_plugin_validation_flag(
-                request_dict)
+            skip_plugins_validation=skip_plugins_validation,
         )
+        try:
+            rm.execute_workflow(deployment.make_create_environment_execution(
+                inputs=request_dict.get('inputs', {}),
+                skip_plugins_validation=skip_plugins_validation,
+            ), bypass_maintenance=bypass_maintenance,)
+        except manager_exceptions.ExistingRunningExecutionError:
+            rm.delete_deployment(deployment)
+            raise
         return deployment, 201
 
     def create_request_schema(self):

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -48,6 +48,11 @@ from manager_rest.rest import (
     rest_decorators,
     responses_v3
 )
+from manager_rest.workflow_executor import (
+    get_amqp_client,
+    workflow_sendhandler
+)
+
 
 SHARED_RESOURCE_TYPE = 'cloudify.nodes.SharedResource'
 COMPONENT_TYPE = 'cloudify.nodes.Component'
@@ -585,18 +590,38 @@ class DeploymentGroupsId(SecuredResource):
             raise manager_exceptions.ConflictError(
                 'Cannot create deployments: group {0} has no '
                 'default blueprint set'.format(group.id))
-        for inputs in input_overrides:
-            deployment_inputs = (group.default_inputs or {}).copy()
-            deployment_inputs.update(inputs)
-            dep = rm.create_deployment(
-                blueprint_id=group.default_blueprint.id,
-                deployment_id='{0}-{1}'.format(group.id, deployment_count + 1),
-                private_resource=None,
-                visibility=group.visibility,
-                inputs=deployment_inputs,
-            )
-            group.deployments.append(dep)
-            deployment_count += 1
+        if not input_overrides:
+            return
+        create_exec_group = models.ExecutionGroup(
+            id=str(uuid.uuid4()),
+            deployment_group=group,
+            workflow_id='create_deployment_environment',
+            visibility=group.visibility,
+        )
+        sm.put(create_exec_group)
+        with sm.transaction():
+            for inputs in input_overrides:
+                deployment_inputs = (group.default_inputs or {}).copy()
+                deployment_inputs.update(inputs)
+                dep = rm.create_deployment(
+                    blueprint=group.default_blueprint,
+                    deployment_id=f'{group.id}-{deployment_count + 1}',
+                    private_resource=None,
+                    visibility=group.visibility,
+                )
+                group.deployments.append(dep)
+                create_execution = dep.make_create_environment_execution(
+                    inputs=deployment_inputs,
+                )
+                create_execution.is_id_unique = True
+                sm.put(create_execution)
+                create_exec_group.executions.append(create_execution)
+                deployment_count += 1
+        amqp_client = get_amqp_client()
+        handler = workflow_sendhandler()
+        amqp_client.add_handler(handler)
+        with amqp_client:
+            create_exec_group.start_executions(sm, rm, handler)
 
     def _remove_group_deployments(self, sm, group, request_dict):
         remove_ids = request_dict.get('deployment_ids') or []

--- a/rest-service/manager_rest/rest/resources_v3_1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/executions.py
@@ -210,19 +210,7 @@ class ExecutionGroups(SecuredResource):
         handler = workflow_sendhandler()
         amqp_client.add_handler(handler)
         with amqp_client:
-            for execution in executions[:group.concurrency]:
-                rm.execute_workflow(
-                    execution,
-                    force=force,
-                    send_handler=handler,
-                    queue=True,  # allow queue, but it will try to run
-                )
-
-        with sm.transaction():
-            for execution in executions[group.concurrency:]:
-                execution.status = ExecutionState.QUEUED
-                sm.update(execution, modified_attrs=('status', ))
-
+            group.start_executions(sm, rm, handler, force=force)
         return group
 
 

--- a/rest-service/manager_rest/rest/resources_v3_1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/executions.py
@@ -185,7 +185,6 @@ class ExecutionGroups(SecuredResource):
             id=str(uuid.uuid4()),
             deployment_group=dep_group,
             workflow_id=workflow_id,
-            created_at=datetime.now(),
             visibility=dep_group.visibility,
             concurrency=concurrency,
         )

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -487,6 +487,19 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         else:
             return DeploymentState.IN_PROGRESS
 
+    def make_create_environment_execution(
+            self, inputs=None, skip_plugins_validation=False):
+        self.create_execution = Execution(
+            workflow_id='create_deployment_environment',
+            deployment=self,
+            status=ExecutionState.PENDING,
+            parameters={
+                'inputs': inputs,
+                'skip_plugins_validation': skip_plugins_validation,
+            },
+        )
+        return self.create_execution
+
 
 class DeploymentGroup(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'deployment_groups'

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -10,6 +10,10 @@ from manager_rest.storage import models
 from manager_rest.test import base_test
 
 
+@mock.patch(
+    'manager_rest.rest.resources_v3_1.deployments.workflow_sendhandler',
+    mock.Mock()
+)
 class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
     def setUp(self):
         super(DeploymentGroupsTestCase, self).setUp()


### PR DESCRIPTION
Instead of starting all the create-dep-envs at the same time,
make an execution-group and put them in that. The create-dep-env
executions will then be run using the queueing mechanism.

To do that, there's a few refactors and some divorcing needed!
See each commit message. It does get tied all together at the
end, I promise.