### PR TITLE
Store the manager_config in the prepare script

### DIFF
--- a/tests/integration_tests/framework/flask_utils.py
+++ b/tests/integration_tests/framework/flask_utils.py
@@ -13,16 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import json
 import logging
-import tempfile
 
 from cloudify.utils import setup_logger
 
 from integration_tests.framework.docker import (execute,
                                                 copy_file_to_manager)
-from integration_tests.tests.constants import MANAGER_CONFIG, MANAGER_PYTHON
+from integration_tests.tests.constants import MANAGER_PYTHON
 from integration_tests.tests.utils import get_resource
 
 
@@ -39,16 +37,8 @@ def prepare_reset_storage_script(container_id):
     prepare = get_resource('scripts/prepare_reset_storage.py')
     copy_file_to_manager(container_id, reset_script, SCRIPT_PATH)
     copy_file_to_manager(container_id, prepare, PREPARE_SCRIPT_PATH)
-    with tempfile.NamedTemporaryFile(delete=False, mode='w') as f:
-        json.dump({
-            'manager_config': MANAGER_CONFIG,
-        }, f)
-    try:
-        copy_file_to_manager(container_id, f.name, CONFIG_PATH)
-        execute(container_id,
-                [MANAGER_PYTHON, PREPARE_SCRIPT_PATH, '--config', CONFIG_PATH])
-    finally:
-        os.unlink(f.name)
+    execute(container_id,
+            [MANAGER_PYTHON, PREPARE_SCRIPT_PATH, '--config', CONFIG_PATH])
 
 
 def reset_storage(container_id):

--- a/tests/integration_tests/resources/scripts/prepare_reset_storage.py
+++ b/tests/integration_tests/resources/scripts/prepare_reset_storage.py
@@ -7,6 +7,15 @@ from manager_rest.storage import models
 from manager_rest.flask_utils import setup_flask_app
 
 
+MANAGER_CONFIG = {
+    'workflow': {
+        'task_retries': 0,
+        'task_retry_interval': 0,
+        'subgraph_retries': 0
+    },
+}
+
+
 def get_password_hash():
     setup_flask_app()
     return models.User.query.get(0).password
@@ -16,11 +25,12 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', dest='config')
     args = parser.parse_args()
-    with open(args.config) as f:
-        script_config = json.load(f)
     config.instance.load_from_file('/opt/manager/cloudify-rest.conf')
 
-    script_config['password_hash'] = get_password_hash()
+    script_config = {
+        'manager_config': MANAGER_CONFIG,
+        'password_hash': get_password_hash(),
+    }
 
     with open(args.config, 'w') as f:
         json.dump(script_config, f)

--- a/tests/integration_tests/tests/constants.py
+++ b/tests/integration_tests/tests/constants.py
@@ -1,10 +1,3 @@
-MANAGER_CONFIG = {
-    'workflow': {
-        'task_retries': 0,
-        'task_retry_interval': 0,
-        'subgraph_retries': 0
-    },
-}
 USER_ROLE = 'default'
 ADMIN_ROLE = 'sys_admin'
 USER_IN_TENANT_ROLE = 'user'


### PR DESCRIPTION
It has to be hardcoded somewhere, might as well be in the prepare
script, not in the separate json file.
Then, we dont need to copy the json file from host, we entirely
prepare it container-side.