### PR TITLE
RD-1534 Handle labels in deployment update

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2184,21 +2184,25 @@ class ResourceManager(object):
         If a new label already exists, it won't be created again.
         If an existing label is not in the new labels list, it will be deleted.
         """
+        labels_to_create = self.get_labels_to_create(resource, new_labels)
 
         new_labels_set = set(new_labels)
-        existing_labels = resource.labels
-        existing_labels_tup = set(
-            (label.key, label.value) for label in existing_labels)
-
-        labels_to_create = new_labels_set - existing_labels_tup
-
-        for label in existing_labels:
+        for label in resource.labels:
             if (label.key, label.value) not in new_labels_set:
                 self.sm.delete(label)
 
         self.create_resource_labels(labels_resource_model,
                                     resource,
                                     labels_to_create)
+
+    @staticmethod
+    def get_labels_to_create(resource, new_labels):
+        new_labels_set = set(new_labels)
+        existing_labels = resource.labels
+        existing_labels_tup = set(
+            (label.key, label.value) for label in existing_labels)
+
+        return new_labels_set - existing_labels_tup
 
     def create_resource_labels(self,
                                labels_resource_model,

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1241,6 +1241,10 @@ class DeploymentUpdate(CreatedAtMixin, SQLResourceBase):
     def schedules_to_delete(cls):
         return None
 
+    @declared_attr
+    def labels_to_create(cls):
+        return None
+
     @classproperty
     def response_fields(cls):
         fields = super(DeploymentUpdate, cls).response_fields
@@ -1268,6 +1272,7 @@ class DeploymentUpdate(CreatedAtMixin, SQLResourceBase):
         fields['schedules_to_create'] = flask_fields.List(
             flask_fields.Nested(created_scheduled_fields))
         fields['schedules_to_delete'] = flask_fields.List(flask_fields.String)
+        fields['labels_to_create'] = flask_fields.List(flask_fields.Raw)
         return fields
 
     def to_response(self, **kwargs):
@@ -1277,6 +1282,7 @@ class DeploymentUpdate(CreatedAtMixin, SQLResourceBase):
         dep_update_dict['recursive_dependencies'] = self.recursive_dependencies
         dep_update_dict['schedules_to_create'] = self.schedules_to_create
         dep_update_dict['schedules_to_delete'] = self.schedules_to_delete
+        dep_update_dict['labels_to_create'] = self.labels_to_create
         return dep_update_dict
 
     def set_deployment(self, deployment):

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -975,11 +975,20 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
 
     @attr(client_min_version=3.1,
           client_max_version=base_test.LATEST_API_VERSION)
-    def test_update_empty_deployments_labels(self):
+    def test_remove_deployments_labels(self):
         deployment = self.put_deployment_with_labels(self.LABELS)
         self.assert_resource_labels(deployment.labels, self.LABELS)
         updated_dep = self.client.deployments.update_labels(deployment.id, [])
         self.assertEmpty(updated_dep.labels)
+
+    @attr(client_min_version=3.1,
+          client_max_version=base_test.LATEST_API_VERSION)
+    def test_update_empty_deployments_labels(self):
+        _, _, _, deployment = self.put_deployment()
+        self.assertEqual(deployment.labels, [])
+        updated_dep = self.client.deployments.update_labels(deployment.id,
+                                                            self.LABELS)
+        self.assert_resource_labels(updated_dep.labels, self.LABELS)
 
     @attr(client_min_version=3.1,
           client_max_version=base_test.LATEST_API_VERSION)

--- a/tests/integration_tests/resources/dsl/updated_blueprint_with_labels.yaml
+++ b/tests/integration_tests/resources/dsl/updated_blueprint_with_labels.yaml
@@ -6,15 +6,20 @@ imports:
 inputs:
   label_value:
     default: key2_val2
+  updated_label_value:
+    default: updated_key_val2
 
 blueprint_labels:
   bp_key1:
     values:
-      - bp_key1_val1
+      - updated_bp_key1_val1
   bp_key2:
     values:
       - bp_key2_val1
-      - bp_key2_val2
+      - updated_bp_key2_val2
+  updated_bp_key:
+    values:
+      - updated_bp_key_val1
 
 labels:
   key1:
@@ -22,5 +27,9 @@ labels:
       - key1_val1
   key2:
     values:
-      - key2_val1
+      - updated_key2_val1
       - { get_input: label_value }
+  updated_key:
+    values:
+      - updated_key_val1
+      - { get_input: updated_label_value }

--- a/tests/integration_tests/tests/agentless_tests/test_labels.py
+++ b/tests/integration_tests/tests/agentless_tests/test_labels.py
@@ -46,6 +46,34 @@ class DeploymentsLabelsTest(AgentlessTestCase):
 
     def test_upload_blueprint_with_labels(self):
         new_labels = [{'key1': 'key1_val1'}, {'key3': 'val3'}]
+        deployment = self._create_deployment_from_blueprint_with_labels(
+            new_labels)
+        labels_list = [{'key1': 'key1_val1'}, {'key2': 'key2_val1'},
+                       {'key2': 'key2_val2'}, {'key3': 'val3'}]
+        self.assert_labels(deployment.labels, labels_list)
+
+    def test_deployment_update_with_labels(self):
+        deployment = self._create_deployment_from_blueprint_with_labels()
+        new_blueprint_id = 'update_labels'
+        dsl_path = utils.get_resource('dsl/updated_blueprint_with_labels.yaml')
+        blueprint = self.client.blueprints.upload(dsl_path, new_blueprint_id)
+        self.client.deployment_updates.update_with_existing_blueprint(
+            deployment.id, new_blueprint_id)
+        updated_deployment = self.client.deployments.get(deployment.id)
+        deployment_labels_list = [{'key1': 'key1_val1'},
+                                  {'key2': 'key2_val1'},
+                                  {'key2': 'key2_val2'},
+                                  {'key2': 'updated_key2_val1'},
+                                  {'updated_key': 'updated_key_val1'},
+                                  {'updated_key': 'updated_key_val2'}]
+        blueprint_labels_list = [{'bp_key1': 'updated_bp_key1_val1'},
+                                 {'bp_key2': 'bp_key2_val1'},
+                                 {'bp_key2': 'updated_bp_key2_val2'},
+                                 {'updated_bp_key': 'updated_bp_key_val1'}]
+        self.assert_labels(blueprint['labels'], blueprint_labels_list)
+        self.assert_labels(updated_deployment.labels, deployment_labels_list)
+
+    def _create_deployment_from_blueprint_with_labels(self, new_labels=None):
         dsl_path = utils.get_resource('dsl/blueprint_with_labels.yaml')
         blueprint_id = deployment_id = 'd{0}'.format(uuid.uuid4())
         self.client.blueprints.upload(dsl_path, blueprint_id)
@@ -55,9 +83,7 @@ class DeploymentsLabelsTest(AgentlessTestCase):
         utils.wait_for_deployment_creation_to_complete(self.env.container_id,
                                                        deployment_id,
                                                        self.client)
-        labels_list = [{'key1': 'key1_val1'}, {'key2': 'key2_val1'},
-                       {'key2': 'key2_val2'}, {'key3': 'val3'}]
-        self.assert_labels(deployment.labels, labels_list)
+        return deployment
 
     def _assert_keys_and_values(self, client, keys_values_dict):
         keys_list = client.deployments_labels.list_keys()


### PR DESCRIPTION
During the deployment update, any label specified in the labels section of the new blueprint should be added to the deployment. No labels are deleted in the process. 

Associated PRs: 
https://github.com/cloudify-cosmo/cloudify-common/pull/732
https://github.com/cloudify-cosmo/cloudify-cli/pull/1255