### PR TITLE
RD-1416 group assoc proxies for deps & execs

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -430,6 +430,7 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
     @classproperty
     def response_fields(cls):
         fields = super(Deployment, cls).response_fields
+        fields.pop('deployment_group_id')
         fields['workflows'] = flask_fields.List(
             flask_fields.Nested(Workflow.resource_fields)
         )
@@ -730,6 +731,7 @@ class Execution(CreatedAtMixin, SQLResourceBase):
     def resource_fields(cls):
         fields = super(Execution, cls).resource_fields
         fields.pop('token')
+        fields.pop('execution_group_id')
         return fields
 
     @validates('deployment')

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1244,6 +1244,7 @@ class DeploymentUpdate(CreatedAtMixin, SQLResourceBase):
     @classproperty
     def response_fields(cls):
         fields = super(DeploymentUpdate, cls).response_fields
+        fields.pop('deployment_update_deployment')
         fields['steps'] = flask_fields.List(
             flask_fields.Nested(DeploymentUpdateStep.response_fields)
         )

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -394,6 +394,8 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
                                        initially='DEFERRED',
                                        use_alter=True)
 
+    deployment_group_id = association_proxy('deployment_groups', 'id')
+
     @classproperty
     def labels_model(cls):
         return DeploymentLabel
@@ -692,6 +694,8 @@ class Execution(CreatedAtMixin, SQLResourceBase):
 
     total_operations = db.Column(db.Integer, nullable=True)
     finished_operations = db.Column(db.Integer, nullable=True)
+
+    execution_group_id = association_proxy('execution_groups', 'id')
 
     @declared_attr
     def deployment(cls):


### PR DESCRIPTION
Just declaring an association proxy allows using group IDs in filters,
eg. in the summary request.