### PR TITLE
RD-2251 Exc-group cancel: skip already-finished executions

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/executions.py
@@ -266,6 +266,8 @@ class ExecutionGroupsId(SecuredResource):
             for exc in group.executions:
                 if exc.status == ExecutionState.QUEUED:
                     exc.status = ExecutionState.CANCELLED
+                elif exc.status in ExecutionState.END_STATES:
+                    continue
                 else:
                     to_cancel.append(exc)
             for exc in to_cancel:


### PR DESCRIPTION
They're already finished, nothing more to do. Don't attempt to cancel
them because that's just a 400.