### PR TITLE
RD-1956 Change unique constraint for latest execution foreign key

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -344,6 +344,11 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
             'id', '_tenant_id',
             unique=True
         ),
+        db.Index(
+            'deployments__latest_execution_fk_idx',
+            '_latest_execution_fk',
+            unique=True
+        ),
     )
     skipped_fields = dict(
         SQLResourceBase.skipped_fields,


### PR DESCRIPTION
Make the unique constraint for the latest_execution foreign key unique in the mode side to avoid and stop alembic from keep generating it every time there is a change on the model   