### PR TITLE
node.plugins is a list, not a dict

### DIFF
--- a/rest-service/manager_rest/deployment_update/handlers.py
+++ b/rest-service/manager_rest/deployment_update/handlers.py
@@ -497,8 +497,8 @@ class PluginHandler(ModifiableEntityHandlerBase):
         node = get_node(ctx.deployment_id, ctx.raw_node_id)
 
         # Can be either node.plugins or node.plugins_to_install
-        plugins_dict = getattr(node, ctx.plugin_key, {})
-        plugins = deepcopy(plugins_dict)
+        plugins = getattr(node, ctx.plugin_key, [])
+        plugins = deepcopy(plugins)
         plugins = mutate_func(ctx, plugins, node, return_dict)
 
         current_entities[ctx.raw_node_id][ctx.plugin_key] = plugins

--- a/rest-service/manager_rest/rest/resources_v3_1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/nodes.py
@@ -50,7 +50,7 @@ class Nodes(v3_Nodes):
             host_id=raw_node.get('host_id'),
             properties=raw_node.get('properties') or {},
             operations=raw_node.get('operations') or {},
-            plugins=raw_node.get('plugins') or {},
+            plugins=raw_node.get('plugins') or [],
             plugins_to_install=raw_node.get('plugins_to_install'),
             relationships=self._prepare_node_relationships(raw_node)
         )


### PR DESCRIPTION
default to the empty list, not the empty dict

Also rename the variable in dep-up. It's obvious that it's not a dict
there, because we immediately do .append and .remove on it.

Also change the getattr default in dep-up: I think it's actually
never used for .plugins, but might be for plugins_to_install

This fixes the inte-tests in test_deployment_update_misc.py