### PR TITLE
RD-872 Allow --force plugins update in components (#2586)

### DIFF
--- a/rest-service/manager_rest/deployment_update/manager.py
+++ b/rest-service/manager_rest/deployment_update/manager.py
@@ -194,7 +194,8 @@ class DeploymentUpdateManager(object):
                                  ignore_failure=False,
                                  install_first=False,
                                  reinstall_list=None,
-                                 update_plugins=True):
+                                 update_plugins=True,
+                                 force=False):
         # Mark deployment update as committing
         dep_update.keep_old_deployment_dependencies = skip_uninstall
         dep_update.state = STATES.UPDATING
@@ -274,7 +275,8 @@ class DeploymentUpdateManager(object):
             reinstall_list=reinstall_list,
             central_plugins_to_install=central_plugins_to_install,
             central_plugins_to_uninstall=central_plugins_to_uninstall,
-            update_plugins=update_plugins
+            update_plugins=update_plugins,
+            force=force
         )
 
         # Update deployment attributes in the storage manager
@@ -440,7 +442,8 @@ class DeploymentUpdateManager(object):
                                  reinstall_list=None,
                                  central_plugins_to_install=None,
                                  central_plugins_to_uninstall=None,
-                                 update_plugins=True):
+                                 update_plugins=True,
+                                 force=False):
         """Executed the update workflow or a custom workflow
 
         :param dep_update: deployment update object
@@ -461,6 +464,8 @@ class DeploymentUpdateManager(object):
         :param central_plugins_to_uninstall: plugins to uninstall that have the
         central_deployment_agent as the executor.
         :param update_plugins: whether or not to perform plugin updates.
+        :param force: force update (i.e. even if the blueprint is used to
+        create components).
 
         :return: an Execution object.
         """
@@ -532,7 +537,8 @@ class DeploymentUpdateManager(object):
             blueprint_id=dep_update.new_blueprint_id,
             parameters=parameters,
             allow_custom_parameters=True,
-            allow_overlapping_running_wf=True
+            allow_overlapping_running_wf=True,
+            force=force,
         )
 
     def finalize_commit(self, deployment_update_id):

--- a/rest-service/manager_rest/plugins_update/constants.py
+++ b/rest-service/manager_rest/plugins_update/constants.py
@@ -44,6 +44,7 @@ ALL_TO_LATEST = 'all_to_latest'
 TO_MINOR = 'to_minor'
 ALL_TO_MINOR = 'all_to_minor'
 MAPPING = 'mapping'
+FORCE = 'force'
 AUTO_CORRECT_TYPES = 'auto_correct_types'
 REEVALUATE_ACTIVE_STATUSES = 'reevaluate_active_statuses'
 

--- a/rest-service/manager_rest/plugins_update/manager.py
+++ b/rest-service/manager_rest/plugins_update/manager.py
@@ -101,12 +101,12 @@ class PluginsUpdateManager(object):
         temp_blueprint.is_hidden = True
         return self.sm.update(temp_blueprint)
 
-    def _stage_plugin_update(self, blueprint):
+    def _stage_plugin_update(self, blueprint, forced):
         update_id = str(uuid.uuid4())
         plugins_update = models.PluginsUpdate(
             id=update_id,
             created_at=utils.get_formatted_timestamp(),
-            forced=False)
+            forced=forced)
         plugins_update.set_blueprint(blueprint)
         return self.sm.put(plugins_update)
 
@@ -145,7 +145,8 @@ class PluginsUpdateManager(object):
 
         changes_required = _did_plugins_to_install_change(temp_plan,
                                                           blueprint.plan)
-        plugins_update = self._stage_plugin_update(blueprint)
+        plugins_update = self._stage_plugin_update(blueprint,
+                                                   filters.get('force', False))
         if changes_required:
             plugins_update.deployments_to_update = [
                 dep.id for dep in self._get_deployments_to_update(blueprint_id)

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -322,6 +322,7 @@ class ResourceManager(object):
                 'update_id': plugins_update.id,
                 'deployments_to_update': plugins_update.deployments_to_update,
                 'temp_blueprint_id': plugins_update.temp_blueprint_id,
+                'force': plugins_update.forced,
                 'auto_correct_types': auto_correct_types,
                 'reevaluate_active_statuses': reevaluate_active_statuses,
             },

