### PR TITLE
update_execution_status: use a single transaction

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -141,7 +141,8 @@ class ResourceManager(object):
 
     def update_execution_status(self, execution_id, status, error):
         with self.sm.transaction():
-            execution = self.sm.get(models.Execution, execution_id)
+            execution = self.sm.get(models.Execution, execution_id,
+                                    locking=True)
             if execution._deployment_fk:
                 deployment = execution.deployment
             else:

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -147,14 +147,13 @@ class ResourceManager(object):
                 deployment = execution.deployment
             else:
                 deployment = None
+            deployment_storage_id = execution._deployment_fk
+            workflow_id = execution.workflow_id
             if not self._validate_execution_update(execution.status, status):
                 raise manager_exceptions.InvalidExecutionUpdateStatus(
-                    'Invalid relationship - can\'t change status from {0} to {1}'
-                    ' for "{2}" execution while running "{3}" workflow.'
-                    .format(execution.status,
-                            status,
-                            execution.id,
-                            execution.workflow_id))
+                    f"Invalid relationship - can't change status from "
+                    f'{execution.status} to {status} for "{execution.id}" '
+                    f'execution while running "{workflow_id}" workflow.')
             execution.status = status
             execution.error = error
             self._update_execution_group(execution)
@@ -173,8 +172,6 @@ class ResourceManager(object):
             execution = self.sm.update(execution)
             self.update_deployment_statuses(execution)
 
-            deployment_storage_id = execution._deployment_fk
-            workflow_id = execution.workflow_id
             res = execution.to_response()
             # do not use `execution` after this transaction ends, because it
             # would possibly require refetching the related objects, and by

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -898,7 +898,8 @@ class ExecutionQueueingTests(BaseServerTestCase):
         self.sm.put(self.execution1)
 
     def _get_queued(self):
-        return list(self.rm._get_queued_executions(self.execution1))
+        return list(
+            self.rm._get_queued_executions(self.deployment1._storage_id))
 
     def _make_execution(self, status=None, deployment=None):
         execution = models.Execution(


### PR DESCRIPTION
Put as much as possible up front in a single transaction. 

This avoids a 500 in inte-tests when the db is cleaned before the
whole thing actually finishes, but it makes a lot easier to reason
about that function anyway, because the execution doesn't
need to be refetched multiple times.