### PR TITLE
RD-1418 Add _execution_group_fk to logs and events tables

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
@@ -37,21 +37,19 @@ def _add_execution_group_fk():
         ['_execution_group_fk'],
         unique=False
     )
-    with op.batch_alter_table(
+    op.create_foreign_key(
+        op.f('events__execution_group_fk_fkey'),
         'events',
-        table_args=[sa.CheckConstraint(
-            '(_execution_fk IS NOT NULL) != (_execution_group_fk IS NOT NULL)',
-            name='events__one_fk_not_null'
-        )]
-    ) as batch_op:
-        batch_op.create_foreign_key(
-            op.f('events__execution_group_fk_fkey'),
-            'events',
-            'execution_groups',
-            ['_execution_group_fk'],
-            ['_storage_id'],
-            ondelete='CASCADE'
-        )
+        'execution_groups',
+        ['_execution_group_fk'],
+        ['_storage_id'],
+        ondelete='CASCADE'
+    )
+    op.create_check_constraint(
+        'events__one_fk_not_null',
+        'events',
+        '(_execution_fk IS NOT NULL) != (_execution_group_fk IS NOT NULL)'
+    )
 
     op.add_column(
         'logs',
@@ -69,21 +67,19 @@ def _add_execution_group_fk():
         ['_execution_group_fk'],
         unique=False
     )
-    with op.batch_alter_table(
+    op.create_foreign_key(
+        op.f('logs__execution_group_fk_fkey'),
         'logs',
-        table_args=[sa.CheckConstraint(
-            '(_execution_fk IS NOT NULL) != (_execution_group_fk IS NOT NULL)',
-            name='logs__one_fk_not_null'
-        )]
-    ) as batch_op:
-        batch_op.create_foreign_key(
-            op.f('logs__execution_group_fk_fkey'),
-            'logs',
-            'execution_groups',
-            ['_execution_group_fk'],
-            ['_storage_id'],
-            ondelete='CASCADE'
-        )
+        'execution_groups',
+        ['_execution_group_fk'],
+        ['_storage_id'],
+        ondelete='CASCADE'
+    )
+    op.create_check_constraint(
+        'logs__one_fk_not_null',
+        'logs',
+        '(_execution_fk IS NOT NULL) != (_execution_group_fk IS NOT NULL)'
+    )
 
 
 def downgrade():

