### PR TITLE
several integration test fixes

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -954,7 +954,7 @@ class ResourceManager(object):
             filters={
                 'deployment_id': execution.deployment_id,
                 'id': lambda col: col != execution.id,
-                'status': lambda col: col.notin_(ExecutionState.END_STATES)
+                'status': ExecutionState.ACTIVE_STATES,
             },
             is_include_system_workflows=True
         ).items

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -485,6 +485,7 @@ class ResourceManager(object):
         # Verify plugin exists and can be removed
         plugin = self.sm.get(models.Plugin, plugin_id)
         validate_global_modification(plugin)
+        self._check_for_active_system_wide_execution(queue=False)
 
         if not force:
             affected_blueprint_ids = []
@@ -940,7 +941,7 @@ class ResourceManager(object):
             and this is set, queue the execution. Otherwise, throw.
         """
         system_exec_running = self._check_for_active_system_wide_execution(
-            execution, queue)
+            queue)
         if force or not execution.deployment:
             return system_exec_running
         else:
@@ -968,7 +969,7 @@ class ResourceManager(object):
                 f'deployment: {running}. To execute this workflow anyway, '
                 f'pass "force=true" as a query parameter to this request')
 
-    def _check_for_active_system_wide_execution(self, execution, queue):
+    def _check_for_active_system_wide_execution(self, queue):
         executions = self.sm.list(models.Execution, filters={
             'is_system_workflow': True,
             'status': ExecutionState.ACTIVE_STATES,

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -972,7 +972,7 @@ class ResourceManager(object):
     def _check_for_active_system_wide_execution(self, queue):
         executions = self.sm.list(models.Execution, filters={
             'is_system_workflow': True,
-            'status': ExecutionState.ACTIVE_STATES,
+            'status': ExecutionState.ACTIVE_STATES + [ExecutionState.QUEUED],
         }, get_all_results=True, all_tenants=True).items
         if executions and queue:
             return True

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -723,8 +723,11 @@ class ExecutionGroupsTestCase(base_test.BaseServerTestCase):
     def test_cancel_group(self):
         self.client.deployment_groups.add_deployments(
             'group1',
-            count=20
+            count=2
         )
+        for dep in self.client.deployments.list():
+            if dep.id != 'dep1':
+                self.create_deployment_environment(dep)
         exc_group = self.client.execution_groups.start(
             deployment_group_id='group1',
             workflow_id='install',
@@ -743,8 +746,11 @@ class ExecutionGroupsTestCase(base_test.BaseServerTestCase):
         """After all executions have been cancelled, resume them"""
         self.client.deployment_groups.add_deployments(
             'group1',
-            count=20
+            count=2
         )
+        for dep in self.client.deployments.list():
+            if dep.id != 'dep1':
+                self.create_deployment_environment(dep)
         exc_group = self.client.execution_groups.start(
             deployment_group_id='group1',
             workflow_id='install',

--- a/tests/integration_tests/framework/utils.py
+++ b/tests/integration_tests/framework/utils.py
@@ -62,9 +62,8 @@ def sh_bake(command):
 
 
 def get_profile_context(container_id):
-    container_ip = docker.get_manager_ip(container_id)
     profile_context_cmd =\
-        'cat /root/.cloudify/profiles/{0}/context.json'.format(container_ip)
+        'cat /root/.cloudify/profiles/manager-local/context.json'
     return json.loads(docker.execute(container_id, profile_context_cmd))
 
 

--- a/tests/integration_tests/framework/utils.py
+++ b/tests/integration_tests/framework/utils.py
@@ -89,12 +89,11 @@ def create_rest_client(host, **kwargs):
     password = kwargs.get('password', 'admin')
     tenant = kwargs.get('tenant', 'default_tenant')
     token = kwargs.get('token')
-    rest_port = kwargs.get('rest_port',
-                           os.environ.get(constants.CLOUDIFY_REST_PORT, 80))
+    rest_port = kwargs.get('rest_port', 443)
     rest_protocol = kwargs.get('rest_protocol',
-                               'https' if rest_port == '443' else 'http')
-    cert_path = kwargs.get('cert_path', cli_env.get_ssl_cert())
-    trust_all = kwargs.get('trust_all', cli_env.get_ssl_trust_all())
+                               'https' if rest_port == 443 else 'http')
+    cert_path = kwargs.get('cert_path')
+    trust_all = kwargs.get('trust_all', False)
 
     headers = create_auth_header(username, password, token, tenant)
 

--- a/tests/integration_tests/framework/utils.py
+++ b/tests/integration_tests/framework/utils.py
@@ -32,8 +32,6 @@ import sh
 import pika
 import ssl
 
-from . import constants
-
 from cloudify.utils import setup_logger
 from cloudify_rest_client import CloudifyClient
 from manager_rest.utils import create_auth_header

--- a/tests/integration_tests/tests/agentless_tests/component/test_component_cascading.py
+++ b/tests/integration_tests/tests/agentless_tests/component/test_component_cascading.py
@@ -26,7 +26,6 @@ from integration_tests.tests.utils import (
     verify_deployment_env_created,
     do_retries,
     get_resource as resource,
-    generate_scheduled_for_date,
     wait_for_blueprint_upload)
 
 
@@ -732,27 +731,3 @@ workflows:
         executions = self.client.executions.list(
             workflow_id='nothing_workflow')
         self.assertEqual(len(executions), 4)
-
-    def test_cascading_scheduled_workflow_execution(self):
-        basic_blueprint_path = self.make_yaml_file(
-            self.component_blueprint_with_nothing_workflow)
-        self.client.blueprints.upload(basic_blueprint_path,
-                                      entity_id='workflow')
-        wait_for_blueprint_upload('workflow', self.client)
-
-        deployment_id = 'd{0}'.format(uuid.uuid4())
-        main_blueprint = self.generate_root_blueprint_with_component()
-        main_blueprint_path = self.make_yaml_file(main_blueprint)
-        self.deploy_application(main_blueprint_path,
-                                deployment_id=deployment_id)
-
-        scheduled_time = generate_scheduled_for_date()
-        self.client.executions.start(deployment_id,
-                                     'nothing_workflow',
-                                     schedule=scheduled_time)
-
-        executions = self.client.executions.list(
-            workflow_id='nothing_workflow')
-        for execution in executions:
-            self.assertEqual(Execution.SCHEDULED, execution.status)
-        self.assertEqual(len(executions), 2)

--- a/tests/integration_tests/tests/agentless_tests/security/security_base.py
+++ b/tests/integration_tests/tests/agentless_tests/security/security_base.py
@@ -24,7 +24,8 @@ from integration_tests import AgentlessTestCase
 class TestAuthenticationBase(AgentlessTestCase):
     @contextmanager
     def _login_client(self, **kwargs):
-        self.logger.info('Logging in to client with {0}'.format(str(kwargs)))
+        self.logger.info('Logging in to client with {0}'.format(kwargs))
+        kwargs.setdefault('cert_path', self.ca_cert)
         client = self.client
         try:
             self.client = utils.create_rest_client(self.env.container_ip,

--- a/tests/integration_tests/tests/agentless_tests/test_deployment_workflows.py
+++ b/tests/integration_tests/tests/agentless_tests/test_deployment_workflows.py
@@ -38,7 +38,7 @@ class TestDeploymentWorkflows(AgentlessTestCase):
         deployment, _ = self.deploy_application(dsl_path)
         deployment_id = deployment.id
         workflows = self.client.deployments.get(deployment_id).workflows
-        self.assertEqual(12, len(workflows))
+        self.assertEqual(14, len(workflows))
         wf_ids = [x.name for x in workflows]
         self.assertIn('uninstall', wf_ids)
         self.assertIn('install', wf_ids)

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -143,7 +143,7 @@ class EventsTest(AgentlessTestCase):
         else:
             self.fail("Expected logs to be found")
 
-    @pytest.mark.skipif(reason='causes the DB deadlock in snapshot')
+    @pytest.mark.skip(reason='causes the DB deadlock in snapshot')
     def test_snapshots_events(self):
         """ Make sure snapshots events appear when using the
          'cfy events list' command """

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -143,6 +143,7 @@ class EventsTest(AgentlessTestCase):
         else:
             self.fail("Expected logs to be found")
 
+    @pytest.mark.skipif(reason='causes the DB deadlock in snapshot')
     def test_snapshots_events(self):
         """ Make sure snapshots events appear when using the
          'cfy events list' command """
@@ -155,7 +156,6 @@ class EventsTest(AgentlessTestCase):
         self.undeploy_application(
             self.deployment_id, is_delete_deployment=True)
         execution = self.client.snapshots.restore(snapshot_id, force=True)
-
         # give the database some time to downgrade/upgrade before running
         # requests to avoid the deadlock described in CY-1455
         time.sleep(10)

--- a/tests/integration_tests/tests/agentless_tests/test_executions.py
+++ b/tests/integration_tests/tests/agentless_tests/test_executions.py
@@ -562,7 +562,8 @@ class ExecutionsTest(AgentlessTestCase):
 
     def test_fail_to_delete_plugin_while_creating_snapshot(self):
         # Upload plugin
-        upload_mock_plugin(self.client, 'cloudify-script-plugin', '1.2')
+        plugin = upload_mock_plugin(
+            self.client, 'cloudify-script-plugin', '1.2')
         plugins_list = self.client.plugins.list()
         # 3 plugins were uploaded with the test class
         self.assertEqual(4, len(plugins_list),
@@ -570,9 +571,9 @@ class ExecutionsTest(AgentlessTestCase):
                          'got {0}'.format(len(plugins_list)))
 
         # Create snapshot and make sure it's state remains 'started'
+        self._create_snapshot_and_modify_execution_status(Execution.STARTED)
         self._execute_unpermitted_operation_and_catch_exception(
-            self._create_snapshot_and_modify_execution_status,
-            Execution.STARTED)
+            self.client.plugins.delete, plugin.id)
 
     def test_cancel_execution(self):
         execution, deployment_id = self._execute_and_cancel_execution(

--- a/tests/integration_tests/tests/agentless_tests/test_executions.py
+++ b/tests/integration_tests/tests/agentless_tests/test_executions.py
@@ -903,10 +903,11 @@ class ExecutionsTest(AgentlessTestCase):
         # The token in the container is invalid, create new valid one
         create_api_token(self.env.container_id)
         create_tenants_and_add_users(client=self.client, num_of_tenants=1)
-        tenant_client = utils.create_rest_client(host=self.env.container_ip,
-                                                 username='user_0',
-                                                 password='password',
-                                                 tenant='tenant_0')
+        tenant_client = utils.create_rest_client(
+            host=self.env.container_ip,
+            username='user_0', password='password', tenant='tenant_0',
+            rest_port=443, rest_protocol='https', cert_path=self.ca_cert,
+        )
         dsl_path = resource('dsl/sleep_workflows.yaml')
         dep = self.deploy(dsl_path, wait=False, client=tenant_client)
         dep_id = dep.id

--- a/tests/integration_tests/tests/agentless_tests/test_executions.py
+++ b/tests/integration_tests/tests/agentless_tests/test_executions.py
@@ -880,9 +880,9 @@ class ExecutionsTest(AgentlessTestCase):
                                       Execution.QUEUED, tenant_client)
         self.client.executions.update(snapshot.id, Execution.TERMINATED)
         self.wait_for_execution_to_end(execution, client=tenant_client)
-        schedule = self.client.execution_schedules.list(
+        schedule = tenant_client.execution_schedules.list(
             deployment_id=dep.id)[0]
-        self.client.execution_schedules.delete(schedule.id, dep_id)
+        tenant_client.execution_schedules.delete(schedule.id, dep_id)
 
     def test_two_scheduled_execution_same_tenant(self):
         """

