### PR TITLE
exec-group start: only fetch the executions list once

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1147,12 +1147,13 @@ class ExecutionGroup(CreatedAtMixin, SQLResourceBase):
         This will only actually run executions up to the concurrency limit,
         and queue the rest.
         """
+        executions = self.executions  # only retrieve this once
         with sm.transaction():
-            for execution in self.executions[self.concurrency:]:
+            for execution in executions[self.concurrency:]:
                 execution.status = ExecutionState.QUEUED
                 sm.update(execution, modified_attrs=('status', ))
 
-        for execution in self.executions[:self.concurrency]:
+        for execution in executions[:self.concurrency]:
             rm.execute_workflow(
                 execution,
                 force=force,


### PR DESCRIPTION
This method used to access `self.execution` twice, in separate
transactions. This was then separate DB lookups, which could be
ordered differently. In other words,
`self.executions[:concurrency] + self.executions[concurrency:]` was
not necessarily the whole thing (it would often be all of them, because
postgres prefers sequential access, but not always).

This led to some executions being handled twice: they would get both
their status changed to queued, and be started. The start would then
throw the 401; and later they would be dequeued normally and succeed.

...and some executions would not be handled at all (because the
"twice" ones took their place) and would stay "pending" forever.

We could've added an `order by` to the collection, but a better
way is to just only fetch it once.