### PR TITLE
RD-1484 Add automatic label to children when using csys-environment input

### DIFF
--- a/rest-service/manager_rest/deployment_update/manager.py
+++ b/rest-service/manager_rest/deployment_update/manager.py
@@ -192,6 +192,90 @@ class DeploymentUpdateManager(object):
                                                step.entity_id,
                                                step.topology_order)
 
+    def delete_input_label_after_deployment_update(self,
+                                                   rm,
+                                                   dep_graph,
+                                                   dep,
+                                                   old_csys_environment):
+        rm.delete_deployment_from_labels_graph(
+            dep_graph, dep, old_csys_environment
+        )
+        dep_graph.propagate_deployment_statuses(
+            old_csys_environment
+        )
+        self._delete_single_label_from_deployment(
+            'csys-obj-parent',
+            old_csys_environment,
+            dep
+        )
+
+    @staticmethod
+    def add_input_label_after_deployment_update(rm,
+                                                dep_graph,
+                                                dep,
+                                                new_csys_environment):
+        labels_to_add = rm.get_deployment_parents_from_inputs(
+            new_csys_environment
+        )
+        if labels_to_add:
+            rm.create_resource_labels(
+                models.DeploymentLabel,
+                dep,
+                labels_to_add
+            )
+            rm.add_deployment_to_labels_graph(
+                dep_graph,
+                dep,
+                new_csys_environment
+            )
+            dep_graph.propagate_deployment_statuses(
+                new_csys_environment
+            )
+
+    def update_deployment_parents_from_input(self,
+                                             rm,
+                                             dep,
+                                             old_inputs,
+                                             new_inputs):
+        old_inputs = old_inputs or {}
+        new_inputs = new_inputs or {}
+        old_csys_environment = old_inputs.get('csys-environment')
+        new_csys_environment = new_inputs.get('csys-environment')
+        if old_csys_environment or new_csys_environment:
+            dep_graph = RecursiveDeploymentLabelsDependencies(self.sm)
+            dep_graph.create_dependencies_graph()
+
+            if new_csys_environment and not old_csys_environment:
+                self.add_input_label_after_deployment_update(
+                    rm,
+                    dep_graph,
+                    dep,
+                    new_csys_environment
+                )
+
+            elif old_csys_environment and not new_csys_environment:
+                self.delete_input_label_after_deployment_update(
+                    rm,
+                    dep_graph,
+                    dep,
+                    old_csys_environment
+                )
+
+            elif old_csys_environment and new_csys_environment and \
+                    old_csys_environment != new_csys_environment:
+                self.delete_input_label_after_deployment_update(
+                    rm,
+                    dep_graph,
+                    dep,
+                    old_csys_environment
+                )
+                self.add_input_label_after_deployment_update(
+                    rm,
+                    dep_graph,
+                    dep,
+                    new_csys_environment
+                )
+
     def commit_deployment_update(self,
                                  dep_update,
                                  skip_install=False,
@@ -252,6 +336,10 @@ class DeploymentUpdateManager(object):
         dep_update.central_plugins_to_uninstall = central_plugins_to_uninstall
         deployment = self.sm.get(models.Deployment, dep_update.deployment_id)
         labels_to_create = self._get_deployment_labels_to_create(dep_update)
+        csys_environment = dep_update.new_inputs.get('csys-environment')
+        new_inputs = dep_update.new_inputs.copy()
+        old_inputs = deployment.inputs.copy()
+        rm.verify_csys_environment_input(deployment, csys_environment)
         parents_labels = []
         if labels_to_create:
             parents_labels = rm.get_deployment_parents_from_labels(
@@ -343,7 +431,12 @@ class DeploymentUpdateManager(object):
                     deployment,
                     parent
                 )
-        # Return the deployment update object
+        self.update_deployment_parents_from_input(
+            rm,
+            deployment,
+            old_inputs,
+            new_inputs
+        )
         return self.get_deployment_update(dep_update.id)
 
     def validate_no_active_updates_per_deployment(self, deployment_id):
@@ -728,6 +821,21 @@ class DeploymentUpdateManager(object):
                                           constants.LABELS)
         return get_resource_manager().get_labels_to_create(deployment,
                                                            new_labels)
+
+    def _delete_single_label_from_deployment(self,
+                                             label_key,
+                                             label_value,
+                                             deployment):
+        dep_label = self.sm.get(
+            models.DeploymentLabel,
+            None,
+            filters={
+                '_labeled_model_fk': deployment._storage_id,
+                'key': label_key,
+                'value': label_value
+            }
+        )
+        self.sm.delete(dep_label)
 
 
 # What we need to access this manager in Flask

--- a/rest-service/manager_rest/manager_exceptions.py
+++ b/rest-service/manager_rest/manager_exceptions.py
@@ -137,6 +137,18 @@ class DeploymentParentNotFound(ManagerException):
         )
 
 
+class InvalidCSYSEnvironmentInput(ManagerException):
+    INVALID_CSYS_ENV_ERROR_CODE = 'invalid_csys_environment_error'
+
+    def __init__(self, *args, **kwargs):
+        super(InvalidCSYSEnvironmentInput, self).__init__(
+            400,
+            InvalidCSYSEnvironmentInput.INVALID_CSYS_ENV_ERROR_CODE,
+            *args,
+            **kwargs
+        )
+
+
 class NonexistentWorkflowError(ManagerException):
     NONEXISTENT_WORKFLOW_ERROR_CODE = 'nonexistent_workflow_error'
 

