### PR TITLE
RD-1816 Deployment update workflow

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -976,16 +976,17 @@ class Execution(CreatedAtMixin, SQLResourceBase):
     def get_workflow(self, deployment=None, workflow_id=None):
         deployment = deployment or self.deployment
         workflow_id = workflow_id or self.workflow_id
+
+        if deployment and deployment.workflows\
+                and workflow_id in deployment.workflows:
+            return deployment.workflows[workflow_id]
         system_task_name = self._system_workflow_task_name(workflow_id)
         if system_task_name:
             self.allow_custom_parameters = True
             return {'operation': system_task_name}
-        try:
-            return deployment.workflows[workflow_id]
-        except KeyError:
-            raise manager_exceptions.NonexistentWorkflowError(
-                f'Workflow {workflow_id} does not exist in the '
-                f'deployment {deployment.id}') from None
+        raise manager_exceptions.NonexistentWorkflowError(
+            f'Workflow {workflow_id} does not exist in the '
+            f'deployment {deployment.id}')
 
     def merge_workflow_parameters(self, parameters, deployment, workflow_id):
         if not deployment.workflows:

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -967,7 +967,10 @@ class Execution(CreatedAtMixin, SQLResourceBase):
             'delete_deployment_environment':
                 'cloudify_system_workflows.deployment_environment.delete',
             'update_plugin': 'cloudify_system_workflows.plugins.update',
-            'upload_blueprint': 'cloudify_system_workflows.blueprint.upload'
+            'upload_blueprint': 'cloudify_system_workflows.blueprint.upload',
+            'update_deployment':
+            'cloudify_system_workflows.deployment_environment.'
+            'update_deployment'
         }.get(wf_id)
 
     def get_workflow(self, deployment=None, workflow_id=None):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -969,8 +969,8 @@ class Execution(CreatedAtMixin, SQLResourceBase):
             'update_plugin': 'cloudify_system_workflows.plugins.update',
             'upload_blueprint': 'cloudify_system_workflows.blueprint.upload',
             'csys_update_deployment':
-            'cloudify_system_workflows.deployment_environment.'
-            'update_deployment'
+                'cloudify_system_workflows.deployment_environment.'
+                'update_deployment'
         }.get(wf_id)
 
     def get_workflow(self, deployment=None, workflow_id=None):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -968,7 +968,7 @@ class Execution(CreatedAtMixin, SQLResourceBase):
                 'cloudify_system_workflows.deployment_environment.delete',
             'update_plugin': 'cloudify_system_workflows.plugins.update',
             'upload_blueprint': 'cloudify_system_workflows.blueprint.upload',
-            'update_deployment':
+            'csys_update_deployment':
             'cloudify_system_workflows.deployment_environment.'
             'update_deployment'
         }.get(wf_id)

--- a/workflows/cloudify_system_workflows/deployment_environment.py
+++ b/workflows/cloudify_system_workflows/deployment_environment.py
@@ -271,3 +271,19 @@ def _get_external_clients(nodes: list, manager_ips: list):
 
     return external_client, client_config, \
         target_deployment.get('id') if target_deployment else None
+
+
+@workflow
+def update_deployment(ctx, **kwargs):
+    """Run an update on this deployment. Any kwargs are passed to the update.
+
+    This exposes deployment update creation as a workflow on the deployment.
+    """
+    client = get_rest_client(tenant=ctx.tenant_name)
+    deployment_update = \
+        client.deployment_updates.update_with_existing_blueprint(
+            deployment_id=ctx.deployment.id,
+            **kwargs
+        )
+    ctx.logger.info('Started update of deployment %s: %s',
+                    ctx.deployment.id, deployment_update.id)


### PR DESCRIPTION
For making the dep-update async so that it can be called for a
deployment group: I give up. It's not possible to refactor it enough
in this timeframe.

Instead, I'm going to cheat!

Add a new builtin workflow that just creates a deployment update.
THAT workflow can well be run for a group (as a bonus, it can be also
used for scheduling and whatever else).