### PR TITLE
RD-2110 Lock tables explicitly up front

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/postgres.py
+++ b/workflows/cloudify_system_workflows/snapshots/postgres.py
@@ -548,8 +548,12 @@ class Postgres(object):
         all_tables = [table for table in all_tables if
                       table not in self._TABLES_TO_KEEP]
 
-        queries = [self._TRUNCATE_QUERY.format(table) for table in all_tables
-                   if table != 'users'] + ['DELETE FROM users;']
+        queries = (
+                ['LOCK TABLE users, maintenance_mode;'] +
+                [self._TRUNCATE_QUERY.format(table) for table in all_tables
+                 if table != 'users'] +
+                ['DELETE FROM users;']
+        )
         if preserve_defaults:
             self._add_preserve_defaults_queries(queries)
         return queries


### PR DESCRIPTION
This fixes the deadlock issue in snapshot restore.
Ported from https://github.com/cloudify-cosmo/cloudify-manager/pull/2933/commits/ea36f0777be0b1f52dfc7e604ea562cc2135b532