--- a/tests/integration_tests/tests/agentless_tests/test_executions.py
+++ b/tests/integration_tests/tests/agentless_tests/test_executions.py
@@ -527,12 +527,10 @@ class ExecutionsTest(AgentlessTestCase):
         self._assert_execution_status(snapshot.id, Execution.CANCELLED)
 
     def _execute_unpermitted_operation_and_catch_exception(self, op, args):
-        try:
+        with self.assertRaisesRegex(
+                CloudifyClientError, '[Cc]annot start') as cm:
             op(args)
-        except CloudifyClientError as e:
-            self.assertIn('You cannot start an execution that modifies DB'
-                          ' state while a `create_snapshot`', str(e))
-            self.assertEqual(e.status_code, 400)
+        self.assertEqual(cm.exception.status_code, 400)
 
     def test_fail_to_create_deployment_while_creating_snapshot(self):
         # Create snapshot and make sure it's state remains 'started'
@@ -557,12 +555,10 @@ class ExecutionsTest(AgentlessTestCase):
     def test_fail_to_upload_plugin_while_creating_snapshot(self):
         # Create snapshot and make sure it's state remains 'started'
         self._create_snapshot_and_modify_execution_status(Execution.STARTED)
-        try:
+        with self.assertRaisesRegex(
+                CloudifyClientError, '[Cc]annot start') as cm:
             upload_mock_plugin(self.client, 'cloudify-script-plugin', '1.2')
