### PR TITLE
Lock the deployment when updating its attributes

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2443,6 +2443,7 @@ class ResourceManager(object):
         labels_to_delete = self.get_labels_to_delete(resource, new_labels)
         for label in labels_to_delete:
             self.sm.delete(label)
+            resource.labels.remove(label)
 
         self.create_resource_labels(labels_resource_model,
                                     resource,

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2443,7 +2443,8 @@ class ResourceManager(object):
         labels_to_delete = self.get_labels_to_delete(resource, new_labels)
         for label in labels_to_delete:
             self.sm.delete(label)
-            resource.labels.remove(label)
+            if label in resource.labels:
+                resource.labels.remove(label)
 
         self.create_resource_labels(labels_resource_model,
                                     resource,

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -42,6 +42,7 @@ from manager_rest.manager_exceptions import (
 from manager_rest.resource_manager import get_resource_manager
 from manager_rest.maintenance import is_bypass_maintenance_mode
 from manager_rest.dsl_functions import evaluate_deployment_capabilities
+from manager_rest.execution_token import current_execution
 
 from manager_rest.rest.filters_utils import get_filter_rules_from_filter_id
 from manager_rest.rest import (
@@ -172,6 +173,9 @@ class DeploymentsId(resources_v1.DeploymentsId):
 
     def _handle_deployment_labels(self, sm, rm, deployment, raw_labels_list):
         new_labels = rest_utils.get_labels_list(raw_labels_list)
+        if self._is_create_execution(deployment):
+            new_labels = self._add_existing_labels(new_labels)
+
         graph = rest_utils.RecursiveDeploymentLabelsDependencies(sm)
         is_updated = self._update_deployment_counts(rm, graph, deployment,
                                                     new_labels)
@@ -179,6 +183,26 @@ class DeploymentsId(resources_v1.DeploymentsId):
         if is_updated:
             for dep in deployment.deployment_parents:
                 graph.propagate_deployment_statuses(dep)
+
+    def _is_create_execution(self, deployment):
+        """Are we running in deployment's create execution?"""
+        return current_execution and \
+            current_execution == deployment.create_execution
+
+    def _add_existing_labels(self, deployment, new_labels):
+        """Add existing deployment labels to new_labels.
+
+        This is to be run during the set-labels executed as part of
+        create-deployment-environment, so that we don't overwrite labels
+        attached to the deployment (directly or via a group) while
+        create-deployment-environment was running.
+        Instead, the labels attached in the meantime, are considered to be
+        part of the new labels set as well.
+        """
+        old_labels = [(l.key, l.value) for l in deployment.labels]
+        for l in old_labels:
+            if l not in new_labels:
+                new_labels.append(l)
 
     @authorize('deployment_create')
     @rest_decorators.marshal_with(models.Deployment)

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -174,7 +174,7 @@ class DeploymentsId(resources_v1.DeploymentsId):
     def _handle_deployment_labels(self, sm, rm, deployment, raw_labels_list):
         new_labels = rest_utils.get_labels_list(raw_labels_list)
         if self._is_create_execution(deployment):
-            new_labels = self._add_existing_labels(new_labels)
+            self._add_existing_labels(deployment, new_labels)
 
         graph = rest_utils.RecursiveDeploymentLabelsDependencies(sm)
         is_updated = self._update_deployment_counts(rm, graph, deployment,

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -199,10 +199,10 @@ class DeploymentsId(resources_v1.DeploymentsId):
         Instead, the labels attached in the meantime, are considered to be
         part of the new labels set as well.
         """
-        old_labels = [(l.key, l.value) for l in deployment.labels]
-        for l in old_labels:
-            if l not in new_labels:
-                new_labels.append(l)
+        old_labels = [(label.key, label.value) for label in deployment.labels]
+        for label in old_labels:
+            if label not in new_labels:
+                new_labels.append(label)
 
     @authorize('deployment_create')
     @rest_decorators.marshal_with(models.Deployment)

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -33,7 +33,7 @@ from cloudify.models_states import (
     DeploymentState,
 )
 
-from manager_rest.storage import models
+from manager_rest.storage import db, models
 from manager_rest.constants import RESERVED_LABELS, RESERVED_PREFIX
 from manager_rest.dsl_functions import (get_secret_method,
                                         evaluate_intrinsic_functions)
@@ -689,6 +689,7 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
                     target.sub_services_count += total_services
                     target.sub_environments_count += total_environments
                     self.sm.update(target)
+                    db.session.flush()
 
     def decrease_deployment_counts_in_graph(self,
                                             target_ids,
@@ -724,6 +725,7 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
                     if target.sub_environments_count:
                         target.sub_environments_count -= total_environments
                     self.sm.update(target)
+                    db.session.flush()
 
     def update_deployment_counts_after_source_conversion(self,
                                                          source,
@@ -756,6 +758,7 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
             target.sub_services_count += srv_to_update
             target.sub_environments_count += env_to_update
             self.sm.update(target)
+            db.session.flush()
 
     def propagate_deployment_statuses(self, source_id):
         """
@@ -777,6 +780,7 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
                 _target.deployment_status = \
                     _target.evaluate_deployment_status()
                 self.sm.update(_target)
+                db.session.flush()
         queue = deque([source_id] + self.find_recursive_deployments(
             [source_id]
         ))


### PR DESCRIPTION
The deployment update as part of create-dep-env must be locking,
so that concurrent changes are not lost.

See commit messages