### PR TITLE
Migrations: handle labels + group events

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
@@ -8,6 +8,7 @@ Create Date: 2021-04-12 09:33:44.399254
 from alembic import op
 import sqlalchemy as sa
 
+from manager_rest.storage import models
 
 # revision identifiers, used by Alembic.
 revision = 'b92770a7b6ca'
@@ -143,6 +144,11 @@ def _drop_execution_group_fk():
         op.f('logs__execution_group_fk_idx'),
         table_name='logs'
     )
+    op.execute(
+        models.Log.__table__
+        .delete()
+        .where(models.Log.__table__.c._execution_fk.is_(None))
+    )
     op.alter_column(
         'logs',
         '_execution_fk',
@@ -167,6 +173,11 @@ def _drop_execution_group_fk():
     op.drop_index(
         op.f('events__execution_group_fk_idx'),
         table_name='events'
+    )
+    op.execute(
+        models.Event.__table__
+        .delete()
+        .where(models.Event.__table__.c._execution_fk.is_(None))
     )
     op.alter_column(
         'events',


### PR DESCRIPTION
Two separate fixups, see each separately.

This allows migrations to actually run in cases:
- upgrade 5.2→5.3, if the system already has labels (eg. a 5.2 snapshot with deployment labels)
- downgrade 6.0→5.3 if there exist execution group logs/events

This allows downgrading like `/opt/manager/env/bin/alembic downgrade 9d261e90b1f3` (that id = 5.2) to run, and afterwards, `alembic upgrade head`
