### PR TITLE
RD-1832 Fix join failure in filters

### DIFF
--- a/rest-service/manager_rest/storage/filters.py
+++ b/rest-service/manager_rest/storage/filters.py
@@ -17,7 +17,10 @@ def add_filter_rules_to_query(query, model_class, filter_rules):
         filter_rule_type = filter_rule['type']
         if filter_rule_type == FilterRuleType.LABEL:
             if not labels_join_added:
-                query = query.join(labels_model).distinct()
+                query = query.join(
+                    labels_model,
+                    labels_model._labeled_model_fk == model_class._storage_id)\
+                    .distinct()
                 labels_join_added = True
             query = add_labels_filter_to_query(query,
                                                labels_model,

--- a/rest-service/manager_rest/test/endpoints/test_filters.py
+++ b/rest-service/manager_rest/test/endpoints/test_filters.py
@@ -142,7 +142,7 @@ class BlueprintsFiltersFunctionalityCase(FiltersFunctionalityBaseCase):
     def setUp(self):
         super().setUp(models.Blueprint)
 
-    def test_labels_filters_applied(self):
+    def test_filters_applied(self):
         bp_1 = self.put_blueprint_with_labels(self.LABELS, blueprint_id='bp_1')
         bp_2 = self.put_blueprint_with_labels(self.LABELS_2,
                                               blueprint_id='bp_2')
@@ -156,7 +156,7 @@ class DeploymentFiltersFunctionalityCase(FiltersFunctionalityBaseCase):
     def setUp(self):
         super().setUp(models.Deployment)
 
-    def test_labels_filters_applied(self):
+    def test_filters_applied(self):
         self.client.sites.create('site_1')
         self.client.sites.create('other_site')
         dep1 = self.put_deployment_with_labels(self.LABELS,
@@ -171,12 +171,12 @@ class DeploymentFiltersFunctionalityCase(FiltersFunctionalityBaseCase):
              ('c', ['y', 'z'], LabelsOperator.NOT_ANY_OF, 'label')], {dep1.id})
 
         self.assert_filters_applied(
-            [('a', ['b'], LabelsOperator.ANY_OF, 'label'),
-             ('blueprint_id', ['res_1', 'res_2'], AttrsOperator.ANY_OF,
+            [('blueprint_id', ['res_1', 'res_2'], AttrsOperator.ANY_OF,
               'attribute'),
-             ('blueprint_id', ['not_bp'], AttrsOperator.NOT_ANY_OF,
+             ('created_by', ['not_user'], AttrsOperator.NOT_ANY_OF,
               'attribute'),
-             ('site_name', ['site'], AttrsOperator.CONTAINS, 'attribute')],
+             ('site_name', ['site'], AttrsOperator.CONTAINS, 'attribute'),
+             ('a', ['b'], LabelsOperator.ANY_OF, 'label')],
             {dep1.id, dep2.id},
         )
 


### PR DESCRIPTION
When trying to filter a list of resources first by a `created_by` filter rule and then by labels' filters, the process fails. This happens because SQLAlchemy can't determine how to add the labels' join. The error is e.g.: 
```
sqlalchemy.exc.AmbiguousForeignKeysError: Can't determine join between 'Join object on Join object on
deployments(139701398608192) and users(139701400069960)(139701286089224) and sites(139701398997368)' and
deployments_labels'; tables have more than one foreign key constraint relationship between them. 
Please specify the 'onclause' of this join explicitly.
```

To solve this, we do what the error message suggests, specify the `oncluase` of the labels' join explicitly. 
We also modify a unit test to test this use case.