### PR TITLE
RD-1164 create-dep-env: join dep-groups declared in the DSL

### DIFF
--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -1086,6 +1086,17 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
         with self.assertRaisesRegex(CloudifyClientError, 'already set'):
             self.client.deployments.set_attributes('dep1', description='d2')
 
+    def test_create_deployment_with_default_groups(self):
+        _, _, _, deployment = self.put_deployment(
+            blueprint_file_name='blueprint_with_default_groups.yaml',
+            inputs={'inp1': 'g3'}
+        )
+
+        dep = self.sm.get(models.Deployment, deployment.id)
+        groups = dep.deployment_groups
+        assert len(groups) == 2
+        assert {g.id for g in groups} == {'g1', 'g3'}
+
     def test_create_deployment_with_default_schedules(self):
         _, _, _, deployment = self.put_deployment(
             blueprint_file_name='blueprint_with_default_schedules.yaml')

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_default_groups.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_default_groups.yaml
@@ -1,0 +1,13 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - cloudify/types/types.yaml
+
+inputs:
+  inp1:
+    default: g2
+
+deployment_settings:
+  default_groups:
+    - g1
+    - {get_input: inp1}


### PR DESCRIPTION
In the blueprint, deployment_settings.default_groups is the list
of groups the deployment is going to belong to when created.