### PR TITLE
Add _include to searches swagger

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/searches.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/searches.py
@@ -19,6 +19,12 @@ def _get_swagger_searches_parameters():
     return [
         {
             'in': 'query',
+            'name': '_include',
+            'type': 'string',
+            'required': 'false'
+        },
+        {
+            'in': 'query',
             'name': '_size',
             'type': 'integer',
             'required': 'false'


### PR DESCRIPTION
`_include` did not appear in the `/searches` swagger, even though it is supported. 

@Gelio, FYI