### PR TITLE
RD-2249 deployment id template: more variables

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
@@ -23,9 +23,11 @@ def upgrade():
     _drop_events_id()
     _drop_logs_id()
     _add_deployments_display_name_column()
+    _add_depgroups_creation_counter()
 
 
 def downgrade():
+    _drop_depgroups_creation_counter()
     _drop_deployments_display_name_column()
     _create_logs_id()
     _create_events_id()
@@ -213,3 +215,15 @@ def _drop_deployments_display_name_column():
     op.drop_index(op.f('deployments_display_name_idx'),
                   table_name='deployments')
     op.drop_column('deployments', 'display_name')
+
+
+def _add_depgroups_creation_counter():
+    op.add_column(
+        'deployment_groups',
+        sa.Column('creation_counter', sa.Integer(), nullable=False,
+                  server_default='0')
+    )
+
+
+def _drop_depgroups_creation_counter():
+    op.drop_column('deployment_groups', 'creation_counter')

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -1164,6 +1164,7 @@ class DeploymentGroupsId(SecuredResource):
         for template, replace, makes_unique, makes_variable in [
             ('{group_id}', group.id, False, False),
             ('{uuid}', str(uuid.uuid4()), True, True),
+            ('{blueprint_id}', group.default_blueprint.id, False, False),
         ]:
             if template in new_id:
                 new_id = new_id.replace(template, replace)

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -1167,6 +1167,7 @@ class DeploymentGroupsId(SecuredResource):
             ('{uuid}', uuid.uuid4(), True, True),
             ('{blueprint_id}', group.default_blueprint.id, False, False),
             ('{count}', group.creation_counter, False, True),
+            ('{site_name}', new_dep_spec.get('site_name', ''), False, False),
         ]:
             if template in new_id:
                 new_id = new_id.replace(template, str(replace))

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -1124,6 +1124,7 @@ class DeploymentGroupsId(SecuredResource):
                 'runtime_only_evaluation', False),
             site=new_dep_spec.get('site'),
         )
+        group.creation_counter += 1
         dep.is_id_unique = not is_id_unique
         create_execution = dep.make_create_environment_execution(
             inputs=deployment_inputs,
@@ -1163,11 +1164,12 @@ class DeploymentGroupsId(SecuredResource):
 
         for template, replace, makes_unique, makes_variable in [
             ('{group_id}', group.id, False, False),
-            ('{uuid}', str(uuid.uuid4()), True, True),
+            ('{uuid}', uuid.uuid4(), True, True),
             ('{blueprint_id}', group.default_blueprint.id, False, False),
+            ('{count}', group.creation_counter, False, True),
         ]:
             if template in new_id:
-                new_id = new_id.replace(template, replace)
+                new_id = new_id.replace(template, str(replace))
                 is_unique |= makes_unique
                 has_variable |= makes_variable
 

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -707,6 +707,7 @@ class DeploymentGroup(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'deployment_groups'
     description = db.Column(db.Text)
     default_inputs = db.Column(JSONString)
+    creation_counter = db.Column(db.Integer, default=0, nullable=False)
     _default_blueprint_fk = foreign_key(
         Blueprint._storage_id,
         ondelete='SET NULL',

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -1301,3 +1301,10 @@ class TestGenerateID(unittest.TestCase):
         group.creation_counter = 42
         new_id, _ = self._generate_id(group, {'id': '{group_id}-{count}'})
         assert new_id == 'g1-42'
+
+    def test_site_name(self):
+        group = models.DeploymentGroup(id='g1')
+        group.default_blueprint = self._mock_blueprint()
+        new_id, _ = self._generate_id(
+            group, {'id': '{site_name}-{uuid}', 'site_name': 'a'})
+        assert new_id.startswith('a-')

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -1232,6 +1232,7 @@ class TestGenerateID(unittest.TestCase):
 
     def _mock_blueprint(self, id_template=None):
         bp = mock.MagicMock()
+        bp.id = 'blueprint_id'
         bp.plan = {
             'deployment_settings': {'id_template': id_template}
         }
@@ -1284,3 +1285,10 @@ class TestGenerateID(unittest.TestCase):
         assert is_unique
         assert new_id.startswith('hello')
         assert len(new_id) > 36
+
+    def test_blueprint_id(self):
+        group = models.DeploymentGroup(id='g1')
+        group.default_blueprint = self._mock_blueprint()
+        new_id, is_unique = self._generate_id(
+            group, {'id': '{blueprint_id}-{uuid}'})
+        assert new_id.startswith(group.default_blueprint.id)

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -181,7 +181,9 @@ class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
         )
 
         assert set(group.deployment_ids) == {'spec_dep1'}
-        deps = self.sm.get(models.DeploymentGroup, 'group1').deployments
+        sm_group = self.sm.get(models.DeploymentGroup, 'group1')
+        assert sm_group.creation_counter == 1
+        deps = sm_group.deployments
         assert len(deps) == 1
         create_exec_params = deps[0].create_execution.parameters
         assert create_exec_params['inputs'] == inputs
@@ -1289,6 +1291,13 @@ class TestGenerateID(unittest.TestCase):
     def test_blueprint_id(self):
         group = models.DeploymentGroup(id='g1')
         group.default_blueprint = self._mock_blueprint()
-        new_id, is_unique = self._generate_id(
+        new_id, _ = self._generate_id(
             group, {'id': '{blueprint_id}-{uuid}'})
         assert new_id.startswith(group.default_blueprint.id)
+
+    def test_creation_counter(self):
+        group = models.DeploymentGroup(id='g1')
+        group.default_blueprint = self._mock_blueprint()
+        group.creation_counter = 42
+        new_id, _ = self._generate_id(group, {'id': '{group_id}-{count}'})
+        assert new_id == 'g1-42'


### PR DESCRIPTION
Additional template variables for the deployment ID template.

Note that `count` requires actually keeping a counter. So I add
a column.
The other two are trivial.