### PR TITLE
RD-1950 Add support to update counters for deployment when deployment…

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1398,6 +1398,14 @@ class ResourceManager(object):
                 parents.append(value)
         return parents
 
+    @staticmethod
+    def get_deployment_object_type_from_labels(labels):
+        types = set()
+        for label, value in labels:
+            if label == 'csys-obj-type' and value:
+                types.add(value.lower())
+        return types
+
     def verify_deployment_parent_labels(self, parents, deployment_id):
         if not parents:
             return

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1398,13 +1398,19 @@ class ResourceManager(object):
                 parents.append(value)
         return parents
 
-    @staticmethod
-    def get_deployment_object_type_from_labels(labels):
-        types = set()
-        for label, value in labels:
-            if label == 'csys-obj-type' and value:
-                types.add(value.lower())
-        return types
+    def get_deployment_object_types_from_labels(self, deployment, labels):
+        new_labels = self.get_labels_to_create(deployment, labels)
+        created_types = set()
+        delete_types = set()
+        for key, value in new_labels:
+            if key == 'csys-obj-type' and value:
+                created_types.add(value.lower())
+
+        new_labels_set = set(new_labels)
+        for label in deployment.labels:
+            if (label.key, label.value) not in new_labels_set:
+                delete_types.add(label.value.lower())
+        return created_types, delete_types
 
     def verify_deployment_parent_labels(self, parents, deployment_id):
         if not parents:

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -103,18 +103,21 @@ class DeploymentsId(resources_v1.DeploymentsId):
         return deployment
 
     @staticmethod
-    def _update_deployment_counts(rm, deployment, new_labels):
-        if deployment.deployment_parents:
-            types = rm.get_deployment_object_type_from_labels(new_labels)
-            to_srv = deployment.is_environment and 'environment' not in types
-            to_env = not deployment.is_environment and 'environment' in types
+    def _update_deployment_counts(rm, dep, new_labels):
+        if dep.deployment_parents:
+            created_types, deleted_types = \
+                rm.get_deployment_object_types_from_labels(
+                    dep, new_labels
+                )
+            to_srv = dep.is_environment and 'environment' in deleted_types
+            to_env = not dep.is_environment and 'environment' in created_types
             _type = 'service' if to_srv else 'environment' if to_env else None
             if _type:
                 sm = get_storage_manager()
                 graph = rest_utils.RecursiveDeploymentLabelsDependencies(sm)
                 graph.create_dependencies_graph()
                 graph.update_deployment_counts_after_source_conversion(
-                    deployment.id, _type
+                    dep, _type
                 )
 
     @staticmethod

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -103,10 +103,23 @@ class DeploymentsId(resources_v1.DeploymentsId):
         return deployment
 
     @staticmethod
-    def _handle_deployment_labels(rm, deployment, raw_labels_list):
-        deployment_parents = deployment.deployment_parents
-        new_labels = rest_utils.get_labels_list(raw_labels_list)
+    def _update_deployment_counts(rm, deployment, new_labels):
+        if deployment.deployment_parents:
+            types = rm.get_deployment_object_type_from_labels(new_labels)
+            to_srv = deployment.is_environment and 'environment' not in types
+            to_env = not deployment.is_environment and 'environment' in types
+            _type = 'service' if to_srv else 'environment' if to_env else None
+            if _type:
+                sm = get_storage_manager()
+                graph = rest_utils.RecursiveDeploymentLabelsDependencies(sm)
+                graph.create_dependencies_graph()
+                graph.update_deployment_counts_after_source_conversion(
+                    deployment.id, _type
+                )
 
+    @staticmethod
+    def _update_labels_for_deployment(rm, deployment, new_labels):
+        deployment_parents = deployment.deployment_parents
         parents_labels = rm.get_deployment_parents_from_labels(
             new_labels
         )
@@ -133,6 +146,11 @@ class DeploymentsId(resources_v1.DeploymentsId):
             rm.handle_deployment_labels_graph(
                 parents, deployment
             )
+
+    def _handle_deployment_labels(self, rm, deployment, raw_labels_list):
+        new_labels = rest_utils.get_labels_list(raw_labels_list)
+        self._update_deployment_counts(rm, deployment, new_labels)
+        self._update_labels_for_deployment(rm, deployment, new_labels)
 
     @authorize('deployment_create')
     @rest_decorators.marshal_with(models.Deployment)


### PR DESCRIPTION
This PR created in order to fix issue when we changed the type of deployment by adding/removing `csys-obj-type` where the number of counters for parents deployments of the deployment that we delete/add `csys-obj-type` should be updated so that we can have the right counters