### PR TITLE
RD-1165 Storage backend for get_group_capability

### DIFF
--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_group_capabilities.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_group_capabilities.yaml
@@ -1,0 +1,109 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - cloudify/types/types.yaml
+
+inputs:
+  inp1:
+    default: a
+  inp2:
+    default: b
+  parent_group_id:
+    default: some-group-id
+
+
+node_types:
+  test_type:
+    derived_from: cloudify.nodes.Root
+    properties:
+      value: {}
+
+node_templates:
+  node1:
+    type: test_type
+    properties:
+      value:
+        cap1:
+          get_group_capability:
+            - { get_input: parent_group_id }
+            - cap1
+        cap2:
+          get_group_capability:
+            - { get_input: parent_group_id }
+            - cap2
+        both_caps:
+          get_group_capability:
+            - { get_input: parent_group_id }
+            - [cap1, cap2]
+        cap1_by_id:
+          get_group_capability:
+            - { get_input: parent_group_id }
+            - deployment_id:cap1
+        complex_cap:
+          get_group_capability:
+            - { get_input: parent_group_id }
+            - complex_capability
+        complex_cap_indexed:
+          get_group_capability:
+            - { get_input: parent_group_id }
+            - complex_capability
+            - level_1
+            - 1
+        complex_cap_indexed_by_id:
+          get_group_capability:
+            - { get_input: parent_group_id }
+            - deployment_id:complex_capability
+            - level_1
+            - 1
+
+capabilities:
+  cap1:
+    value: { get_input: inp1 }
+  cap2:
+    value: { get_input: inp2 }
+  complex_capability:
+    value:
+      level_1:
+        - { get_input: inp1 }
+        - { get_input: inp2 }
+
+outputs:
+  cap1:
+    value:
+      get_group_capability:
+        - { get_input: parent_group_id }
+        - cap1
+  cap2:
+    value:
+      get_group_capability:
+        - { get_input: parent_group_id }
+        - cap2
+  both_caps:
+    value:
+      get_group_capability:
+        - { get_input: parent_group_id }
+        - [cap1, cap2]
+  cap1_by_id:
+    value:
+      get_group_capability:
+        - { get_input: parent_group_id }
+        - deployment_id:cap1
+  complex_cap:
+    value:
+      get_group_capability:
+        - { get_input: parent_group_id }
+        - complex_capability
+  complex_cap_indexed:
+    value:
+      get_group_capability:
+        - { get_input: parent_group_id }
+        - complex_capability
+        - level_1
+        - 1
+  complex_cap_indexed_by_id:
+    value:
+      get_group_capability:
+        - { get_input: parent_group_id }
+        - deployment_id:complex_capability
+        - level_1
+        - 1

--- a/rest-service/manager_rest/test/mock_blueprint/blueprint_with_group_capabilities_2.yaml
+++ b/rest-service/manager_rest/test/mock_blueprint/blueprint_with_group_capabilities_2.yaml
@@ -1,0 +1,21 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - cloudify/types/types.yaml
+
+inputs:
+  inp1:
+    default: a
+
+node_types:
+  test_type:
+    derived_from: cloudify.nodes.Root
+
+node_templates:
+  node1:
+    type: test_type
+
+
+capabilities:
+  cap1:
+    value: { get_input: inp1 }


### PR DESCRIPTION
This implements the storage logic for `get_group_capability`.

This is the logic part, AKA the interesting part, however it's
all mostly a single function anyway, with like fifty possible
modes of working.

Requires cloudify-cosmo/cloudify-common#752