### PR TITLE
RD-1487 Handle statuses propagation and delete deployment

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -133,6 +133,10 @@ class ResourceManager(object):
         dep.latest_execution = latest_execution
         dep.deployment_status = dep.evaluate_deployment_status()
         self.sm.update(dep)
+        if dep.deployment_parents:
+            graph = RecursiveDeploymentLabelsDependencies(self.sm)
+            graph.create_dependencies_graph()
+            graph.propagate_deployment_statuses(dep.id)
 
     def update_execution_status(self, execution_id, status, error):
         execution = self.sm.get(models.Execution, execution_id)
@@ -661,6 +665,28 @@ class ResourceManager(object):
 
         return self.sm.delete(blueprint)
 
+    def retrieve_and_display_dependencies(self, deployment):
+        dep_graph = RecursiveDeploymentDependencies(self.sm)
+        excluded_ids = self._excluded_component_creator_ids(deployment)
+        deployment_dependencies = \
+            dep_graph.retrieve_and_display_dependencies(
+                deployment.id,
+                excluded_component_creator_ids=excluded_ids)
+
+        if deployment.has_sub_deployments:
+            dep_graph = RecursiveDeploymentLabelsDependencies(self.sm)
+            labels_dependencies = \
+                dep_graph.retrieve_and_display_dependencies(
+                    deployment
+                )
+            if deployment_dependencies:
+                deployment_dependencies = deployment_dependencies\
+                                          + labels_dependencies
+            else:
+                deployment_dependencies = labels_dependencies
+
+        return deployment_dependencies
+
     def check_deployment_delete(self, deployment, force=False):
         """Check that deployment can be deleted"""
         executions = self.sm.list(models.Execution, filters={
@@ -669,15 +695,8 @@ class ResourceManager(object):
                 ExecutionState.ACTIVE_STATES + ExecutionState.QUEUED_STATE
             )
         }, get_all_results=True)
-
-        # Verify deleting the deployment won't affect dependent deployments
-        dep_graph = RecursiveDeploymentDependencies(self.sm)
-        excluded_ids = self._excluded_component_creator_ids(deployment)
-        deployment_dependencies = \
-            dep_graph.retrieve_and_display_dependencies(
-                deployment.id,
-                excluded_component_creator_ids=excluded_ids)
-
+        deployment_dependencies = self.retrieve_and_display_dependencies(
+            deployment)
         if deployment_dependencies:
             if force:
                 current_app.logger.warning(
@@ -691,7 +710,6 @@ class ResourceManager(object):
                     f"existing installations depend on it:\n"
                     f"{deployment_dependencies}"
                 )
-
         if executions:
             running_ids = ','.join(
                 execution.id for execution in executions
@@ -732,6 +750,21 @@ class ResourceManager(object):
         if external_targets:
             self._clean_dependencies_from_external_targets(
                 deployment, external_targets)
+
+        parents = deployment.deployment_parents
+        if parents:
+            dep_graph = RecursiveDeploymentLabelsDependencies(self.sm)
+            dep_graph.create_dependencies_graph()
+            dep_graph.decrease_deployment_counts_in_graph(parents, deployment)
+            for _parent in parents:
+                dep_graph.remove_dependency_from_graph(deployment.id, _parent)
+                self._remove_deployment_label_dependency(
+                    deployment,
+                    self.sm.get(
+                        models.Deployment, _parent
+                    )
+                )
+                dep_graph.propagate_deployment_statuses(_parent)
 
         deployment_folder = os.path.join(
             config.instance.file_server_root,
@@ -1339,7 +1372,8 @@ class ResourceManager(object):
                           visibility,
                           skip_plugins_validation=False,
                           site=None,
-                          runtime_only_evaluation=False):
+                          runtime_only_evaluation=False,
+                          labels=None,):
         verify_blueprint_uploaded_state(blueprint)
         plan = blueprint.plan
         visibility = self.get_resource_visibility(models.Deployment,
@@ -1352,7 +1386,11 @@ class ResourceManager(object):
                 f"Can't create global deployment {deployment_id} because "
                 f"blueprint {blueprint.id} is not global"
             )
