### PR TITLE
cloudify-types: bump requests version

### DIFF
--- a/cloudify_types/setup.py
+++ b/cloudify_types/setup.py
@@ -30,7 +30,7 @@ setup(
     description='Various special Cloudify types implementation.',
     install_requires=[
         'cloudify-common==5.3.0.dev1',
-        'requests==2.21.0',
-        'PyYAML==5.4.1'
+        'requests>=2.25.0,<3.0.0',
+        'PyYAML==5.4.1',
     ]
 )


### PR DESCRIPTION
this is the same version as in cloudify-common.
Otherwise, we get a lot of version conflicts, eg. when running
the ctx executable in mgmtworker (`/opt/mgmtworker/env/bin/ctx`)