### PR TITLE
RD-1902 Use cryptography 3.3.2

### DIFF
--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     'python-dateutil==2.8.1',
     'voluptuous==0.9.3',
     'pika==1.1.0',
-    'cryptography==3.4.7',
+    'cryptography==3.3.2',
     'psycopg2==2.7.4',
     'pytz==2021.1',
     'packaging==17.1',

--- a/workflows/setup.py
+++ b/workflows/setup.py
@@ -28,7 +28,7 @@ setup(
         'cloudify-common==5.3.0.dev1',
         'retrying==1.3.3',
         'psycopg2==2.7.4',
-        'cryptography==3.4.7',
+        'cryptography==3.3.2',
         'python-dateutil==2.8.1',
         'pytz==2021.1',
     ]


### PR DESCRIPTION
In order to keep the same library version accross all repositories,
let's downgrade to cryptography==3.3.2 (which is the last version
compatible with Python 2.7).