### PR TITLE
RD-2036 Label each deployment as service

### DIFF
--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -173,7 +173,8 @@ class BaseServerTestCase(unittest.TestCase):
     def assert_metadata_filtered(self, resource_list, filtered_cnt):
         self.assertEqual(resource_list.metadata.get('filtered'), filtered_cnt)
 
-    def assert_resource_labels(self, resource_labels, compared_labels):
+    def assert_resource_labels(self, resource_labels, compared_labels,
+                               verify_service_label=True):
         simplified_labels = set()
         compared_labels_set = set()
 
@@ -183,6 +184,8 @@ class BaseServerTestCase(unittest.TestCase):
         for compared_label in compared_labels:
             [(key, value)] = compared_label.items()
             compared_labels_set.add((key, value))
+        if verify_service_label:
+            compared_labels_set.add(('csys-obj-type', 'service'))
 
         self.assertEqual(simplified_labels, compared_labels_set)
 

--- a/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
@@ -216,7 +216,7 @@ class DeploymentLabelsDependenciesTest(BaseServerTestCase):
         deployment_2 = self.client.deployments.get('deployment_2')
         self.assertEqual(deployment_1.sub_services_count, 1)
         self.assertEqual(deployment_2.sub_services_count, 0)
-        self.assertEqual(len(deployment_1.labels), 0)
+        self.assertEqual(len(deployment_1.labels), 1)
 
     def test_number_of_direct_services_deployed_inside_environment(self):
         self.put_deployment(deployment_id='env',

--- a/workflows/cloudify_system_workflows/deployment_environment.py
+++ b/workflows/cloudify_system_workflows/deployment_environment.py
@@ -82,6 +82,7 @@ def _get_deployment_labels(new_labels, plan_labels):
     for name, label_spec in plan_labels.items():
         labels |= {(name.lower(), value) for value in
                    label_spec.get('values', [])}
+    labels.add(('csys-obj-type', 'service'))
     return [{k: v} for k, v in labels]
 
 


### PR DESCRIPTION
Adding the label `csys-obj-type: service` to every deployment on creation.

Associated PR: https://github.com/cloudify-cosmo/cloudify-premium/pull/764