### PR TITLE
RD-2046 Drop a query to avoid deadlocks

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -998,7 +998,7 @@ class ResourceManager(object):
     def _check_for_active_executions(self, execution, queue):
         running = self.list_executions(
             filters={
-                'deployment_id': execution.deployment_id,
+                '_deployment_fk': execution._deployment_fk,
                 'id': lambda col: col != execution.id,
                 'status':
                 ExecutionState.ACTIVE_STATES + [ExecutionState.QUEUED],

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -265,33 +265,22 @@ class ResourceManager(object):
             return
 
         if finished_execution.deployment:
-            deployment_id = finished_execution.deployment.id
-            queued_executions = self.sm.list(
-                models.Execution,
-                filters={
-                    'status': ExecutionState.QUEUED_STATE,
-                    'is_system_workflow': False
-                },
-                sort=OrderedDict([
-                    ('_deployment_fk', lambda col: col != finished_execution._deployment_fk),
-                    ('created_at', 'asc'),
-                ]),
-                get_all_results=True,
-                all_tenants=True,
-                locking=True,
-            ).items
-        else:
-            queued_executions = self.sm.list(
-                models.Execution,
-                filters={
-                    'status': ExecutionState.QUEUED_STATE,
-                    'is_system_workflow': False,
-                },
-                sort=sort_by,
-                get_all_results=True,
-                all_tenants=True,
-                locking=True,
-            ).items
+            # same deployment first
+            sort_by = OrderedDict([(
+                '_deployment_fk',
+                lambda col: col != finished_execution._deployment_fk
+            )], **sort_by)
+        queued_executions = self.sm.list(
+            models.Execution,
+            filters={
+                'status': ExecutionState.QUEUED_STATE,
+                'is_system_workflow': False
+            },
+            sort=sort_by,
+            get_all_results=True,
+            all_tenants=True,
+            locking=True,
+        ).items
 
         # {deployment: whether it can run executions}
         busy_deployments = {}

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1000,7 +1000,8 @@ class ResourceManager(object):
             filters={
                 'deployment_id': execution.deployment_id,
                 'id': lambda col: col != execution.id,
-                'status': ExecutionState.ACTIVE_STATES,
+                'status':
+                ExecutionState.ACTIVE_STATES + [ExecutionState.QUEUED],
             },
             is_include_system_workflows=True
         ).items

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -138,7 +138,8 @@ class SQLStorageManager(object):
 
         :param query: Base SQL query
         :param sort: An optional dictionary where keys are column names to
-        sort by, and values are the order (asc/desc)
+            sort by, and values are the order (asc/desc), or callables that
+            return join conditions
         :return: An SQLAlchemy AppenderQuery object
         """
         if sort or distinct:
@@ -147,7 +148,10 @@ class SQLStorageManager(object):
             for column, order in sort.items():
                 if order == 'desc':
                     column = column.desc()
-                query = query.order_by(column)
+                if callable(order):
+                    query = query.order_by(order(column))
+                else:
+                    query = query.order_by(column)
         else:
             default_sort = model_class.default_sort_column()
             if default_sort:

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -139,7 +139,7 @@ class SQLStorageManager(object):
         :param query: Base SQL query
         :param sort: An optional dictionary where keys are column names to
             sort by, and values are the order (asc/desc), or callables that
-            return join conditions
+            return sort conditions
         :return: An SQLAlchemy AppenderQuery object
         """
         if sort or distinct:


### PR DESCRIPTION
For the dequeueing, and "same-deployment-first", we can avoid having
to do two (locking) queries, because we can just get the sorting done
in a single query.

Additionally, make sure we queue, if there are already queued executions
(FIFO semantics for executions).

See commit messages too.