### PR TITLE
RD-2056 Reevaluate parameters when starting executions

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1024,8 +1024,13 @@ class ResourceManager(object):
             filters={
                 '_deployment_fk': execution._deployment_fk,
                 'id': lambda col: col != execution.id,
-                'status':
-                ExecutionState.ACTIVE_STATES + [ExecutionState.QUEUED],
+                'status': lambda col: sql_or(
+                    col.in_(ExecutionState.ACTIVE_STATES),
+                    sql_and(
+                        col == ExecutionState.QUEUED,
+                        models.Execution.created_at < execution.created_at
+                    )
+                )
             },
             is_include_system_workflows=True
         ).items

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -22,13 +22,13 @@ import itertools
 import typing
 from copy import deepcopy
 from datetime import datetime
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 
 from flask import current_app
 from flask_security import current_user
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.attributes import flag_modified
-from sqlalchemy import or_ as sql_or, and_ as sql_and, exists
+from sqlalchemy import or_ as sql_or, and_ as sql_and
 
 from cloudify.constants import TERMINATED_STATES as TERMINATED_TASK_STATES
 from cloudify.cryptography_utils import encrypt
@@ -280,7 +280,7 @@ class ResourceManager(object):
                 # no active executions
                 ~models.Execution.query.filter(
                     models.Execution._deployment_fk == \
-                        executions._deployment_fk,
+                    executions._deployment_fk,
                     models.Execution.status.in_(ExecutionState.ACTIVE_STATES)
                 ).exists()
             )


### PR DESCRIPTION
in execute_workflow, make sure to refetch & reevaluate the deployment
and parameters.
This happens in the same transaction as checking if create-dep-env finished.

Otherwise, there's a race:
1. The deployment is fetched
2. We check if create-env finished (in check-for-active-executions)
3. Even if we reevaluated the params, without refetching the deployment,
  the deployment might've been only updated after 1.

Also, check out the commit messages