### PR TITLE
RD-1317 Labels for deployment-groups

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2314,7 +2314,7 @@ class ResourceManager(object):
         if not labels_list:
             return
 
-        current_time = utils.get_formatted_timestamp()
+        current_time = datetime.utcnow()
         for key, value in labels_list:
             new_label = {'key': key,
                          'value': value,
@@ -2324,6 +2324,8 @@ class ResourceManager(object):
                 new_label['deployment'] = resource
             elif labels_resource_model == models.BlueprintLabel:
                 new_label['blueprint'] = resource
+            elif labels_resource_model == models.DeploymentGroupLabel:
+                new_label['deployment_group'] = resource
 
             self.sm.put(labels_resource_model(**new_label))
 

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -560,7 +560,7 @@ class DeploymentGroupsId(SecuredResource):
         return get_storage_manager().get(models.DeploymentGroup, group_id)
 
     @authorize('deployment_group_create')
-    @rest_decorators.marshal_with(models.DeploymentGroup)
+    @rest_decorators.marshal_with(models.DeploymentGroup, force_get_data=True)
     def put(self, group_id):
         request_dict = rest_utils.get_json_and_verify_params({
             'description': {'optional': True},
@@ -598,7 +598,7 @@ class DeploymentGroupsId(SecuredResource):
         )
 
     @authorize('deployment_group_update')
-    @rest_decorators.marshal_with(models.DeploymentGroup)
+    @rest_decorators.marshal_with(models.DeploymentGroup, force_get_data=True)
     def patch(self, group_id):
         request_dict = rest_utils.get_json_and_verify_params({
             'description': {'optional': True},

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -676,7 +676,7 @@ class DeploymentGroupsId(SecuredResource):
         """Create new deployments for the group based on new_deployments"""
         rm = get_resource_manager()
         with sm.transaction():
-            group_labels = [{l.key: l.value} for l in group.labels]
+            group_labels = [{label.key: label.value} for label in group.labels]
             deployment_count = len(group.deployments)
             create_exec_group = models.ExecutionGroup(
                 id=str(uuid.uuid4()),

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -564,11 +564,12 @@ class DeploymentGroupsId(SecuredResource):
     def put(self, group_id):
         request_dict = rest_utils.get_json_and_verify_params({
             'description': {'optional': True},
-            'deployment_ids': {'optional': True},
-            'filter_id': {'optional': True},
+            'visibility': {'optional': True},
+            'labels': {'optional': True},
             'blueprint_id': {'optional': True},
             'default_inputs': {'optional': True},
-            'visibility': {'optional': True},
+            'filter_id': {'optional': True},
+            'deployment_ids': {'optional': True},
             'new_deployments': {'optional': True},
             'deployments_from_group': {'optional': True},
         })
@@ -630,6 +631,14 @@ class DeploymentGroupsId(SecuredResource):
         if request_dict.get('blueprint_id'):
             group.default_blueprint = sm.get(
                 models.Blueprint, request_dict['blueprint_id'])
+
+        if request_dict.get('labels'):
+            rm = get_resource_manager()
+            rm.update_resource_labels(
+                models.DeploymentGroupLabel,
+                group,
+                rest_utils.get_labels_list(request_dict['labels'])
+            )
 
     def _add_group_deployments(self, sm, group, request_dict):
         deployment_ids = request_dict.get('deployment_ids')

--- a/rest-service/manager_rest/storage/models.py
+++ b/rest-service/manager_rest/storage/models.py
@@ -65,4 +65,5 @@ from .resource_models import (
     ExecutionGroup,
     ExecutionSchedule,
     BlueprintLabel,
+    DeploymentGroupLabel,
 )

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -763,6 +763,23 @@ class BlueprintLabel(_Label):
             backref=db.backref('labels', cascade='all, delete-orphan'))
 
 
+class DeploymentGroupLabel(_Label):
+    __tablename__ = 'deployment_groups_labels'
+    __table_args__ = (
+        db.UniqueConstraint(
+            'key', 'value', '_labeled_model_fk'),
+    )
+    labeled_model = DeploymentGroup
+
+    _labeled_model_fk = foreign_key(DeploymentGroup._storage_id)
+
+    @declared_attr
+    def deployment_group(cls):
+        return db.relationship(
+            DeploymentGroup, lazy='joined',
+            backref=db.backref('labels', cascade='all, delete-orphan'))
+
+
 class _Filter(CreatedAtMixin, SQLResourceBase):
     __abstract__ = True
     _extra_fields = {'labels_filter_rules': flask_fields.Raw,

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -698,8 +698,16 @@ class DeploymentGroup(CreatedAtMixin, SQLResourceBase):
         fields['deployment_ids'] = flask_fields.List(
             flask_fields.String()
         )
+        fields['labels'] = flask_fields.List(
+            flask_fields.Nested(Label.resource_fields))
         fields['default_blueprint_id'] = flask_fields.String()
         return fields
+
+    def to_response(self, get_data=False, **kwargs):
+        response = super(DeploymentGroup, self).to_response()
+        if get_data:
+            response['labels'] = self.list_labels(self.labels)
+        return response
 
 
 class _Label(CreatedAtMixin, SQLModelBase):

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -401,7 +401,7 @@ class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
         assert set(group1.deployment_ids) == {'dep2'}
 
     def test_set_labels(self):
-        """Shrink a group providing filter_id"""
+        """Create a group with labels"""
         labels = [{'label1': 'value1'}]
         updated_labels = [{'label1': 'value2'}, {'label2': 'value3'}]
         group = self.client.deployment_groups.put(
@@ -416,7 +416,7 @@ class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
         self.assert_resource_labels(group.labels, updated_labels)
 
     def test_group_labels_for_deployments(self):
-        """Shrink a group providing filter_id"""
+        """Group labels are applied to the newly-created deployments"""
         group = self.client.deployment_groups.put(
             'group1',
             labels=[{'label1': 'value1'}, {'label2': 'value2'}],

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -422,13 +422,20 @@ class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
             labels=[{'label1': 'value1'}, {'label2': 'value2'}],
             blueprint_id='blueprint',
             new_deployments=[{
-                'labels': [{'label1': 'value1'}, {'label3': 'value3'}]
+                'labels': [{'label1': 'value1'}, {'label1': 'value2'},
+                           {'label3': 'value4'}]
             }]
         )
         dep_id = group.deployment_ids[0]
         dep = self.sm.get(models.Deployment, dep_id)
         self.create_deployment_environment(dep)
-        dep = self.sm.refresh(dep)
+        client_dep = self.client.deployments.get(dep_id)
+        self.assert_resource_labels(client_dep.labels, [
+            # labels from both the group, and the deployment
+            # (note that label1=value1 occurs in both places)
+            {'label1': 'value1'}, {'label1': 'value2'}, {'label2': 'value2'},
+            {'label3': 'value4'},
+        ])
 
 
 @mock.patch(

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -400,6 +400,36 @@ class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
         )
         assert set(group1.deployment_ids) == {'dep2'}
 
+    def test_set_labels(self):
+        """Shrink a group providing filter_id"""
+        labels = [{'label1': 'value1'}]
+        updated_labels = [{'label1': 'value2'}, {'label2': 'value3'}]
+        group = self.client.deployment_groups.put(
+            'group1',
+            labels=labels,
+        )
+        self.assert_resource_labels(group.labels, labels)
+        group = self.client.deployment_groups.put(
+            'group1',
+            labels=updated_labels,
+        )
+        self.assert_resource_labels(group.labels, updated_labels)
+
+    def test_group_labels_for_deployments(self):
+        """Shrink a group providing filter_id"""
+        group = self.client.deployment_groups.put(
+            'group1',
+            labels=[{'label1': 'value1'}, {'label2': 'value2'}],
+            blueprint_id='blueprint',
+            new_deployments=[{
+                'labels': [{'label1': 'value1'}, {'label3': 'value3'}]
+            }]
+        )
+        dep_id = group.deployment_ids[0]
+        dep = self.sm.get(models.Deployment, dep_id)
+        self.create_deployment_environment(dep)
+        dep = self.sm.refresh(dep)
+
 
 @mock.patch(
     'manager_rest.rest.resources_v3_1.executions.workflow_sendhandler',

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -164,7 +164,7 @@ class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
         assert len(deps) == 1
         create_exec_params = deps[0].create_execution.parameters
         assert create_exec_params['inputs'] == inputs
-        assert create_exec_params['labels'] == labels
+        assert create_exec_params['labels'] == [('label1', 'label-value')]
 
     def test_add_deployment_ids(self):
         self.client.deployment_groups.put('group1')

--- a/workflows/cloudify_system_workflows/deployment_environment.py
+++ b/workflows/cloudify_system_workflows/deployment_environment.py
@@ -76,7 +76,7 @@ def _join_groups(client, deployment_id, groups):
 
 
 def _get_deployment_labels(new_labels, plan_labels):
-    labels = {label.popitem() for label in new_labels}
+    labels = {tuple(label) for label in new_labels}
     for name, label_spec in plan_labels.items():
         labels |= {(name, value) for value in label_spec.get('values', [])}
     return [{k: v} for k, v in labels]

--- a/workflows/cloudify_system_workflows/deployment_environment.py
+++ b/workflows/cloudify_system_workflows/deployment_environment.py
@@ -74,8 +74,9 @@ def _join_groups(client, deployment_id, groups):
             client.deployment_groups.put(
                 group_name, deployment_ids=[deployment_id])
 
+
 def _get_deployment_labels(new_labels, plan_labels):
-    labels = {l.popitem() for l in new_labels}
+    labels = {label.popitem() for label in new_labels}
     for name, label_spec in plan_labels.items():
         labels |= {(name, value) for value in label_spec.get('values', [])}
     return [{k: v} for k, v in labels]

--- a/workflows/cloudify_system_workflows/deployment_environment.py
+++ b/workflows/cloudify_system_workflows/deployment_environment.py
@@ -74,6 +74,12 @@ def _join_groups(client, deployment_id, groups):
             client.deployment_groups.put(
                 group_name, deployment_ids=[deployment_id])
 
+def _get_deployment_labels(new_labels, plan_labels):
+    labels = {l.popitem() for l in new_labels}
+    for name, label_spec in plan_labels.items():
+        labels |= {(name, value) for value in label_spec.get('values', [])}
+    return [{k: v} for k, v in labels]
+
 
 @workflow
 def create(ctx, labels=None, inputs=None, skip_plugins_validation=False, **_):
@@ -88,12 +94,12 @@ def create(ctx, labels=None, inputs=None, skip_plugins_validation=False, **_):
     client.nodes.create_many(ctx.deployment.id, nodes)
     ctx.logger.info('Creating %d node-instances', len(node_instances))
     client.node_instances.create_many(ctx.deployment.id, node_instances)
+
+    labels_to_create = _get_deployment_labels(
+        labels or [],
+        deployment_plan.get('labels', {}))
+
     ctx.logger.info('Setting deployment attributes')
-    labels_to_create = labels or []
-    labels_to_create += [
-        {k: v} for k, labels_def in deployment_plan.get('labels', {}).items()
-        for v in labels_def.get('values', [])
-    ]
     client.deployments.set_attributes(
         ctx.deployment.id,
         description=deployment_plan['description'],


### PR DESCRIPTION
Labels for the groups: they are automatically applied to deployments
created by the group.

In the future, we'll also extend it to all deployments in the group, not just
_created by_ the group.