### PR TITLE
Handle invalid filters exception

### DIFF
--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -48,13 +48,7 @@ def manager_exception(error):
         current_app.logger.debug(error)
     else:
         current_app.logger.error(error)
-    return jsonify(
-        message=str(error),
-        error_code=error.error_code,
-        # useless, but v1 and v2 api clients require server_traceback
-        # remove this after dropping v1 and v2 api clients
-        server_traceback=None
-    ), error.status_code
+    return error.to_response(), error.status_code
 
 
 @app_errors.app_errorhandler(InternalServerError)


### PR DESCRIPTION
We would like to show the user in the CLI the string form of a filter rule in case of an error. In order to do this, we need to pass the invalid filter rule and error reason as attributes of the exception to the rest-client. The CLI, in turn, will modify these attributes into a nice error message for the user. 

Complementary PR: https://github.com/cloudify-cosmo/cloudify-common/pull/721

