### PR TITLE
Return sub statuses for direct deployment rather than the whole tree …

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -576,7 +576,7 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
                 )
         return _sub_services_status, _sub_environments_status
 
-    def evaluate_deployment_status(self):
+    def evaluate_deployment_status(self, exclude_sub_deployments=False):
         """
         Evaluate the overall deployment status based on installation status
         and latest execution object
@@ -598,7 +598,8 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
             deployment_status = DeploymentState.GOOD
         else:
             deployment_status = DeploymentState.IN_PROGRESS
-        if not (self.sub_services_status or self.sub_environments_status):
+        has_sub_sts = self.sub_services_status or self.sub_environments_status
+        if not has_sub_sts or exclude_sub_deployments:
             return deployment_status
 
         # Check whether or not deployment has services or environments


### PR DESCRIPTION
Re-evaluate sub deployment statuses when we want to display statuses and counters for directed connected deployment by overriding the value stored at DB level instead of the whole graph of depployments 