### PR TITLE
RD-1991 Propagate installed child deployment to their parents

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1532,6 +1532,7 @@ class ResourceManager(object):
             target_id,
             source
         )
+        dep_graph.propagate_deployment_statuses(target_id)
 
     def delete_deployment_from_labels_graph(self,
                                             dep_graph,


### PR DESCRIPTION
Re-calculate the deployment parent statuses after adding label parents to already installed children services or environment   