### PR TITLE
Use an `UPDATE` query for modifying sub-deployment counts

### DIFF
--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -662,7 +662,7 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
         return results
 
     def _modify_deployment_counts_in_graph(
-            self, target_ids,services_delta, envs_delta):
+            self, target_ids, services_delta, envs_delta):
         if not services_delta and not envs_delta:
             return
         target_group = target_ids + self.find_recursive_deployments(target_ids)

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -661,11 +661,10 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
                         visited[dependency.target_deployment_id] = True
         return results
 
-    def _modify_deployment_counts_in_graph(
-            self, target_ids, services_delta, envs_delta):
+    def _modify_deployment_counts(
+            self, target_group, services_delta, envs_delta):
         if not services_delta and not envs_delta:
             return
-        target_group = target_ids + self.find_recursive_deployments(target_ids)
         dep_table = models.Deployment.__table__
         update_query = (
             dep_table.update()
@@ -701,8 +700,9 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
         :param total_environments: Total number of environments to add
         :rtype int
         """
-        self._modify_deployment_counts_in_graph(
-            target_ids, total_services, total_environments)
+        target_group = target_ids + self.find_recursive_deployments(target_ids)
+        self._modify_deployment_counts(
+            target_group, total_services, total_environments)
 
     def decrease_deployment_counts_in_graph(self,
                                             target_ids,
@@ -721,8 +721,9 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
         :param total_environments: Total number of environments to remove
         :rtype int
         """
-        self._modify_deployment_counts_in_graph(
-            target_ids, -total_services, -total_environments)
+        target_group = target_ids + self.find_recursive_deployments(target_ids)
+        self._modify_deployment_counts(
+            target_group, -total_services, -total_environments)
 
     def update_deployment_counts_after_source_conversion(self,
                                                          source,

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -673,13 +673,13 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
         )
         if services_delta:
             update_query = update_query.values(
-                sub_services_count=
-                dep_table.c.sub_services_count + services_delta,
+                sub_services_count=dep_table.c.sub_services_count
+                + services_delta,
             )
         if envs_delta:
             update_query = update_query.values(
-                sub_environments_count=
-                dep_table.c.sub_environments_count + envs_delta,
+                sub_environments_count=dep_table.c.sub_environments_count
+                + envs_delta,
             )
         db.session.execute(update_query)
 

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -682,6 +682,7 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
                 + envs_delta,
             )
         db.session.execute(update_query)
+        db.session.flush()
 
     def increase_deployment_counts_in_graph(self,
                                             target_ids,

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -747,16 +747,8 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
             srv_to_update = 1
 
         target_group = self.find_recursive_deployments([source.id])
-        for target_id in target_group:
-            target = self.sm.get(
-                models.Deployment,
-                target_id,
-                locking=True
-            )
-            target.sub_services_count += srv_to_update
-            target.sub_environments_count += env_to_update
-            self.sm.update(target)
-            db.session.flush()
+        self._modify_deployment_counts(
+            target_group, srv_to_update, env_to_update)
 
     def propagate_deployment_statuses(self, source_id):
         """


### PR DESCRIPTION
Instead of the `sm.get` + `+=` + `sm.update`, use a single query that
does `UPDATE deps SET deps.count = deps.count + 1`.

No need for multiple queries then, and so no race conditions.