### PR TITLE
CY-2316 Prevent circular dependenciec in deployment update

### DIFF
--- a/rest-service/manager_rest/deployment_update/handlers.py
+++ b/rest-service/manager_rest/deployment_update/handlers.py
@@ -31,6 +31,7 @@ from dsl_parser.constants import (NODES,
                                   PLUGIN_INSTALL_KEY,
                                   PLUGIN_EXECUTOR_KEY)
 
+from manager_rest import manager_exceptions
 from manager_rest.storage import models, get_node
 from manager_rest.utils import get_formatted_timestamp
 from manager_rest.resource_manager import get_resource_manager
@@ -544,6 +545,14 @@ class DeploymentUpdateNodeHandler(UpdateHandler):
             filters={'deployment_id': dep_update.deployment_id},
             get_all_results=True
         )
+
+        circular_dependencies = deployment_update_utils.\
+            find_nodes_cycles(current_nodes)
+        if circular_dependencies:
+            raise manager_exceptions.ConflictError(
+                "Circular dependencies between nodes have been "
+                f"detected: {', '.join(circular_dependencies)}")
+
         nodes_dict = {node.id: deepcopy(node.to_dict())
                       for node in current_nodes}
         modified_entities = deployment_update_utils.ModifiedEntitiesDict()

--- a/rest-service/manager_rest/deployment_update/handlers.py
+++ b/rest-service/manager_rest/deployment_update/handlers.py
@@ -545,14 +545,6 @@ class DeploymentUpdateNodeHandler(UpdateHandler):
             filters={'deployment_id': dep_update.deployment_id},
             get_all_results=True
         )
-
-        circular_dependencies = deployment_update_utils.\
-            find_nodes_cycles(current_nodes)
-        if circular_dependencies:
-            raise manager_exceptions.ConflictError(
-                "Circular dependencies between nodes have been "
-                f"detected: {', '.join(circular_dependencies)}")
-
         nodes_dict = {node.id: deepcopy(node.to_dict())
                       for node in current_nodes}
         modified_entities = deployment_update_utils.ModifiedEntitiesDict()
@@ -564,6 +556,13 @@ class DeploymentUpdateNodeHandler(UpdateHandler):
             modified_entities=modified_entities,
             current_entities_dict=nodes_dict
         )
+
+        circular_dependencies = deployment_update_utils.\
+            find_relationship_cycles(modified_entities['relationship'])
+        if circular_dependencies:
+            raise manager_exceptions.ConflictError(
+                "Circular dependencies between nodes have been detected")
+
         return modified_entities, list(nodes_dict.values())
 
     def finalize(self, dep_update):

--- a/rest-service/manager_rest/deployment_update/utils.py
+++ b/rest-service/manager_rest/deployment_update/utils.py
@@ -1,5 +1,7 @@
 import copy
 
+import networkx as nx
+
 from .constants import ENTITY_TYPES, PATH_SEPARATOR
 
 
@@ -141,3 +143,16 @@ def parse_index(s):
 def index_to_str(index):
     if check_is_int(index):
         return '[{0}]'.format(index)
+
+
+def find_nodes_cycles(nodes) -> list:
+    graph = _build_nodes_graph(nodes)
+    return [' -- '.join(c) for c in nx.simple_cycles(graph)]
+
+
+def _build_nodes_graph(nodes) -> nx.DiGraph:
+    raw_graph = {}
+    for node in nodes:
+        raw_graph[node.id] = [n.get('target_id')
+                              for n in node.relationships]
+    return nx.DiGraph(raw_graph)


### PR DESCRIPTION
In case the deployment update ends up having circular dependencies
(a.k.a. cycles within a nodes' relationship graph), throw an exception.