### PR TITLE
RD-2147 Don't require license for OK endpoint

### DIFF
--- a/rest-service/manager_rest/constants.py
+++ b/rest-service/manager_rest/constants.py
@@ -57,7 +57,7 @@ LOCAL_ADDRESS = '127.0.0.1'
 ALLOWED_ENDPOINTS = [
     'brokers', 'managers', 'db-nodes', 'cluster', 'config',
     'status', 'version', 'license', 'maintenance',
-    'cluster-status', 'file-server-auth',
+    'cluster-status', 'file-server-auth', 'ok',
 ]
 ALLOWED_MAINTENANCE_ENDPOINTS = ALLOWED_ENDPOINTS + [
     'snapshots',


### PR DESCRIPTION
Requiring this makes its behaviour different from the status endpoint,
and breaks tests.
Also, since we replicate the license, if it's broken on one manager
then it's broken on all, and a LB allowing traffic will let a user
see that.