### PR TITLE
RD-1989 Fix issue when delete child that its parent is no longer exist

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -756,14 +756,19 @@ class ResourceManager(object):
             dep_graph.create_dependencies_graph()
             dep_graph.decrease_deployment_counts_in_graph(parents, deployment)
             for _parent in parents:
-                dep_graph.remove_dependency_from_graph(deployment.id, _parent)
-                self._remove_deployment_label_dependency(
-                    deployment,
-                    self.sm.get(
-                        models.Deployment, _parent
-                    )
+                _parent_obj = self.sm.get(
+                    models.Deployment,
+                    _parent,
+                    fail_silently=True
                 )
-                dep_graph.propagate_deployment_statuses(_parent)
+                if _parent_obj:
+                    dep_graph.remove_dependency_from_graph(
+                        deployment.id, _parent)
+                    self._remove_deployment_label_dependency(
+                        deployment,
+                        _parent_obj
+                    )
+                    dep_graph.propagate_deployment_statuses(_parent)
 
         deployment_folder = os.path.join(
             config.instance.file_server_root,


### PR DESCRIPTION
Fix issue when delete child deployment that still reference parent label values to deployment that no longer exist