-        except CloudifyClientError as e:
-            self.assertIn('You cannot start an execution that modifies DB'
-                          ' state while a `create_snapshot`', str(e))
-            self.assertEqual(e.status_code, 400)
+        self.assertEqual(cm.exception.status_code, 400)
 
     def test_fail_to_delete_plugin_while_creating_snapshot(self):
         # Upload plugin

--- a/tests/integration_tests/tests/agentless_tests/test_labels.py
+++ b/tests/integration_tests/tests/agentless_tests/test_labels.py
@@ -19,7 +19,7 @@ class DeploymentsLabelsTest(AgentlessTestCase):
         self.client.tenants.add_user('user', 'default_tenant', role='viewer')
         viewer_client = utils.create_rest_client(
             host=self.env.container_ip,
-            username='user', password='password',tenant='default_tenant',
+            username='user', password='password', tenant='default_tenant',
             rest_port=443, rest_protocol='https', cert_path=self.ca_cert,
         )
 

--- a/tests/integration_tests/tests/agentless_tests/test_labels.py
+++ b/tests/integration_tests/tests/agentless_tests/test_labels.py
@@ -17,10 +17,11 @@ class DeploymentsLabelsTest(AgentlessTestCase):
         self._put_deployment_with_labels(self.client, self.LABELS)
         self.client.users.create('user', 'password', role='default')
         self.client.tenants.add_user('user', 'default_tenant', role='viewer')
