### PR TITLE
RD-1535 Resume an execution group

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
+++ b/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py
@@ -55,7 +55,7 @@ def upgrade():
     _create_filters_tables()
     _add_deployment_statuses()
     _add_execgroups_concurrency()
-    _add_execution_operations_columns()
+    _add_executions_columns()
     _create_deployment_labels_dependencies_table()
     _add_deployment_sub_statuses_and_counters()
     _create_depgroups_labels_table()
@@ -74,7 +74,7 @@ def downgrade():
     _revert_changes_to_execution_schedules_table()
     _revert_changes_to_deployments_labels_table()
     _drop_blueprints_labels_table()
-    _drop_execution_operations_columns()
+    _drop_execution_columns()
     _drop_deployment_statuses_enum_types()
 
 
@@ -725,7 +725,7 @@ def _drop_execgroups_concurrency():
     op.drop_column('execution_groups', 'concurrency')
 
 
-def _add_execution_operations_columns():
+def _add_executions_columns():
     op.add_column(
         'executions',
         sa.Column('finished_operations', sa.Integer(), nullable=True)
@@ -734,11 +734,17 @@ def _add_execution_operations_columns():
         'executions',
         sa.Column('total_operations', sa.Integer(), nullable=True)
     )
+    op.add_column(
+        'executions',
+        sa.Column('resume', sa.Boolean(),
+                  server_default='false', nullable=False)
+    )
 
 
-def _drop_execution_operations_columns():
+def _drop_execution_columns():
     op.drop_column('executions', 'total_operations')
     op.drop_column('executions', 'finished_operations')
+    op.drop_column('executions', 'resume')
 
 
 def _drop_deployment_labels_dependencies_table():

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -859,13 +859,11 @@ class ResourceManager(object):
 
         execution.status = ExecutionState.STARTED
         execution.ended_at = None
-        self.sm.update(execution, modified_attrs=('status', 'ended_at'))
+        execution.resumed = True
+        self.sm.update(execution,
+                       modified_attrs=('status', 'ended_at', 'resume'))
 
-        workflow_executor.execute_workflow(
-            execution,
-            bypass_maintenance=False,
-            resume=True,
-        )
+        workflow_executor.execute_workflow(execution, bypass_maintenance=False)
 
         # Dealing with the inner Components' deployments
         components_executions = self._find_all_components_executions(

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -74,7 +74,6 @@ from . import config
 from . import app_context
 from . import workflow_executor
 from . import manager_exceptions
-from .workflow_executor import generate_execution_token
 
 if typing.TYPE_CHECKING:
     from cloudify.amqp_client import SendHandler

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -841,7 +841,6 @@ class ResourceManager(object):
 
     def resume_execution(self, execution_id, force=False):
         execution = self.sm.get(models.Execution, execution_id)
-        execution_token = generate_execution_token(execution)
         if execution.status in {ExecutionState.CANCELLED,
                                 ExecutionState.FAILED}:
             self.reset_operations(execution, force=force)

--- a/rest-service/manager_rest/rest/resources_v3_1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/executions.py
@@ -237,10 +237,16 @@ class ExecutionGroupsId(SecuredResource):
             raise BadParametersError(
                 'Invalid action: {0}, Valid action values are: {1}'.format(
                     action, valid_actions))
+
         sm = get_storage_manager()
+        group = sm.get(models.ExecutionGroup, group_id)
+        if action in ('cancel', 'force-cancel', 'kill'):
+            self._cancel_group(sm, group, action)
+        return group
+
+    def _cancel_group(self, sm, group, action):
         rm = get_resource_manager()
         with sm.transaction():
-            group = sm.get(models.ExecutionGroup, group_id)
             to_cancel = []
             for exc in group.executions:
                 if exc.status == ExecutionState.QUEUED:
@@ -253,4 +259,3 @@ class ExecutionGroupsId(SecuredResource):
                     force=action == 'force-cancel',
                     kill=action == 'kill',
                 )
-        return group

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -877,6 +877,7 @@ class Execution(CreatedAtMixin, SQLResourceBase):
     scheduled_for = db.Column(UTCDateTime, nullable=True)
     is_dry_run = db.Column(db.Boolean, nullable=False, default=False)
     token = db.Column(db.String(100), nullable=True, index=True)
+    resume = db.Column(db.Boolean, nullable=False, server_default='false')
 
     _deployment_fk = foreign_key(Deployment._storage_id, nullable=True)
 
@@ -1053,6 +1054,7 @@ class Execution(CreatedAtMixin, SQLResourceBase):
             'execution_creator_username': self.creator.username,
             'task_target': MGMTWORKER_QUEUE,
             'tenant': {'name': self.tenant.name},
+            'resume': self.resume,
         }
         if self.deployment is not None:
             context['deployment_id'] = self.deployment.id

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1164,7 +1164,10 @@ class ExecutionGroup(CreatedAtMixin, SQLResourceBase):
         This will only actually run executions up to the concurrency limit,
         and queue the rest.
         """
-        executions = self.executions  # only retrieve this once
+        executions = [
+            exc for exc in self.executions
+            if exc.status == ExecutionState.PENDING
+        ]
         with sm.transaction():
             for execution in executions[self.concurrency:]:
                 execution.status = ExecutionState.QUEUED

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -720,3 +720,29 @@ class ExecutionGroupsTestCase(base_test.BaseServerTestCase):
             assert exc.status in (
                 ExecutionState.CANCELLED, ExecutionState.CANCELLING
             )
+
+    @mock.patch('manager_rest.workflow_executor.execute_workflow', mock.Mock())
+    @mock.patch('manager_rest.resource_manager.send_event', mock.Mock())
+    def test_resume_group(self):
+        """After all executions have been cancelled, resume them"""
+        self.client.deployment_groups.add_deployments(
+            'group1',
+            count=20
+        )
+        exc_group = self.client.execution_groups.start(
+            deployment_group_id='group1',
+            workflow_id='install',
+        )
+        group = self.sm.get(models.ExecutionGroup, exc_group.id)
+
+        for exc in group.executions:
+            exc.status = ExecutionState.CANCELLED
+            self.sm.update(exc)
+
+        self.client.execution_groups.resume(exc_group.id)
+
+        group = self.sm.get(models.ExecutionGroup, exc_group.id)
+        for exc in group.executions:
+            assert exc.status in (
+                ExecutionState.PENDING, ExecutionState.QUEUED
+            )

--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -17,13 +17,11 @@ from manager_rest.storage import get_storage_manager, models
 def execute_workflow(execution,
                      bypass_maintenance=None,
                      wait_after_fail=600,
-                     resume=False,
                      handler: SendHandler = None,):
     sm = get_storage_manager()
     token = generate_execution_token(execution)
     context = execution.render_context()
     context.update({
-        'resume': resume,
         'wait_after_fail': wait_after_fail,
         'bypass_maintenance': bypass_maintenance,
         'execution_token': token,


### PR DESCRIPTION
Rewrite .reset_operations a bit to make bulk actions easier,
and implement a resume for a whole execution group.

It will only resume the executions that are indeed cancelled/failed.
If there are any executions still running, they will be unaffected.