--- a/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
@@ -576,3 +576,25 @@ class DeploymentLabelsDependenciesTest(BaseServerTestCase):
         deployment = self.client.deployments.get('env')
         self.assertEqual(deployment.sub_environments_count, 3)
         self.assertEqual(deployment.sub_services_count, 2)
+
+    def test_failure_creation_for_automatic_label_from_input(self):
+        with self.assertRaisesRegex(
+                CloudifyClientError,
+                'referencing invalid `csys-environment` input'):
+            self.put_deployment(
+                'parent',
+                blueprint_id='bp1',
+                blueprint_file_name='blueprint_with_invalid'
+                                    '_csys_environment_input.yaml'
+            )
+
+    def test_success_creation_for_automatic_label_from_input(self):
+        self.put_deployment('parent')
+        self.put_deployment(
+            'child',
+            blueprint_id='child',
+            blueprint_file_name='blueprint_with_valid'
+                                '_csys_environment_input.yaml'
+        )
+        deployment = self.client.deployments.get('parent')
+        self.assertEqual(deployment.sub_services_count, 1)

--- a/rest-service/manager_rest/test/endpoints/test_deployment_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_updates.py
@@ -322,6 +322,33 @@ class DeploymentUpdatesTestCase(DeploymentUpdatesBase):
             deployment.id, blueprint_id='bp2',
             reevaluate_active_statuses=True)
 
+    def test_add_parent_label(self):
+        self.put_deployment(deployment_id='parent', blueprint_id='parent')
+        self._deploy_base('child', 'one_node.yaml')
+        self._update('child', 'one_label.yaml')
+        updated_deployment = \
+            self.client.deployments.get(deployment_id='parent')
+        self.assertEqual(updated_deployment.sub_services_count, 1)
+
+    def test_add_invalid_parent_label(self):
+        error_message = 'label `csys-obj-parent` that does not exist'
+        self.put_deployment(deployment_id='parent', blueprint_id='parent')
+        self._deploy_base('child', 'one_node.yaml')
+        with self.assertRaisesRegex(CloudifyClientError, error_message):
+            self._update('child', 'invalid_one_label.yaml')
+
+    def test_add_csys_environment_input(self):
+        self.put_deployment(deployment_id='parent', blueprint_id='parent')
+        self._deploy_base('child', 'one_node.yaml')
+        self._update(
+            'child',
+            'one_csys_input.yaml',
+            inputs={'csys-environment': 'parent'}
+        )
+        updated_deployment = \
+            self.client.deployments.get(deployment_id='parent')
+        self.assertEqual(updated_deployment.sub_services_count, 1)
+
 
 @mark.skip
 class DeploymentUpdatesStepAndStageTestCase(base_test.BaseServerTestCase):

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_invalid_csys_environment_input.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_invalid_csys_environment_input.yaml
@@ -1,0 +1,14 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - cloudify/types/types.yaml
+
+inputs:
+  csys-environment:
+    default:
+      key1: value1
+      key2: value
+      key3:
+        - value31
+        - value32
+        - value33

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_valid_csys_environment_input.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_valid_csys_environment_input.yaml
@@ -1,0 +1,8 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - cloudify/types/types.yaml
+
+inputs:
+  csys-environment:
+    default: parent

--- a/rest-service/manager_rest/test/resources/deployment_update/depup_step/invalid_one_label.yaml
+++ b/rest-service/manager_rest/test/resources/deployment_update/depup_step/invalid_one_label.yaml
@@ -1,0 +1,20 @@
+tosca_definitions_version: 'cloudify_dsl_1_3'
+
+imports:
+  - cloudify/types/types.yaml
+
+description: >
+  Micro web sites hosting.
+
+labels:
+  csys-obj-parent:
+    values:
+      - invalid_parent
+
+
+node_templates:
+
+  site1:
+    type: cloudify.nodes.Compute
+
+

--- a/rest-service/manager_rest/test/resources/deployment_update/depup_step/one_csys_input.yaml
+++ b/rest-service/manager_rest/test/resources/deployment_update/depup_step/one_csys_input.yaml
@@ -1,0 +1,19 @@
+tosca_definitions_version: 'cloudify_dsl_1_3'
+
+imports:
+  - cloudify/types/types.yaml
+
+description: >
+  Micro web sites hosting.
+
+inputs:
+  csys-environment:
+    type: string
+
+
+node_templates:
+
+  site1:
+    type: cloudify.nodes.Compute
+
+

--- a/rest-service/manager_rest/test/resources/deployment_update/depup_step/one_label.yaml
+++ b/rest-service/manager_rest/test/resources/deployment_update/depup_step/one_label.yaml
@@ -1,0 +1,20 @@
+tosca_definitions_version: 'cloudify_dsl_1_3'
+
+imports:
+  - cloudify/types/types.yaml
+
+description: >
+  Micro web sites hosting.
+
+labels:
+  csys-obj-parent:
+    values:
+      - parent
+
+
+node_templates:
+
+  site1:
+    type: cloudify.nodes.Compute
+
+


### PR DESCRIPTION
This PR created in order to add automatic labels when using `csys-environment` inside blueprint inputs so that we can link between child and its parent without needing to add explicit labels  