### PR TITLE
Execution: move execution_group_id to resource_fields

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -903,6 +903,11 @@ class Execution(CreatedAtMixin, SQLResourceBase):
     def resource_fields(cls):
         fields = super(Execution, cls).resource_fields
         fields.pop('token')
+        return fields
+
+    @classproperty
+    def response_fields(cls):
+        fields = super(Execution, cls).response_fields
         fields.pop('execution_group_id')
         return fields
 


### PR DESCRIPTION
It needs to _stay_ in resource_fields so that filters can
be applied to that.
But it needs to not be in response_fields, so that it's not part
of the response.