### PR TITLE
Rd 2230 fix integ tests 600

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_executions.py
+++ b/tests/integration_tests/tests/agentless_tests/test_executions.py
@@ -86,6 +86,7 @@ class ExecutionsTest(AgentlessTestCase):
                                            _offset=0,
                                            _size=1000).items
 
+    @retry(wait_fixed=300, stop_max_attempt_number=10)
     def _assert_execution_status(self, execution_id,
                                  wanted_status, client=None):
         client = client or self.client
@@ -773,6 +774,7 @@ class ExecutionsTest(AgentlessTestCase):
             execution = self.client.executions.get(execution.id)
         return execution, deployment_id
 
+    @retry(wait_fixed=300, stop_max_attempt_number=10)
     def _assert_execution_cancelled(self, execution, deployment_id):
         self.assertEqual(Execution.CANCELLED, execution.status)
         self.assertIsNotNone(execution.ended_at)

--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -507,7 +507,6 @@ class TestSnapshot(AgentlessTestCase):
         self.copy_file_to_manager(tmp_config_path,
                                   self.REST_SEC_CONFIG_PATH,
                                   owner='cfyuser:')
-        time.sleep(0.2)  # give time for file to be copied
         self.restart_service('cloudify-restservice')
 
     def test_restore_snapshot_scheduled_tasks(self):

--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -507,6 +507,7 @@ class TestSnapshot(AgentlessTestCase):
         self.copy_file_to_manager(tmp_config_path,
                                   self.REST_SEC_CONFIG_PATH,
                                   owner='cfyuser:')
+        time.sleep(0.2)  # give time for file to be copied
         self.restart_service('cloudify-restservice')
 
     def test_restore_snapshot_scheduled_tasks(self):

--- a/tests/integration_tests/tests/test_cases.py
+++ b/tests/integration_tests/tests/test_cases.py
@@ -45,7 +45,8 @@ from integration_tests.tests.utils import (
     wait_for_deployment_deletion_to_complete,
     verify_deployment_env_created,
     run_postgresql_command,
-    do_retries
+    do_retries,
+    do_retries_boolean
 )
 
 from cloudify_rest_client.executions import Execution
@@ -121,6 +122,9 @@ class BaseTestCase(unittest.TestCase):
                 self.env.container_id,
                 ['chown', owner, target]
             )
+        do_retries_boolean(docker.file_exists,
+                           container_id=self.env.container_id,
+                           file_path=target)
         return ret_val
 
     def copy_file_from_manager(self, source, target, owner=None):

--- a/tests/integration_tests/tests/utils.py
+++ b/tests/integration_tests/tests/utils.py
@@ -214,7 +214,7 @@ def do_retries_boolean(func, timeout_seconds=10, **kwargs):
                     'function {0} did not return True in {1} seconds'
                     .format(func.__name__, timeout_seconds)
                 )
-            time.sleep(1)
+            time.sleep(0.5)
 
 
 def create_self_signed_certificate(target_certificate_path,

--- a/workflows/cloudify_system_workflows/deployment_environment.py
+++ b/workflows/cloudify_system_workflows/deployment_environment.py
@@ -169,10 +169,12 @@ def create(ctx, labels=None, inputs=None, skip_plugins_validation=False,
                        for manager in client.manager.get_managers()]
         ext_client, client_config, ext_deployment_id = \
             _get_external_clients(nodes, manager_ips)
+
+        local_tenant_name = ctx.deployment.tenant_name if ext_client else None
         local_idds, external_idds = _create_inter_deployment_dependencies(
             [manager.private_ip for manager in client.manager.get_managers()],
             client_config, new_dependencies, ctx.deployment.id,
-            ctx.deployment.tenant_name, bool(ext_client), ext_deployment_id)
+            local_tenant_name, bool(ext_client), ext_deployment_id)
         if local_idds:
             client.inter_deployment_dependencies.create_many(
                 ctx.deployment.id,


### PR DESCRIPTION
The major change here is in the inter-deployment-dependencies creation: deployment contexts without an external client don't store a tenant_name