--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -189,6 +189,7 @@ class DeploymentUpdate(SecuredResource):
         force = verify_and_convert_bool(
             'force',
             request_json.get('force', False)
+        )
         auto_correct_types = verify_and_convert_bool(
             'auto_correct_types',
             request_json.get('auto_correct_types', False)

--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -83,8 +83,8 @@ class DeploymentUpdate(SecuredResource):
         """
         manager, skip_install, skip_uninstall, skip_reinstall, workflow_id, \
             ignore_failure, install_first, preview, update_plugins, \
-            runtime_eval, auto_correct_args, reevaluate_active_statuses = \
-            self._parse_args(id, request.json)
+            runtime_eval, force, auto_correct_args, \
+            reevaluate_active_statuses = self._parse_args(id, request.json)
         blueprint, inputs, reinstall_list = \
             self._get_and_validate_blueprint_and_inputs(id, request.json)
         blueprint_dir_abs = _get_plugin_update_blueprint_abs_path(
@@ -110,13 +110,14 @@ class DeploymentUpdate(SecuredResource):
                                                 ignore_failure,
                                                 install_first,
                                                 reinstall_list,
-                                                update_plugins=update_plugins)
+                                                update_plugins=update_plugins,
+                                                force=force)
 
     def _commit(self, deployment_id):
         request_json = request.args
         manager, skip_install, skip_uninstall, _, workflow_id, \
             ignore_failure, install_first, _, update_plugins, \
-            runtime_eval, _, _ = self._parse_args(
+            runtime_eval, force, _, _ = self._parse_args(
                 deployment_id, request_json, using_post_request=True)
         manager.validate_no_active_updates_per_deployment(deployment_id)
         deployment_update, _ = \
@@ -130,7 +131,8 @@ class DeploymentUpdate(SecuredResource):
                                                 workflow_id,
                                                 ignore_failure,
                                                 install_first,
-                                                update_plugins=update_plugins)
+                                                update_plugins=update_plugins,
+                                                force=force)
 
     @staticmethod
     def _get_and_validate_blueprint_and_inputs(deployment_id, request_json):
@@ -184,6 +186,9 @@ class DeploymentUpdate(SecuredResource):
             'runtime_only_evaluation',
             request_json.get('runtime_only_evaluation', False)
         )
+        force = verify_and_convert_bool(
+            'force',
+            request_json.get('force', False)
         auto_correct_types = verify_and_convert_bool(
             'auto_correct_types',
             request_json.get('auto_correct_types', False)
@@ -203,6 +208,7 @@ class DeploymentUpdate(SecuredResource):
                 preview,
                 update_plugins,
                 runtime_only_evaluation,
+                force,
                 auto_correct_types,
                 reevaluate_active_statuses)
 

--- a/rest-service/manager_rest/rest/resources_v3_1/plugins.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/plugins.py
@@ -32,6 +32,7 @@ from manager_rest.plugins_update.constants import (PLUGIN_NAMES,
                                                    TO_MINOR,
                                                    ALL_TO_MINOR,
                                                    MAPPING,
+                                                   FORCE,
                                                    AUTO_CORRECT_TYPES,
                                                    REEVALUATE_ACTIVE_STATUSES,)
 from manager_rest.plugins_update.manager import get_plugins_updates_manager
@@ -114,6 +115,7 @@ class PluginsUpdate(SecuredResource):
                 ALL_TO_MINOR: {'type': bool, 'optional': True},
                 TO_MINOR: {'type': list, 'optional': True},
                 MAPPING: {'type': dict, 'optional': True},
+                FORCE: {'type': bool, 'optional': True},
                 AUTO_CORRECT_TYPES: {'type': bool, 'optional': True},
                 REEVALUATE_ACTIVE_STATUSES: {'type': bool, 'optional': True},
             })

--- a/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
@@ -143,6 +143,7 @@ class PluginsUpdateTest(PluginsUpdatesBaseTest):
             {'update_id': plugins_update.id,
              'deployments_to_update': ['d1', 'd2'],
              'temp_blueprint_id': plugins_update.temp_blueprint_id,
+             'force': False,
              'auto_correct_types': False,
              'reevaluate_active_statuses': False})
 

--- a/workflows/cloudify_system_workflows/plugins.py
+++ b/workflows/cloudify_system_workflows/plugins.py
@@ -55,7 +55,7 @@ def _operate_on_plugin(ctx, plugin, action):
 
 
 @workflow(system_wide=True)
-def update(ctx, update_id, temp_blueprint_id, deployments_to_update,
+def update(ctx, update_id, temp_blueprint_id, deployments_to_update, force,
            auto_correct_types, reevaluate_active_statuses, **_):
     """Execute deployment update for all the given deployments_to_update.
 
@@ -64,6 +64,8 @@ def update(ctx, update_id, temp_blueprint_id, deployments_to_update,
     this workflow only.
     :param deployments_to_update: deployments to perform the update on, using
     the temp blueprint ID provided.
+    :param force: force update (i.e. even if the blueprint is used to create
+    components).
     :param auto_correct_types: update deployments with auto_correct_types flag,
      which will attempt to cast inputs to the types defined by the blueprint.
     :reevaluate_active_statuses: reevaluate deployment updates states based on
@@ -89,6 +91,7 @@ def update(ctx, update_id, temp_blueprint_id, deployments_to_update,
                     skip_install=True,
                     skip_uninstall=True,
                     skip_reinstall=True,
+                    force=force,
                     auto_correct_types=auto_correct_types,
                     reevaluate_active_statuses=reevaluate_active_statuses) \
                 .execution_id

--- a/workflows/cloudify_system_workflows/tests/test_plugins.py
+++ b/workflows/cloudify_system_workflows/tests/test_plugins.py
@@ -103,14 +103,20 @@ class TestPluginsUpdate(unittest.TestCase):
                     status=execution_status['curr_exec_status'])
             return PropertyMock(status=ExecutionState.TERMINATED)
 
-        def _assert_update_func():
-            update_func(MagicMock(),
-                        'my_update_id', None, dep_ids, False, True)
+        def _assert_update_func_raises():
+            with self.assertRaisesRegexp(
+                    RuntimeError,
+                    "Deployment update of deployment {0} with execution ID {0}"
+                    " failed, stopped this plugins update "
+                    "\\(id='my_update_id'\\)\\.".format(failed_execution_id)):
+                update_func(MagicMock(), 'my_update_id', None, dep_ids,
+                            False, False, False)
             should_call_these = [call(deployment_id=i,
                                       blueprint_id=None,
                                       skip_install=True,
                                       skip_uninstall=True,
                                       skip_reinstall=True,
+                                      force=False,
                                       auto_correct_types=False,
                                       reevaluate_active_statuses=True)
                                  for i in dep_ids]
@@ -134,13 +140,14 @@ class TestPluginsUpdate(unittest.TestCase):
             = finalize_update_mock
         self.mock_rest_client.executions.get \
             .return_value = PropertyMock(status=ExecutionState.TERMINATED)
-        update_func(MagicMock(),
-                    '12345678', None, dep_ids, False, False)
+        update_func(MagicMock(), '12345678', None, dep_ids,
+                False, False, False)
         should_call_these = [call(deployment_id=i,
                                   blueprint_id=None,
                                   skip_install=True,
                                   skip_uninstall=True,
                                   skip_reinstall=True,
+                                  force=False,
                                   auto_correct_types=False,
                                   reevaluate_active_statuses=False)
                              for i in range(len(dep_ids))]

--- a/workflows/cloudify_system_workflows/tests/test_plugins.py
+++ b/workflows/cloudify_system_workflows/tests/test_plugins.py
@@ -103,14 +103,9 @@ class TestPluginsUpdate(unittest.TestCase):
                     status=execution_status['curr_exec_status'])
             return PropertyMock(status=ExecutionState.TERMINATED)
 