--- a/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
@@ -1,7 +1,5 @@
 """5_3 to 6_0
 
-- Add _execution_group_fk to the events and logs tables
-
 Revision ID: b92770a7b6ca
 Revises: 396303c07e35
 Create Date: 2021-04-12 09:33:44.399254
@@ -23,8 +21,6 @@ def upgrade():
 
 
 def _add_execution_group_fk():
-    # * add _execution_group_fk to the logs and events tables,
-    # * make _execution_fk in these tables nullable,
     op.add_column(
         'events',
         sa.Column('_execution_group_fk', sa.Integer(), nullable=True)
@@ -80,8 +76,6 @@ def downgrade():
 
 
 def _drop_execution_group_fk():
-    # * drop _execution_group_fk from the logs and events tables,
-    # * make _execution_fk in these tables not nullable,
     op.drop_constraint(
         op.f('logs__execution_group_fk_fkey'),
         'logs',

--- a/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
@@ -28,7 +28,7 @@ def _add_execution_group_fk():
     op.alter_column(
         'events',
         '_execution_fk',
-        existing_type=sa.INTEGER(),
+        existing_type=sa.Integer(),
         nullable=True
     )
     op.create_index(
@@ -43,7 +43,7 @@ def _add_execution_group_fk():
         'execution_groups',
         ['_execution_group_fk'],
         ['_storage_id'],
-        ondelete='CASCADE'
+        ondelete='CASCADE',
     )
     op.create_check_constraint(
         'events__one_fk_not_null',
@@ -58,7 +58,7 @@ def _add_execution_group_fk():
     op.alter_column(
         'logs',
         '_execution_fk',
-        existing_type=sa.INTEGER(),
+        existing_type=sa.Integer(),
         nullable=True
     )
     op.create_index(
@@ -104,7 +104,7 @@ def _drop_execution_group_fk():
     op.alter_column(
         'logs',
         '_execution_fk',
-        existing_type=sa.INTEGER(),
+        existing_type=sa.Integer(),
         nullable=False
     )
     op.drop_column(
@@ -129,7 +129,7 @@ def _drop_execution_group_fk():
     op.alter_column(
         'events',
         '_execution_fk',
-        existing_type=sa.INTEGER(),
+        existing_type=sa.Integer(),
         nullable=False
     )
     op.drop_column(

--- a/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
@@ -1,0 +1,122 @@
+"""5_3 to 6_0
+
+- Add _execution_group_fk to the events and logs tables
+
+Revision ID: b92770a7b6ca
+Revises: 396303c07e35
+Create Date: 2021-04-12 09:33:44.399254
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b92770a7b6ca'
+down_revision = '396303c07e35'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    _add_execution_group_fk()
+
+
+def _add_execution_group_fk():
+    # * add _execution_group_fk to the logs and events tables,
+    # * make _execution_fk in these tables nullable,
+    op.add_column(
+        'events',
+        sa.Column('_execution_group_fk', sa.Integer(), nullable=True)
+    )
+    op.alter_column(
+        'events',
+        '_execution_fk',
+        existing_type=sa.INTEGER(),
+        nullable=True
+    )
+    op.create_index(
+        op.f('events__execution_group_fk_idx'),
+        'events',
+        ['_execution_group_fk'],
+        unique=False
+    )
+    op.create_foreign_key(
+        op.f('events__execution_group_fk_fkey'),
+        'events',
+        'execution_groups',
+        ['_execution_group_fk'],
+        ['_storage_id'],
+        ondelete='CASCADE'
+    )
+    op.add_column(
+        'logs',
+        sa.Column('_execution_group_fk', sa.Integer(), nullable=True)
+    )
+    op.alter_column(
+        'logs',
+        '_execution_fk',
+        existing_type=sa.INTEGER(),
+        nullable=True
+    )
+    op.create_index(
+        op.f('logs__execution_group_fk_idx'),
+        'logs',
+        ['_execution_group_fk'],
+        unique=False
+    )
+    op.create_foreign_key(
+        op.f('logs__execution_group_fk_fkey'),
+        'logs',
+        'execution_groups',
+        ['_execution_group_fk'],
+        ['_storage_id'],
+        ondelete='CASCADE'
+    )
+
+
+def downgrade():
+    _drop_execution_group_fk()
+
+
+def _drop_execution_group_fk():
+    # * drop _execution_group_fk from the logs and events tables,
+    # * make _execution_fk in these tables not nullable,
+    op.drop_constraint(
+        op.f('logs__execution_group_fk_fkey'),
+        'logs',
+        type_='foreignkey'
+    )
+    op.drop_index(
+        op.f('logs__execution_group_fk_idx'),
+        table_name='logs'
+    )
+    op.alter_column(
+        'logs',
+        '_execution_fk',
+        existing_type=sa.INTEGER(),
+        nullable=False
+    )
+    op.drop_column(
+        'logs',
+        '_execution_group_fk'
+    )
+    op.drop_constraint(
+        op.f('events__execution_group_fk_fkey'),
+        'events',
+        type_='foreignkey'
+    )
+    op.drop_index(
+        op.f('events__execution_group_fk_idx'),
+        table_name='events'
+    )
+    op.alter_column(
+        'events',
+        '_execution_fk',
+        existing_type=sa.INTEGER(),
+        nullable=False
+    )
+    op.drop_column(
+        'events',
+        '_execution_group_fk'
+    )

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1291,6 +1291,13 @@ class Event(SQLResourceBase):
 
     execution_id = association_proxy('execution', 'id')
 
+    @declared_attr
+    def execution_group(cls):
+        return one_to_many_relationship(cls, ExecutionGroup,
+                                        cls._execution_group_fk)
+
+    execution_group_id = association_proxy('execution_group', 'id')
+
     def set_execution(self, execution):
         self._set_parent(execution)
         self.execution = execution
