### PR TITLE
RD-1943 Use server_default instead of default for deployments counters

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
+++ b/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
@@ -85,7 +85,7 @@ def _add_deployment_sub_statuses_and_counters():
             'sub_environments_count',
             sa.Integer(),
             nullable=False,
-            default=0,
+            server_default='0',
         )
     )
     op.add_column(
@@ -107,7 +107,7 @@ def _add_deployment_sub_statuses_and_counters():
             'sub_services_count',
             sa.Integer(),
             nullable=False,
-            default=0,
+            server_default='0',
         )
     )
     op.add_column(

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -388,8 +388,10 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
             DeploymentState.REQUIRE_ATTENTION,
             name='deployment_status'
         ))
-    sub_services_count = db.Column(db.Integer, nullable=False, default=0)
-    sub_environments_count = db.Column(db.Integer, nullable=False, default=0)
+    sub_services_count = db.Column(
+        db.Integer, nullable=False, server_default='0')
+    sub_environments_count = db.Column(
+        db.Integer, nullable=False, server_default='0')
     _blueprint_fk = foreign_key(Blueprint._storage_id)
     _site_fk = foreign_key(Site._storage_id,
                            nullable=True,


### PR DESCRIPTION
Use `server_default` instead of `default` for Non empty counter deployment fields where it should be inserted 0 by default. However, on snapshot restore it failed to default `0` into already existing deployment rows which caused issue on snapshot restore from version < 5.3.0 