-
+        parents_labels = self.get_deployment_parents_from_labels(
+            labels
+        )
+        if parents_labels:
+            self.verify_deployment_parent_labels(parents_labels, deployment_id)
         #  validate plugins exists on manager when
         #  skip_plugins_validation is False
         if not skip_plugins_validation:
@@ -1367,7 +1405,6 @@ class ResourceManager(object):
                 plan)
             for plugin in host_agent_plugins:
                 self.validate_plugin_is_installed(plugin)
-
         now = datetime.utcnow()
         new_deployment = models.Deployment(
             id=deployment_id,
@@ -1393,9 +1430,10 @@ class ResourceManager(object):
     @staticmethod
     def get_deployment_parents_from_labels(labels):
         parents = []
-        for label, value in labels:
-            if label == 'csys-obj-parent':
-                parents.append(value)
+        labels = labels or []
+        for label_key, label_value in labels:
+            if label_key == 'csys-obj-parent':
+                parents.append(label_value)
         return parents
 
     def get_deployment_object_types_from_labels(self, deployment, labels):
@@ -1412,7 +1450,7 @@ class ResourceManager(object):
                 delete_types.add(label.value.lower())
         return created_types, delete_types
 
-    def verify_deployment_parent_labels(self, parents, deployment_id):
+    def get_missing_deployment_parents(self, parents):
         if not parents:
             return
         result = self.sm.list(
@@ -1422,6 +1460,10 @@ class ResourceManager(object):
         ).items
         _existing_parents = [_parent[0] for _parent in result]
         missing_parents = set(parents) - set(_existing_parents)
+        return missing_parents
+
+    def verify_deployment_parent_labels(self, parents, deployment_id):
+        missing_parents = self.get_missing_deployment_parents(parents)
         if missing_parents:
             raise manager_exceptions.DeploymentParentNotFound(
                 'Deployment {0}: is referencing deployments'
@@ -1468,7 +1510,7 @@ class ResourceManager(object):
                                             dep_graph,
                                             source,
                                             target_id):
-        dep_graph.decrease_deployment_counts_in_graph(target_id, source)
+        dep_graph.decrease_deployment_counts_in_graph([target_id], source)
         dep_graph.remove_dependency_from_graph(source.id, target_id)
         self._remove_deployment_label_dependency(
             source,
@@ -2137,15 +2179,11 @@ class ResourceManager(object):
                                           workflow_id, deployment, force):
         if workflow_id not in ['stop', 'uninstall', 'update']:
             return
-        dep_graph = RecursiveDeploymentDependencies(self.sm)
-
         # if we're in the middle of an execution initiated by the component
         # creator, we'd like to drop the component dependency from the list
-        excluded_ids = self._excluded_component_creator_ids(deployment)
-        deployment_dependencies = \
-            dep_graph.retrieve_and_display_dependencies(
-                deployment.id,
-                excluded_component_creator_ids=excluded_ids)
+        deployment_dependencies = self.retrieve_and_display_dependencies(
+            deployment
+        )
         if not deployment_dependencies:
             return
         if force:

--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -41,7 +41,8 @@ from manager_rest.rest.rest_utils import (get_labels_from_plan,
                                           get_args_and_verify_arguments)
 from manager_rest.manager_exceptions import (ConflictError,
                                              IllegalActionError,
-                                             BadParametersError)
+                                             BadParametersError,
+                                             DeploymentParentNotFound,)
 from manager_rest import config
 from manager_rest.constants import FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER
 
@@ -94,7 +95,6 @@ class BlueprintsId(resources_v2.BlueprintsId):
             valid_values=VisibilityState.STATES
         )
         labels = self._get_labels_from_args(args)
-
         # Fail fast if trying to upload a duplicate blueprint.
         # Allow overriding an existing blueprint which failed to upload
         current_tenant = request.headers.get('tenant')
