### PR TITLE
inte-tests: use cloudify_internal_ca_cert.pem

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -144,7 +144,7 @@ def rest_client(manager_container):
     with tempfile.NamedTemporaryFile('w') as cert_file:
         docker.copy_file_from_manager(
             manager_container.container_id,
-            '/etc/cloudify/ssl/cloudify_external_cert.pem',
+            '/etc/cloudify/ssl/cloudify_internal_ca_cert.pem',
             cert_file.name)
         client = test_utils.create_rest_client(
             host=manager_container.container_ip,


### PR DESCRIPTION
we've made the external cert be signed (by default) by the "main"
CA (which is the internal CA), as opposed to self-signed.

This was because this was more friendly to the user, because now
they can just provide a single CA cert+key and have both certs signed
by that.

That change was in:
https://github.com/cloudify-cosmo/cloudify-manager-install/pull/1105/commits/b699a4edebb7bd8beac7b4064c707e4f758615af