### PR TITLE
reset_storage.py: regenerate admin token

### DIFF
--- a/tests/integration_tests/resources/scripts/prepare_reset_storage.py
+++ b/tests/integration_tests/resources/scripts/prepare_reset_storage.py
@@ -6,12 +6,10 @@ from manager_rest import config
 from manager_rest.storage import db, models
 from manager_rest.flask_utils import setup_flask_app
 
-AUTH_TOKEN_LOCATION = '/opt/mgmtworker/work/admin_token'
-
 
 def get_password_hash():
     setup_flask_app()
-    return db.session.query(models.User).first().password
+    return models.User.query.get(0).password
 
 
 if __name__ == '__main__':
@@ -23,8 +21,6 @@ if __name__ == '__main__':
     config.instance.load_from_file('/opt/manager/cloudify-rest.conf')
 
     script_config['password_hash'] = get_password_hash()
-    with open(AUTH_TOKEN_LOCATION) as f:
-        script_config['admin_token'] = f.read().strip()
 
     with open(args.config, 'w') as f:
         json.dump(script_config, f)

--- a/tests/integration_tests/resources/scripts/prepare_reset_storage.py
+++ b/tests/integration_tests/resources/scripts/prepare_reset_storage.py
@@ -3,7 +3,7 @@ import json
 import argparse
 
 from manager_rest import config
-from manager_rest.storage import db, models
+from manager_rest.storage import models
 from manager_rest.flask_utils import setup_flask_app
 
 

--- a/tests/integration_tests/resources/scripts/reset_storage.py
+++ b/tests/integration_tests/resources/scripts/reset_storage.py
@@ -87,9 +87,7 @@ def close_session(app):
     db.get_engine(app).dispose()
 
 
-def reset_storage(script_config):
-    app = setup_flask_app()
-    config.instance.load_configuration()
+def reset_storage(app, script_config):
     amqp_manager = setup_amqp_manager()
 
     # Clear the old RabbitMQ resources
@@ -102,7 +100,6 @@ def reset_storage(script_config):
     upgrade(directory=migrations_dir)
     # Add default tenant, admin user and provider context
     _add_defaults(app, amqp_manager, script_config)
-    close_session(app)
     with open(AUTH_TOKEN_LOCATION, 'w') as f:
         f.write(script_config['admin_token'])
 
@@ -134,5 +131,9 @@ if __name__ == '__main__':
     with args.config as f:
         script_config = json.load(f)
     config.instance.load_from_file('/opt/manager/cloudify-rest.conf')
-    reset_storage(script_config)
+    config.instance.load_configuration()
+
+    app = setup_flask_app()
+    reset_storage(app, script_config)
     clean_dirs()
+    close_session(app)

--- a/tests/integration_tests/resources/scripts/reset_storage.py
+++ b/tests/integration_tests/resources/scripts/reset_storage.py
@@ -21,7 +21,7 @@ import argparse
 from flask_migrate import upgrade
 
 from manager_rest import config
-from manager_rest.storage import db, models, idencoder, get_storage_manager
+from manager_rest.storage import db, models, idencoder
 from manager_rest.amqp_manager import AMQPManager
 from manager_rest.flask_utils import setup_flask_app
 from manager_rest.constants import (

--- a/tests/integration_tests/resources/scripts/reset_storage.py
+++ b/tests/integration_tests/resources/scripts/reset_storage.py
@@ -21,7 +21,7 @@ import argparse
 from flask_migrate import upgrade
 
 from manager_rest import config
-from manager_rest.storage import db, models
+from manager_rest.storage import db, models, idencoder, get_storage_manager
 from manager_rest.amqp_manager import AMQPManager
 from manager_rest.flask_utils import setup_flask_app
 from manager_rest.constants import (
@@ -100,8 +100,13 @@ def reset_storage(app, script_config):
     upgrade(directory=migrations_dir)
     # Add default tenant, admin user and provider context
     _add_defaults(app, amqp_manager, script_config)
+
+
+def regenerate_auth_token():
+    token_key = models.User.query.get(0).api_token_key
+    enc_uid = idencoder.get_encoder().encode(0)
     with open(AUTH_TOKEN_LOCATION, 'w') as f:
-        f.write(script_config['admin_token'])
+        f.write(enc_uid + token_key)
 
 
 def clean_dirs():
@@ -131,9 +136,12 @@ if __name__ == '__main__':
     with args.config as f:
         script_config = json.load(f)
     config.instance.load_from_file('/opt/manager/cloudify-rest.conf')
+    config.instance.load_from_file('/opt/manager/rest-security.conf',
+                                   namespace='security')
     config.instance.load_configuration()
 
     app = setup_flask_app()
     reset_storage(app, script_config)
+    regenerate_auth_token()
     clean_dirs()
     close_session(app)


### PR DESCRIPTION
Just using one that was stored is not enough, because we re-create the
admin user, and so the token changes as well.
That is visible in the resume tests, where we do restart the mgmtworker.