@@ -197,6 +197,7 @@ class BlueprintsId(resources_v2.BlueprintsId):
                 "Unknown parameters: {}".format(','.join(invalid_params))
             )
         sm = get_storage_manager()
+        rm = get_resource_manager()
         blueprint = sm.get(models.Blueprint, blueprint_id)
 
         # if finished blueprint validation - cleanup DB entry
@@ -230,6 +231,23 @@ class BlueprintsId(resources_v2.BlueprintsId):
             blueprint.main_file_name = request_dict['main_file_name']
         provided_labels = request_dict.get('labels')
 
+        if request_dict.get('plan'):
+            dsl_labels = request_dict['plan'].get('labels', {})
+            csys_obj_parents = dsl_labels.get('csys-obj-parent')
+            if csys_obj_parents:
+                dep_parents = csys_obj_parents['values']
+                missing_parents = rm.get_missing_deployment_parents(
+                    dep_parents
+                )
+                if missing_parents:
+                    raise DeploymentParentNotFound(
+                        'Blueprint {0}: is referencing deployments'
+                        ' using label `csys-obj-parent` that does not exist, '
+                        'make sure that deployment(s) {1} exist before '
+                        'creating blueprint'.format(
+                            blueprint.id, ','.join(missing_parents)
+                        )
+                    )
         # set blueprint state
         state = request_dict.get('state')
         if state:

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -41,6 +41,7 @@ from manager_rest.manager_exceptions import (
 from manager_rest.resource_manager import get_resource_manager
 from manager_rest.maintenance import is_bypass_maintenance_mode
 from manager_rest.dsl_functions import evaluate_deployment_capabilities
+
 from manager_rest.rest.filters_utils import get_filter_rules_from_filter_id
 from manager_rest.rest import (
     rest_utils,
@@ -174,6 +175,8 @@ class DeploymentsId(resources_v1.DeploymentsId):
             optional=True,
             valid_values=VisibilityState.STATES
         )
+        labels = rest_utils.get_labels_list(request_dict.get('labels', []))
+        inputs = request_dict.get('inputs', {})
         skip_plugins_validation = self.get_skip_plugin_validation_flag(
             request_dict)
         rm = get_resource_manager()
@@ -181,7 +184,6 @@ class DeploymentsId(resources_v1.DeploymentsId):
         blueprint = sm.get(models.Blueprint, blueprint_id)
         site_name = _get_site_name(request_dict)
         site = sm.get(models.Site, site_name) if site_name else None
-        labels = rest_utils.get_labels_list(request_dict.get('labels', []))
         rm.cleanup_failed_deployment(deployment_id)
         deployment = rm.create_deployment(
             blueprint,
@@ -192,10 +194,11 @@ class DeploymentsId(resources_v1.DeploymentsId):
             site=site,
             runtime_only_evaluation=request_dict.get(
                 'runtime_only_evaluation', False),
+            labels=labels,
         )
         try:
             rm.execute_workflow(deployment.make_create_environment_execution(
-                inputs=request_dict.get('inputs', {}),
+                inputs=inputs,
                 labels=labels,
                 skip_plugins_validation=skip_plugins_validation,
 

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -642,10 +642,6 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
             v = queue.pop()
             if v not in inv_graph:
                 continue
-            if not visited[v]:
-                visited[v] = True
-            else:
-                continue
             dependencies = self.sm.list(
                 models.DeploymentLabelsDependencies,
                 filters={'source_deployment_id': v})
@@ -826,10 +822,6 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
         while queue:
             v = queue.pop()
             if v not in self.graph:
-                continue
-            if not visited[v]:
-                visited[v] = True
-            else:
                 continue
             from_dependencies = self.sm.list(
                 models.DeploymentLabelsDependencies,

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -670,6 +670,10 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
             return None
         return self.latest_execution.total_operations
 
+    @property
+    def has_sub_deployments(self):
+        return self.sub_services_count or self.sub_environments_count
+
 
 class DeploymentGroup(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'deployment_groups'
@@ -1793,8 +1797,10 @@ class BaseDeploymentDependencies(CreatedAtMixin, SQLResourceBase):
             cls,
             Deployment,
             cls._source_deployment,
-            backref=db.backref(cls._source_backref_name,
-                               cascade=cls._source_cascade)
+            backref=db.backref(
+                cls._source_backref_name,
+                cascade=cls._source_cascade
+            )
         )
 
     @declared_attr
@@ -1803,8 +1809,11 @@ class BaseDeploymentDependencies(CreatedAtMixin, SQLResourceBase):
             cls,
             Deployment,
             cls._target_deployment,
-            backref=db.backref(cls._target_backref_name),
-            cascade=cls._target_cascade)
+            backref=db.backref(
+                cls._target_backref_name,
+                cascade=cls._target_cascade
+            )
+        )
 
     source_deployment_id = association_proxy('source_deployment', 'id')
     target_deployment_id = association_proxy('target_deployment', 'id')

--- a/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
@@ -2,6 +2,7 @@
 from mock import patch
 
 from cloudify_rest_client.exceptions import CloudifyClientError
+from cloudify.models_states import DeploymentState
 
 from manager_rest.rest.rest_utils import RecursiveDeploymentLabelsDependencies
 from manager_rest.test import base_test
@@ -83,6 +84,22 @@ class DeploymentLabelsDependenciesTest(BaseServerTestCase):
         deployment = self.client.deployments.get('parent')
         self.assertEqual(deployment.sub_services_count, 1)
         self.assertEqual(deployment.sub_environments_count, 0)
+
+    def test_upload_blueprint_with_invalid_parent_id_on_dsl(self):
+        with self.assertRaisesRegex(
+                CloudifyClientError,
+                'using label `csys-obj-parent` that does not exist'):
+            self.put_blueprint(
+                blueprint_id='bp1',
+                blueprint_file_name='blueprint_with_invalid_parent_labels.yaml'
+            )
+
+    def test_upload_blueprint_with_valid_parent_id_on_dsl(self):
+        self.put_deployment('valid-id')
+        self.put_blueprint(
+            blueprint_id='bp1',
+            blueprint_file_name='blueprint_with_valid_parent_labels.yaml'
+        )
 
     def test_deployment_with_multiple_parent_labels(self):
         self.put_deployment(deployment_id='parent_1',
@@ -304,6 +321,123 @@ class DeploymentLabelsDependenciesTest(BaseServerTestCase):
         self.assertEqual(deployment_1.sub_environments_count, 1)
         self.assertEqual(deployment_1.sub_environments_count, 1)
 
+    def test_detach_all_services_from_deployment(self):
+        self.put_deployment(
+            deployment_id='env',
+            blueprint_id='env'
+        )
+        self._create_deployment_objects('env', 'service', 2)
+        self._create_deployment_objects('env', 'environment', 2)
+
+        deployment = self.client.deployments.get('env')
+        self.assertEqual(deployment.sub_services_count, 2)
+        self.assertEqual(deployment.sub_environments_count, 2)
+
+        self.client.deployments.update_labels(
+            'service_1_env',
+            [
+                {
+                    'csys-obj-type': 'service'
+                },
+
+            ]
+        )
+        self.client.deployments.update_labels(
+            'service_2_env',
+            [
+                {
+                    'csys-obj-type': 'service'
+                },
+
+            ]
+        )
+
+        deployment = self.client.deployments.get('env')
+        self.assertEqual(deployment.sub_services_count, 0)
+        self.assertEqual(deployment.sub_environments_count, 2)
+
+    def test_detach_all_environments_from_deployment(self):
+        self.put_deployment(
+            deployment_id='env',
+            blueprint_id='env'
+        )
+        self._create_deployment_objects('env', 'service', 2)
+        self._create_deployment_objects('env', 'environment', 2)
+
+        deployment = self.client.deployments.get('env')
+        self.assertEqual(deployment.sub_services_count, 2)
+        self.assertEqual(deployment.sub_environments_count, 2)
+
+        self.client.deployments.update_labels(
+            'environment_1_env',
+            [
+                {
+                    'csys-obj-type': 'environment'
+                }
+            ]
+        )
+        self.client.deployments.update_labels(
+            'environment_2_env',
+            [
+                {
+                    'csys-obj-type': 'environment'
+                }
+            ]
+        )
+
+        deployment = self.client.deployments.get('env')
+        self.assertEqual(deployment.sub_services_count, 2)
+        self.assertEqual(deployment.sub_environments_count, 0)
+
+    def test_deployment_statuses_after_creation_without_sub_deployments(self):
+        self.put_deployment('dep1')
+        deployment = self.client.deployments.get('dep1')
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.REQUIRE_ATTENTION
+        )
+        self.assertIsNone(deployment.sub_services_status)
+        self.assertIsNone(deployment.sub_environments_status)
+
+    def test_deployment_statuses_after_creation_with_sub_deployments(self):
+        self.put_deployment('parent')
+        self._create_deployment_objects('parent', 'environment', 2)
+        self._create_deployment_objects('parent', 'service', 2)
+        deployment = self.client.deployments.get('parent')
+        self.assertEqual(
+            deployment.deployment_status,
+            DeploymentState.REQUIRE_ATTENTION
+        )
+        self.assertEqual(
+            deployment.sub_environments_status,
+            DeploymentState.REQUIRE_ATTENTION
+        )
+        self.assertEqual(
+            deployment.sub_services_status,
+            DeploymentState.REQUIRE_ATTENTION
+        )
+
+    def test_delete_deployment_with_sub_deployments(self):
+        self.put_deployment('parent')
+        self._create_deployment_objects('parent', 'service', 2)
+        with self.assertRaisesRegex(
+                CloudifyClientError, 'Can\'t delete deployment'):
+            self.client.deployments.delete('parent')
+
+    def test_stop_deployment_with_sub_deployments(self):
+        self.put_deployment('parent')
+        self._create_deployment_objects('parent', 'service', 2)
+        with self.assertRaisesRegex(
+                CloudifyClientError, 'Can\'t execute workflow `stop`'):
+            self.client.executions.start('parent', 'stop')
+
+    def test_uninstall_deployment_with_sub_deployments(self):
+        self.put_deployment('parent')
+        self._create_deployment_objects('parent', 'service', 2)
+        with self.assertRaisesRegex(
+                CloudifyClientError, 'Can\'t execute workflow `uninstall`'):
+            self.client.executions.start('parent', 'uninstall')
+
     def test_create_deployment_labels_dependencies_graph(self):
         self._populate_deployment_labels_dependencies()
         dep_graph = RecursiveDeploymentLabelsDependencies(self.sm)
@@ -372,7 +506,7 @@ class DeploymentLabelsDependenciesTest(BaseServerTestCase):
         )
         dep_graph = RecursiveDeploymentLabelsDependencies(self.sm)
         dep_graph.create_dependencies_graph()
-        targets = dep_graph.find_recursive_deployments('dep_0')
+        targets = dep_graph.find_recursive_deployments(['dep_0'])
         self.assertEqual(len(targets), 5)
         self.assertIn('dep_1', targets)
         self.assertIn('dep_11', targets)

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_invalid_parent_labels.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_invalid_parent_labels.yaml
@@ -1,0 +1,9 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - cloudify/types/types.yaml
+
+labels:
+  csys-obj-parent:
+    values:
+      - nonexist_id

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_valid_parent_labels.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_valid_parent_labels.yaml
@@ -1,0 +1,9 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - cloudify/types/types.yaml
+
+labels:
+  csys-obj-parent:
+    values:
+      - valid-id


### PR DESCRIPTION
This PR created in order to handle the following:
1. Handle statuses propagation to upper deployments and update the overall deployment status based on sub-services and sub-environments
2. Add validation on the blueprint creation and deployment when reference invalid parent inside DSL
3. Add validation on delete/stop/uninstall/update when deployments has  sub-services and sub-environments
4. Update counter for deployment when one its sub-services and sub-environments get deleted