### PR TITLE
RD-1868 System filters infrastructure

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
+++ b/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
@@ -492,6 +492,8 @@ def _create_filters_tables():
         sa.Column('updated_at', UTCDateTime(), nullable=True),
         sa.Column('_tenant_id', sa.Integer(), nullable=False),
         sa.Column('_creator_id', sa.Integer(), nullable=False),
+        sa.Column('is_system_filter', sa.Boolean(), nullable=False,
+                  server_default='f'),
         sa.ForeignKeyConstraint(
             ['_creator_id'],
             ['users.id'],
@@ -530,6 +532,10 @@ def _create_filters_tables():
                     'blueprints_filters',
                     ['visibility'],
                     unique=False)
+    op.create_index(op.f('blueprints_filters_is_system_filter_idx'),
+                    'blueprints_filters',
+                    ['is_system_filter'],
+                    unique=False)
 
     op.create_table(
         'deployments_filters',
@@ -544,6 +550,8 @@ def _create_filters_tables():
         sa.Column('updated_at', UTCDateTime(), nullable=True),
         sa.Column('_tenant_id', sa.Integer(), nullable=False),
         sa.Column('_creator_id', sa.Integer(), nullable=False),
+        sa.Column('is_system_filter', sa.Boolean(), nullable=False,
+                  server_default='f'),
         sa.ForeignKeyConstraint(
             ['_creator_id'],
             ['users.id'],
@@ -582,6 +590,11 @@ def _create_filters_tables():
                     'deployments_filters',
                     ['visibility'],
                     unique=False)
+    op.create_index(op.f('deployments_filters_is_system_filter_idx'),
+                    'deployments_filters',
+                    ['is_system_filter'],
+                    unique=False)
+
     op.drop_index('filters__creator_id_idx',
                   table_name='filters')
     op.drop_index('filters__tenant_id_idx',
@@ -662,6 +675,7 @@ def _revert_filters_modifications():
                     'filters',
                     ['_creator_id'],
                     unique=False)
+
     op.drop_index(op.f('deployments_filters_visibility_idx'),
                   table_name='deployments_filters')
     op.drop_index(op.f('deployments_filters_id_idx'),
@@ -674,7 +688,10 @@ def _revert_filters_modifications():
                   table_name='deployments_filters')
     op.drop_index(op.f('deployments_filters__creator_id_idx'),
                   table_name='deployments_filters')
+    op.drop_index(op.f('deployments_filters_is_system_filter_idx'),
+                  table_name='deployments_filters')
     op.drop_table('deployments_filters')
+
     op.drop_index(op.f('blueprints_filters_visibility_idx'),
                   table_name='blueprints_filters')
     op.drop_index(op.f('blueprints_filters_id_idx'),
@@ -686,6 +703,8 @@ def _revert_filters_modifications():
     op.drop_index(op.f('blueprints_filters__tenant_id_idx'),
                   table_name='blueprints_filters')
     op.drop_index(op.f('blueprints_filters__creator_id_idx'),
+                  table_name='blueprints_filters')
+    op.drop_index(op.f('blueprints_filters_is_system_filter_idx'),
                   table_name='blueprints_filters')
     op.drop_table('blueprints_filters')
 

--- a/rest-service/manager_rest/constants.py
+++ b/rest-service/manager_rest/constants.py
@@ -76,16 +76,16 @@ MODELS_TO_PERMISSIONS = {
 FORBIDDEN_METHODS = ['POST', 'PATCH', 'PUT']
 SANITY_MODE_FILE_PATH = '/opt/manager/sanity_mode'
 
-CFY_LABELS = {'csys-obj-name',
-              'csys-obj-type',
-              'csys-env-type',
-              'csys-wrcp-services',
-              'csys-location-name',
-              'csys-location-lat',
-              'csys-location-long',
-              'csys-obj-parent'}
+RESERVED_LABELS = {'csys-obj-name',
+                   'csys-obj-type',
+                   'csys-env-type',
+                   'csys-wrcp-services',
+                   'csys-location-name',
+                   'csys-location-lat',
+                   'csys-location-long',
+                   'csys-obj-parent'}
 
-CFY_LABELS_PREFIX = 'csys-'
+RESERVED_PREFIX = 'csys-'
 
 
 class LabelsOperator(str, Enum):

--- a/rest-service/manager_rest/rest/resources_v3_1/filters.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/filters.py
@@ -103,7 +103,7 @@ class FiltersId(SecuredResource):
         rest_utils.validate_inputs({'filter_id': filter_id})
         storage_manager = get_storage_manager()
         filter_elem = storage_manager.get(filters_model, filter_id)
-        _verify_not_a_system_filter(filter_elem)
+        _verify_not_a_system_filter(filter_elem, 'delete')
         storage_manager.delete(filter_elem, validate_global=True)
         return None, 204
 
@@ -127,7 +127,7 @@ class FiltersId(SecuredResource):
 
         storage_manager = get_storage_manager()
         filter_elem = storage_manager.get(filters_model, filter_id)
-        _verify_not_a_system_filter(filter_elem)
+        _verify_not_a_system_filter(filter_elem, 'update')
         if visibility:
             get_resource_manager().validate_visibility_value(
                 filters_model, filter_elem, visibility)
@@ -165,10 +165,10 @@ def _get_filter_rules_by_type(filter_rules_list, filter_rule_type):
             filter_rules_list if filter_rule['type'] == filter_rule_type]
 
 
-def _verify_not_a_system_filter(filter_elem):
+def _verify_not_a_system_filter(filter_elem, action):
     if filter_elem.is_system_filter:
         raise manager_exceptions.IllegalActionError(
-            'Cannot delete a system filter')
+            f'Cannot {action} a system filter')
 
 
 class BlueprintsFiltersId(FiltersId):

--- a/rest-service/manager_rest/rest/resources_v3_1/filters.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/filters.py
@@ -4,6 +4,7 @@ from cloudify.models_states import VisibilityState
 
 from manager_rest import manager_exceptions
 from manager_rest.security import SecuredResource
+from manager_rest.constants import RESERVED_PREFIX
 from manager_rest.utils import get_formatted_timestamp
 from manager_rest.rest import rest_decorators, rest_utils
 from manager_rest.security.authorization import authorize
@@ -65,6 +66,10 @@ class FiltersId(SecuredResource):
     def put(self, filters_model, filter_id, filtered_resource):
         """Create a filter"""
         rest_utils.validate_inputs({'filter_id': filter_id})
+        if filter_id.lower().startswith(RESERVED_PREFIX):
+            raise manager_exceptions.BadParametersError(
+                f'All filters with a `{RESERVED_PREFIX}` prefix are reserved '
+                f'for internal use.')
         request_dict = rest_utils.get_json_and_verify_params(
             {'filter_rules': {'type': list}})
         filter_rules = create_filter_rules_list(request_dict['filter_rules'],
@@ -98,6 +103,7 @@ class FiltersId(SecuredResource):
         rest_utils.validate_inputs({'filter_id': filter_id})
         storage_manager = get_storage_manager()
         filter_elem = storage_manager.get(filters_model, filter_id)
+        _verify_not_a_system_filter(filter_elem)
         storage_manager.delete(filter_elem, validate_global=True)
         return None, 204
 
@@ -121,6 +127,7 @@ class FiltersId(SecuredResource):
 
         storage_manager = get_storage_manager()
         filter_elem = storage_manager.get(filters_model, filter_id)
+        _verify_not_a_system_filter(filter_elem)
         if visibility:
             get_resource_manager().validate_visibility_value(
                 filters_model, filter_elem, visibility)
@@ -156,6 +163,12 @@ class FiltersId(SecuredResource):
 def _get_filter_rules_by_type(filter_rules_list, filter_rule_type):
     return [filter_rule for filter_rule in
             filter_rules_list if filter_rule['type'] == filter_rule_type]
+
+
+def _verify_not_a_system_filter(filter_elem):
+    if filter_elem.is_system_filter:
+        raise manager_exceptions.IllegalActionError(
+            'Cannot delete a system filter')
 
 
 class BlueprintsFiltersId(FiltersId):

--- a/rest-service/manager_rest/rest/resources_v3_1/labels.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/labels.py
@@ -1,6 +1,6 @@
 from flask import request
 
-from manager_rest.constants import CFY_LABELS
+from manager_rest.constants import RESERVED_LABELS
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
 from manager_rest.storage.storage_manager import ListResult
@@ -17,7 +17,7 @@ class DeploymentsLabels(SecuredResource):
     def get(self, pagination=None, search=None):
         """Get all deployments' labels' keys"""
         if _is_reserved_labels_keys_in_request():
-            return ListResult.from_list(items=CFY_LABELS)
+            return ListResult.from_list(items=RESERVED_LABELS)
         return get_labels_keys(models.Deployment,
                                models.DeploymentLabel,
                                pagination,
@@ -46,7 +46,7 @@ class BlueprintsLabels(SecuredResource):
     def get(self, pagination=None, search=None):
         """Get all blueprints' labels' keys"""
         if _is_reserved_labels_keys_in_request():
-            return ListResult.from_list(items=CFY_LABELS)
+            return ListResult.from_list(items=RESERVED_LABELS)
         return get_labels_keys(models.Blueprint,
                                models.BlueprintLabel,
                                pagination,

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -34,7 +34,7 @@ from cloudify.models_states import (
 )
 
 from manager_rest.storage import models
-from manager_rest.constants import CFY_LABELS, CFY_LABELS_PREFIX
+from manager_rest.constants import RESERVED_LABELS, RESERVED_PREFIX
 from manager_rest.dsl_functions import (get_secret_method,
                                         evaluate_intrinsic_functions)
 from manager_rest import manager_exceptions, config, app_context
@@ -904,12 +904,12 @@ def parse_label(label_key, label_value):
     parsed_label_key = label_key.lower()
     parsed_label_value = unicodedata.normalize('NFKC', label_value).casefold()
 
-    if (parsed_label_key.startswith(CFY_LABELS_PREFIX) and
-            parsed_label_key not in CFY_LABELS):
-        allowed_cfy_labels = ', '.join(CFY_LABELS)
+    if (parsed_label_key.startswith(RESERVED_PREFIX) and
+            parsed_label_key not in RESERVED_LABELS):
+        allowed_cfy_labels = ', '.join(RESERVED_LABELS)
         raise manager_exceptions.BadParametersError(
-            f'All labels with a `{CFY_LABELS_PREFIX}` prefix are reserved for '
-            f'internal use. Allowed `{CFY_LABELS_PREFIX}` prefixed labels '
+            f'All labels with a `{RESERVED_PREFIX}` prefix are reserved for '
+            f'internal use. Allowed `{RESERVED_PREFIX}` prefixed labels '
             f'are: {allowed_cfy_labels}')
 
     return parsed_label_key, parsed_label_value

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -797,6 +797,10 @@ class _Filter(CreatedAtMixin, SQLResourceBase):
 
     value = db.Column(JSONString, nullable=True)
     updated_at = db.Column(UTCDateTime)
+    is_system_filter = db.Column(db.Boolean,
+                                 nullable=False,
+                                 index=True,
+                                 default=False)
 
     @property
     def labels_filter_rules(self):

--- a/rest-service/manager_rest/test/endpoints/test_labels.py
+++ b/rest-service/manager_rest/test/endpoints/test_labels.py
@@ -15,7 +15,7 @@
 
 from manager_rest.test import base_test
 from manager_rest.test.attribute import attr
-from manager_rest.constants import CFY_LABELS
+from manager_rest.constants import RESERVED_LABELS
 
 
 @attr(client_min_version=3.1, client_max_version=base_test.LATEST_API_VERSION)
@@ -47,7 +47,7 @@ class LabelsTestCase(base_test.BaseServerTestCase):
 
     def test_get_reserved_labels(self):
         reserved_labels = self.labels_client.get_reserved_labels_keys()
-        self.assertEqual(reserved_labels.items, list(CFY_LABELS))
+        self.assertEqual(reserved_labels.items, list(RESERVED_LABELS))
 
 
 class DeploymentsLabelsTestCase(LabelsTestCase):


### PR DESCRIPTION
The system filters infrastructure follows these guidelines: 

- System filters will be defined in the DB using a boolean "flag" named `is_system_filter`. 
- System filters are `csys-` prefixed, and therefore a user won't be able to create a `csys-` prefixed filters.
- A user shouldn't be able to modify or delete a system filter.

I also changed in this PR the names of the constants `CFY_PREFIX` and `CFY_LABELS` to more accurate ones - `RESERVED_PREFIX` and `RESERVED_LABELS`. 