### PR TITLE
CYBL-1139 execute_queued_workflow: preserve current_tenant

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -933,7 +933,7 @@ class ResourceManager(object):
         and re-run it with the correct workflow executor.
         :param execution: an execution DB object
         """
-        current_tenant = utils.current_tenant
+        current_tenant = utils.current_tenant._get_current_object()
         deployment = execution.deployment
         deployment_id = None
         if deployment:


### PR DESCRIPTION
current_tenant needs to be set to the actual tenant object, not
to the proxy. If it's set to the proxy, then the proxy points to the
proxy, and the next attempt to access utils.current_tenant throws.