### PR TITLE
create_deployment: remove pointless `labels`

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1395,8 +1395,7 @@ class ResourceManager(object):
                           visibility,
                           skip_plugins_validation=False,
                           site=None,
-                          runtime_only_evaluation=False,
-                          labels=None,):
+                          runtime_only_evaluation=False):
         verify_blueprint_uploaded_state(blueprint)
         plan = blueprint.plan
         visibility = self.get_resource_visibility(models.Deployment,
@@ -1408,17 +1407,6 @@ class ResourceManager(object):
             raise manager_exceptions.ForbiddenError(
                 f"Can't create global deployment {deployment_id} because "
                 f"blueprint {blueprint.id} is not global"
-            )
-        parents_labels = self.get_deployment_parents_from_labels(
-            labels
-        )
-        if parents_labels:
-            dep_graph = RecursiveDeploymentLabelsDependencies(self.sm)
-            dep_graph.create_dependencies_graph()
-            self.verify_attaching_deployment_to_parents(
-                dep_graph,
-                parents_labels,
-                deployment_id
             )
         #  validate plugins exists on manager when
         #  skip_plugins_validation is False

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -226,7 +226,6 @@ class DeploymentsId(resources_v1.DeploymentsId):
             site=site,
             runtime_only_evaluation=request_dict.get(
                 'runtime_only_evaluation', False),
-            labels=labels,
         )
         try:
             rm.execute_workflow(deployment.make_create_environment_execution(


### PR DESCRIPTION
passing labels here is incorrect, because they're not evaluated yet,
wrt. intrinsic functions. It is create-deployment-environment who
sets labels.