-        def _assert_update_func_raises():
-            with self.assertRaisesRegexp(
-                    RuntimeError,
-                    "Deployment update of deployment {0} with execution ID {0}"
-                    " failed, stopped this plugins update "
-                    "\\(id='my_update_id'\\)\\.".format(failed_execution_id)):
-                update_func(MagicMock(), 'my_update_id', None, dep_ids,
-                            False, False, False)
+        def _assert_update_func():
+            update_func(MagicMock(),
+                        'my_update_id', None, dep_ids, False, False, True)
             should_call_these = [call(deployment_id=i,
                                       blueprint_id=None,
                                       skip_install=True,
@@ -140,8 +135,8 @@ class TestPluginsUpdate(unittest.TestCase):
             = finalize_update_mock
         self.mock_rest_client.executions.get \
             .return_value = PropertyMock(status=ExecutionState.TERMINATED)
-        update_func(MagicMock(), '12345678', None, dep_ids,
-                False, False, False)
+        update_func(MagicMock(),
+                    '12345678', None, dep_ids,  False, False, False)
         should_call_these = [call(deployment_id=i,
                                   blueprint_id=None,
                                   skip_install=True,


### PR DESCRIPTION
* Use --force parameter to fill PluginsUpdate.forced

The --force parameter is going to mark PluginUpdate to be forcefully
updated (i.e. regardless of the fact that the blueprint is used to
create a component).

* Propagate --force parameter down to the plugins.update functions

* Fix plugins update tests