### PR TITLE
RD-1603 Create schedules in create-dep-env

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1355,8 +1355,6 @@ class ResourceManager(object):
         """This runs when create-deployment-environment finishes"""
         # RD-1602 will move this to the workflow:
         self._create_deployment_initial_dependencies(deployment)
-        # RD-1603 will move this:
-        self.create_deployment_schedules(deployment, deployment.blueprint.plan)
 
     def install_plugin(self, plugin, manager_names=None, agent_names=None):
         """Send the plugin install task to the given managers or agents."""

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -1089,8 +1089,8 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
 
         sc1 = self.client.execution_schedules.get('sc1', deployment.id)
         # sc2 = self.client.execution_schedules.get('sc2', deployment.id)
-        self.assertEquals(sc1['rule']['recurrence'], '1w')
-        self.assertEquals(len(sc1['all_next_occurrences']), 5)
+        self.assertEqual(sc1['rule']['recurrence'], '1w')
+        self.assertEqual(len(sc1['all_next_occurrences']), 5)
 
     def test_list_deployments_with_not_empty_filter(self):
         self.client.sites.create(self.SITE_NAME)
@@ -1151,7 +1151,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
 
         # sc2's workflow_id of should change to `uninstall` after the update
         sc2 = self.client.execution_schedules.get('sc2', deployment.id)
-        self.assertEquals('install', sc2['workflow_id'])
+        self.assertEqual('install', sc2['workflow_id'])
 
         self.client.deployment_updates.update_with_existing_blueprint(
             deployment.id, new_blueprint_id)
@@ -1160,7 +1160,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
             ['sc2', 'sc3'],
             [sc['id'] for sc in self.client.execution_schedules.list()])
         sc2 = self.client.execution_schedules.get('sc2', deployment.id)
-        self.assertEquals('uninstall', sc2['workflow_id'])
+        self.assertEqual('uninstall', sc2['workflow_id'])
 
     def test_update_deployment_with_default_schedule_manually_deleted(self):
         _, _, _, deployment = self.put_deployment(

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -1078,7 +1078,8 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
 
     def test_create_deployment_with_default_schedules(self):
         _, _, _, deployment = self.put_deployment(
-            blueprint_file_name='blueprint_with_default_schedules.yaml')
+            blueprint_file_name='blueprint_with_default_schedules.yaml',
+            inputs={'param1': 'value2'})
 
         sched_ids = list(self.client.execution_schedules.list(
             _include=['id', 'deployment_id']))
@@ -1088,9 +1089,9 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
              {'id': 'sc2', 'deployment_id': deployment.id}])
 
         sc1 = self.client.execution_schedules.get('sc1', deployment.id)
-        # sc2 = self.client.execution_schedules.get('sc2', deployment.id)
         self.assertEqual(sc1['rule']['recurrence'], '1w')
         self.assertEqual(len(sc1['all_next_occurrences']), 5)
+        self.assertEqual(sc1['parameters'], {'param1': 'value2'})
 
     def test_list_deployments_with_not_empty_filter(self):
         self.client.sites.create(self.SITE_NAME)

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_default_schedules.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_default_schedules.yaml
@@ -3,6 +3,11 @@ tosca_definitions_version: cloudify_dsl_1_3
 imports:
   - cloudify/types/types.yaml
 
+inputs:
+  param1:
+    description: parameter param1 for sc1's workflow
+    default: value1
+
 deployment_settings:
   default_schedules:
     sc1:
@@ -12,6 +17,8 @@ deployment_settings:
       recurrence: 1w
       weekdays: [mo, fr]
       count: 5
+      workflow_parameters:
+        param1: {get_input: param1}
     sc2:
       workflow: install
       since: '2022-1-1 15:00'


### PR DESCRIPTION
Move creating the schedules to the workflow, so that they don't need to be
created up-front, and so that their definitions can use intrinsic functions