### PR TITLE
RD-1969 Get rid of events.id and logs.id columns

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
@@ -19,11 +19,39 @@ depends_on = None
 def upgrade():
     _add_execution_group_fk()
     _add_new_execution_columns()
+    _drop_events_id()
+    _drop_logs_id()
 
 
 def downgrade():
+    _create_logs_id()
+    _create_events_id()
     _drop_execution_group_fk()
     _drop_new_execution_columns()
+
+
+def _drop_events_id():
+    op.drop_index('events_id_idx', table_name='events')
+    op.drop_column('events', 'id')
+
+
+def _drop_logs_id():
+    op.drop_index('logs_id_idx', table_name='logs')
+    op.drop_column('logs', 'id')
+
+
+def _create_logs_id():
+    op.add_column('logs', sa.Column('id', sa.Text(),
+                  autoincrement=False, nullable=True))
+    op.create_index('logs_id_idx', 'logs', ['id'],
+                    unique=False)
+
+
+def _create_events_id():
+    op.add_column('events', sa.Column('id', sa.Text(),
+                  autoincrement=False, nullable=True))
+    op.create_index('events_id_idx', 'events', ['id'],
+                    unique=False)
 
 
 def _add_new_execution_columns():

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -325,7 +325,6 @@ class Events(SecuredResource):
 
         query = (
             db.session.query(
-                select_column('id'),
                 select_column('_storage_id'),
                 select_column('timestamp'),
                 select_column('reported_timestamp'),

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1265,7 +1265,9 @@ class Event(SQLResourceBase):
             name='events__one_fk_not_null'
         ),
     )
-    id = db.Column(db.Text, index=True, default=lambda: str(uuid.uuid4()))
+    is_id_unique = False
+
+    id = None
     timestamp = db.Column(
         UTCDateTime,
         default=datetime.utcnow,
@@ -1321,8 +1323,9 @@ class Log(SQLResourceBase):
             name='logs__one_fk_not_null'
         ),
     )
+    is_id_unique = False
 
-    id = db.Column(db.Text, index=True, default=lambda: str(uuid.uuid4()))
+    id = None
     timestamp = db.Column(
         UTCDateTime,
         default=datetime.utcnow,

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1267,7 +1267,7 @@ class Event(SQLResourceBase):
     )
     is_id_unique = False
 
-    id = None
+    id = None  # this is just to override the parent class attribute
     timestamp = db.Column(
         UTCDateTime,
         default=datetime.utcnow,
@@ -1325,7 +1325,7 @@ class Log(SQLResourceBase):
     )
     is_id_unique = False
 
-    id = None
+    id = None  # this is just to override the parent class attribute
     timestamp = db.Column(
         UTCDateTime,
         default=datetime.utcnow,


### PR DESCRIPTION
Let's get rid of `events.id` and `logs.id` which were always empty anyway.