### PR TITLE
RD-2246 Dep-update: cleanup the unpacked new blueprint

### DIFF
--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -92,16 +92,21 @@ class DeploymentUpdate(SecuredResource):
             config.instance.file_server_root, blueprint)
         deployment_dir = join(FILE_SERVER_DEPLOYMENTS_FOLDER,
                               current_tenant.name,
-                              id)
+                              id,
+                              'updated_blueprint')
         dep_dir_abs = join(config.instance.file_server_root, deployment_dir)
         rmtree(dep_dir_abs, ignore_errors=True)
         copytree(blueprint_dir_abs, dep_dir_abs)
         file_name = blueprint.main_file_name
-        deployment_update = manager.stage_deployment_update(
-            id, deployment_dir, file_name, inputs, blueprint.id, preview,
-            runtime_only_evaluation=runtime_eval,
-            auto_correct_types=auto_correct_args,
-            reevaluate_active_statuses=reevaluate_active_statuses)
+        try:
+            deployment_update = manager.stage_deployment_update(
+                id, deployment_dir, file_name, inputs, blueprint.id, preview,
+                runtime_only_evaluation=runtime_eval,
+                auto_correct_types=auto_correct_args,
+                reevaluate_active_statuses=reevaluate_active_statuses)
+        finally:
+            rmtree(dep_dir_abs, ignore_errors=True)
+
         manager.extract_steps_from_deployment_update(deployment_update)
         return manager.commit_deployment_update(deployment_update,
                                                 skip_install,


### PR DESCRIPTION
This ports #2973 to 5.2.2

Dep-update unpacks and parses the new blueprint so that it can parse
the blueprint to figure out the differences.

However, it must also clean up, obviously!

Also, let's make it go under a subdirectory ('updated_blueprint')
in the deployment directory - that's way better than just removing
the deployment directory entirely: it could've been used for other
things as well.