-        viewer_client = utils.create_rest_client(host=self.env.container_ip,
-                                                 username='user',
-                                                 password='password',
-                                                 tenant='default_tenant')
+        viewer_client = utils.create_rest_client(
+            host=self.env.container_ip,
+            username='user', password='password',tenant='default_tenant',
+            rest_port=443, rest_protocol='https', cert_path=self.ca_cert,
+        )
 
         self._assert_keys_and_values(viewer_client,
                                      {'key1': {'val1', 'val2'},
@@ -33,7 +34,9 @@ class DeploymentsLabelsTest(AgentlessTestCase):
         """
         self.client.tenants.create('new_tenant')
         new_tenant_client = utils.create_rest_client(
-            host=self.env.container_ip, tenant='new_tenant')
+            host=self.env.container_ip, tenant='new_tenant',
+            rest_port=443, rest_protocol='https', cert_path=self.ca_cert,
+        )
         self._put_deployment_with_labels(self.client, self.LABELS)
         self._put_deployment_with_labels(new_tenant_client,
                                          self.LABELS_2,

--- a/tests/integration_tests/tests/agentless_tests/test_resume.py
+++ b/tests/integration_tests/tests/agentless_tests/test_resume.py
@@ -241,7 +241,8 @@ class TestResumeMgmtworker(AgentlessTestCase):
         self._create_user(username, password, 'default_tenant')
         user_client = create_rest_client(
             host=self.env.container_ip,
-            username=username, password=password, tenant='default_tenant'
+            username=username, password=password, tenant='default_tenant',
+            rest_port=443, rest_protocol='https', cert_path=self.ca_cert,
         )
         self._resume_no_duplicates_test(user_client)
 

--- a/tests/integration_tests/tests/agentless_tests/test_secrets.py
+++ b/tests/integration_tests/tests/agentless_tests/test_secrets.py
@@ -65,10 +65,11 @@ class SecretsTest(AgentlessTestCase):
         self.client.secrets.create('key', 'value')
         self.client.users.create('user', 'password', 'default')
         self.client.tenants.add_user('user', 'default_tenant', 'viewer')
-        viewer_client = utils.create_rest_client(host=self.env.container_ip,
-                                                 username='user',
-                                                 password='password',
-                                                 tenant='default_tenant')
+        viewer_client = utils.create_rest_client(
+            host=self.env.container_ip,
+            username='user', password='password', tenant='default_tenant',
+            rest_port=443, rest_protocol='https', cert_path=self.ca_cert,
+        )
         self.assertRaisesRegexp(ForbiddenError,
                                 '403: User `user` is not permitted to perform'
                                 ' the action secret_export in the tenant '

--- a/tests/integration_tests/tests/agentless_tests/test_secrets.py
+++ b/tests/integration_tests/tests/agentless_tests/test_secrets.py
@@ -16,9 +16,7 @@
 from integration_tests.framework import utils
 from integration_tests import AgentlessTestCase
 from integration_tests.tests.utils import get_resource as resource
-from cloudify_rest_client.exceptions import (CloudifyClientError,
-                                             UnknownDeploymentSecretError,
-                                             ForbiddenError)
+from cloudify_rest_client.exceptions import CloudifyClientError, ForbiddenError
 
 
 class SecretsTest(AgentlessTestCase):
@@ -51,11 +49,9 @@ class SecretsTest(AgentlessTestCase):
 
     def test_get_secret_intrinsic_function(self):
         dsl_path = resource("dsl/basic_get_secret.yaml")
-
-        # Fails to create deployment because the secret is missing
-        error_msg = "400: Required secrets: .* don't exist in this tenant"
+        error_msg = "Required secrets: .* don't exist in this tenant"
         self.assertRaisesRegexp(
-            UnknownDeploymentSecretError,
+            CloudifyClientError,
             error_msg,
             self.deploy_application,
             dsl_path

--- a/workflows/cloudify_system_workflows/deployment_environment.py
+++ b/workflows/cloudify_system_workflows/deployment_environment.py
@@ -87,7 +87,8 @@ def create(ctx, labels=None, inputs=None, skip_plugins_validation=False, **_):
     client = get_rest_client(tenant=ctx.tenant_name)
     bp = client.blueprints.get(ctx.blueprint.id)
     deployment_plan = tasks.prepare_deployment_plan(
-        bp.plan, client.secrets.get, inputs)
+        bp.plan, client.secrets.get, inputs,
+        runtime_only_evaluation=ctx.deployment.runtime_only_evaluation)
     nodes = deployment_plan['nodes']
     node_instances = deployment_plan['node_instances']
 


### PR DESCRIPTION
Multiple, mostly unrelated fixes for integration tests.
Unfortunate that they're all in a single PR, but imagine waiting
for CI 18 times.

Most of them has to do with either:
1. using external ssl
2. the new queueing mechanism
3. async deployment create