### PR TITLE
RD-1196 Add/remove deployments given by a group

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -649,7 +649,8 @@ class DeploymentGroupsId(SecuredResource):
         remove_ids = request_dict.get('deployment_ids') or []
         for remove_id in remove_ids:
             dep = sm.get(models.Deployment, remove_id)
-            group.deployments.remove(dep)
+            if dep in group.deployments:
+                group.deployments.remove(dep)
 
         filter_id = request_dict.get('filter_id')
         if filter_id is not None:
@@ -659,7 +660,8 @@ class DeploymentGroupsId(SecuredResource):
                     filter_id, models.DeploymentsFilter)
             )
             for dep in deployments:
-                group.deployments.remove(dep)
+                if dep in group.deployments:
+                    group.deployments.remove(dep)
 
         remove_group = request_dict.get('deployments_from_group')
         if remove_group:

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -504,6 +504,7 @@ class DeploymentGroupsId(SecuredResource):
             'default_inputs': {'optional': True},
             'visibility': {'optional': True},
             'new_deployments': {'optional': True},
+            'deployments_from_group': {'optional': True},
         })
         sm = get_storage_manager()
         try:
@@ -590,6 +591,11 @@ class DeploymentGroupsId(SecuredResource):
                     'default blueprint set'.format(group.id))
             self._create_new_deployments(sm, group, new_deployments)
 
+        add_group = request_dict.get('deployments_from_group')
+        if add_group:
+            group_to_clone = sm.get(models.DeploymentGroup, add_group)
+            group.deployments += group_to_clone.deployments
+
     def _create_new_deployments(self, sm, group, new_deployments):
         """Create new deployments for the group based on new_deployments"""
         rm = get_resource_manager()
@@ -654,6 +660,13 @@ class DeploymentGroupsId(SecuredResource):
             )
             for dep in deployments:
                 group.deployments.remove(dep)
+
+        remove_group = request_dict.get('deployments_from_group')
+        if remove_group:
+            group_to_remove = sm.get(models.DeploymentGroup, remove_group)
+            for dep in group_to_remove.deployments:
+                if dep in group.deployments:
+                    group.deployments.remove(dep)
 
     @authorize('deployment_group_delete')
     def delete(self, group_id):


### PR DESCRIPTION
Add and remove deployments to a group, based on another group.

This gives us the "clone group" feature, because you can just create a
group, and set its deployments to ones defined by another group.

Removing isn't something that was asked for, but why not.