### PR TITLE
RD-2018 Update blueprint statuses in snapshot restore

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/constants.py
+++ b/workflows/cloudify_system_workflows/snapshots/constants.py
@@ -68,6 +68,7 @@ V_4_4_0 = ManagerVersion('4.4.0')
 V_4_5_5 = ManagerVersion('4.5.5')
 V_4_6_0 = ManagerVersion('4.6.0')
 V_5_0_5 = ManagerVersion('5.0.5')
+V_5_2_0 = ManagerVersion('5.2.0')
 V_5_3_0 = ManagerVersion('5.3.0')
 
 

--- a/workflows/cloudify_system_workflows/snapshots/populate_blueprint_statuses.py
+++ b/workflows/cloudify_system_workflows/snapshots/populate_blueprint_statuses.py
@@ -1,0 +1,25 @@
+import os
+
+from manager_rest import config
+from manager_rest.storage import models, get_storage_manager
+from manager_rest.flask_utils import setup_flask_app
+from manager_rest.constants import SECURITY_FILE_LOCATION
+
+from cloudify.models_states import BlueprintUploadState
+
+os.environ['MANAGER_REST_CONFIG_PATH'] = '/opt/manager/cloudify-rest.conf'
+os.environ['MANAGER_REST_SECURITY_CONFIG_PATH'] = SECURITY_FILE_LOCATION
+
+
+def _populate_blueprint_statuses():
+    sm = get_storage_manager()
+    blueprints = sm.list(models.Blueprint, get_all_results=True)
+    for blueprint in blueprints:
+        blueprint.state = BlueprintUploadState.UPLOADED
+        sm.update(blueprint)
+
+
+if __name__ == '__main__':
+    with setup_flask_app().app_context():
+        config.instance.load_configuration()
+        _populate_blueprint_statuses()

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -55,6 +55,7 @@ from .constants import (
     V_4_4_0,
     V_4_6_0,
     V_5_0_5,
+    V_5_2_0,
     V_5_3_0,
     SECURITY_FILE_LOCATION,
     SECURITY_FILENAME,
@@ -152,6 +153,7 @@ class SnapshotRestore(object):
                 self._restore_scheduled_executions()
                 self._restore_inter_deployment_dependencies()
                 self._update_roles_and_permissions()
+                self._update_blueprint_statuses()
                 self._update_deployment_statuses()
                 self._update_node_instance_indices()
                 self._set_default_user_profile_flags()
@@ -246,6 +248,17 @@ class SnapshotRestore(object):
         ctx.logger.info('Updating roles and permissions')
         if os.path.exists(REST_AUTHORIZATION_CONFIG_PATH):
             utils.run(['/opt/manager/scripts/load_permissions.py'])
+
+    def _update_blueprint_statuses(self):
+        ctx.logger.info('Updating blueprint statuses.')
+        if self._snapshot_version < V_5_2_0:
+            dir_path = os.path.dirname(os.path.realpath(__file__))
+            scrip_path = os.path.join(
+                dir_path,
+                'populate_blueprint_statuses.py'
+            )
+            command = [MANAGER_PYTHON, scrip_path, self._tempdir]
+            utils.run(command)
 
     def _update_deployment_statuses(self):
         ctx.logger.info('Updating deployment statuses.')


### PR DESCRIPTION
This solves bugs related to blueprints restored from versions prior to 5.2 having no status