@@ -1339,6 +1346,13 @@ class Log(SQLResourceBase):
         return one_to_many_relationship(cls, Execution, cls._execution_fk)
 
     execution_id = association_proxy('execution', 'id')
+
+    @declared_attr
+    def execution_group(cls):
+        return one_to_many_relationship(cls, ExecutionGroup,
+                                        cls._execution_group_fk)
+
+    execution_group_id = association_proxy('execution_group', 'id')
 
     def set_execution(self, execution):
         self._set_parent(execution)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -27,6 +27,7 @@ from sqlalchemy import func, select, table, column
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import validates
+from sqlalchemy.sql.schema import CheckConstraint
 
 from cloudify.constants import MGMTWORKER_QUEUE
 from cloudify.models_states import (AgentState,
@@ -1255,6 +1256,12 @@ class Event(SQLResourceBase):
             'events_node_id_visibility_idx',
             'node_id', 'visibility'
         ),
+        CheckConstraint(
+            '(_execution_fk IS NOT NULL OR _execution_group_fk IS NOT NULL) '
+            'AND NOT '
+            '(_execution_fk IS NOT NULL AND _execution_group_fk IS NOT NULL)',
+            name='events__one_not_null_fk'
+        ),
     )
     timestamp = db.Column(
         UTCDateTime,
@@ -1272,7 +1279,9 @@ class Event(SQLResourceBase):
     target_id = db.Column(db.Text)
     error_causes = db.Column(JSONString)
 
-    _execution_fk = foreign_key(Execution._storage_id)
+    _execution_fk = foreign_key(Execution._storage_id, nullable=True)
+    _execution_group_fk = foreign_key(ExecutionGroup._storage_id,
+                                      nullable=True)
 
     @classmethod
     def default_sort_column(cls):
@@ -1297,6 +1306,12 @@ class Log(SQLResourceBase):
             'logs_node_id_visibility_execution_fk_idx',
             'node_id', 'visibility', '_execution_fk'
         ),
+        CheckConstraint(
+            '(_execution_fk IS NOT NULL OR _execution_group_fk IS NOT NULL) '
+            'AND NOT '
+            '(_execution_fk IS NOT NULL AND _execution_group_fk IS NOT NULL)',
+            name='events__one_not_null_fk'
+        ),
     )
 
     timestamp = db.Column(
@@ -1315,7 +1330,9 @@ class Log(SQLResourceBase):
     source_id = db.Column(db.Text)
     target_id = db.Column(db.Text)
 
-    _execution_fk = foreign_key(Execution._storage_id)
+    _execution_fk = foreign_key(Execution._storage_id, nullable=True)
+    _execution_group_fk = foreign_key(ExecutionGroup._storage_id,
+                                      nullable=True)
 
     @classmethod
     def default_sort_column(cls):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1257,10 +1257,8 @@ class Event(SQLResourceBase):
             'node_id', 'visibility'
         ),
         CheckConstraint(
-            '(_execution_fk IS NOT NULL OR _execution_group_fk IS NOT NULL) '
-            'AND NOT '
-            '(_execution_fk IS NOT NULL AND _execution_group_fk IS NOT NULL)',
-            name='events__one_not_null_fk'
+            '(_execution_fk IS NOT NULL) != (_execution_group_fk IS NOT NULL)',
+            name='events__one_fk_not_null'
         ),
     )
     timestamp = db.Column(
@@ -1307,10 +1305,8 @@ class Log(SQLResourceBase):
             'node_id', 'visibility', '_execution_fk'
         ),
         CheckConstraint(
-            '(_execution_fk IS NOT NULL OR _execution_group_fk IS NOT NULL) '
-            'AND NOT '
-            '(_execution_fk IS NOT NULL AND _execution_group_fk IS NOT NULL)',
-            name='events__one_not_null_fk'
+            '(_execution_fk IS NOT NULL) != (_execution_group_fk IS NOT NULL)',
+            name='logs__one_fk_not_null'
         ),
     )
 


### PR DESCRIPTION
Plus make _execution_fk nullable with additional constraint that exactly
one of _execution_fk and _execution_group_fk must not be null for any
given record in these tables.