### PR TITLE
RD-1419 Save exec-group results into dep-group

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -366,6 +366,15 @@ class ResourceManager(object):
             if execution.error:
                 event.message += f" with error '{execution.error}'"
             self.sm.put(event)
+            if execution.deployment:
+                if execution.status == ExecutionState.TERMINATED and \
+                        execution_group.success_group:
+                    execution_group.success_group.deployments.append(
+                        execution.deployment)
+                if execution.status == ExecutionState.FAILED and \
+                        execution_group.failed_group:
+                    execution_group.failed_group.deployments.append(
+                        execution.deployment)
 
     @staticmethod
     def _get_conf_for_snapshots_wf():

--- a/rest-service/manager_rest/rest/resources_v3_1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/executions.py
@@ -300,7 +300,7 @@ class ExecutionGroupsId(SecuredResource):
 
     @authorize('execution_group_update')
     @rest_decorators.marshal_with(models.ExecutionGroup)
-    def put(self, group_id, **kwargs):
+    def patch(self, group_id, **kwargs):
         request_dict = get_json_and_verify_params({
             'success_group_id': {'optional': True},
             'failure_group_id': {'optional': True},

--- a/rest-service/manager_rest/rest/resources_v3_1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/executions.py
@@ -17,6 +17,7 @@ import uuid
 from datetime import datetime
 
 from flask import request
+from sqlalchemy.dialects.postgresql import insert
 
 from cloudify.models_states import ExecutionState
 from manager_rest.rest.responses_v3 import ItemsCount
@@ -32,7 +33,7 @@ from manager_rest.rest.rest_utils import (
     verify_and_convert_bool,
     parse_datetime_multiple_formats
 )
-from manager_rest.storage import models, get_storage_manager, ListResult
+from manager_rest.storage import models, db, get_storage_manager, ListResult
 from manager_rest.workflow_executor import (
     get_amqp_client,
     workflow_sendhandler
@@ -296,3 +297,56 @@ class ExecutionGroupsId(SecuredResource):
         amqp_client.add_handler(handler)
         with amqp_client:
             group.start_executions(sm, rm, handler)
+
+    @authorize('execution_group_update')
+    @rest_decorators.marshal_with(models.ExecutionGroup)
+    def put(self, group_id, **kwargs):
+        request_dict = get_json_and_verify_params({
+            'success_group_id': {'optional': True},
+            'failure_group_id': {'optional': True},
+        })
+        sm = get_storage_manager()
+
+        with sm.transaction():
+            group = sm.get(models.ExecutionGroup, group_id)
+            success_group_id = request_dict.get('success_group_id')
+            if success_group_id:
+                group.success_group = sm.get(
+                    models.DeploymentGroup, success_group_id)
+                self._add_deps_to_group(group)
+            failure_group_id = request_dict.get('failure_group_id')
+            if failure_group_id:
+                group.failed_group = sm.get(
+                    models.DeploymentGroup, failure_group_id)
+                self._add_deps_to_group(group, success=False)
+            sm.update(group)
+        return group
+
+    def _add_deps_to_group(self, group, success=True):
+        deployment_ids = (
+            db.session.query(models.Execution._deployment_fk)
+            .filter(models.Execution.execution_group_id == group.id)
+            .filter(
+                models.Execution.status == (
+                    ExecutionState.TERMINATED if success
+                    else ExecutionState.FAILED
+                )
+            )
+            .all()
+        )
+        if success:
+            target_group_id = group.success_group._storage_id
+        else:
+            target_group_id = group.failed_group._storage_id
+        # low-level sqlalchemy core, to avoid having to fetch all the deps
+        tb = models.Deployment.deployment_groups.property.secondary
+        db.session.execute(
+            insert(tb)
+            .values([
+                {
+                    'deployment_group_id': target_group_id,
+                    'deployment_id': dep_id
+                } for dep_id, in deployment_ids
+            ])
+            .on_conflict_do_nothing()
+        )

--- a/rest-service/manager_rest/storage/relationships.py
+++ b/rest-service/manager_rest/storage/relationships.py
@@ -69,7 +69,7 @@ def one_to_many_relationship(child_class,
 
 def many_to_many_relationship(current_class, other_class, table_prefix=None,
                               primary_key_tuple=False, ondelete=None,
-                              **relationship_kwargs):
+                              unique=False, **relationship_kwargs):
     """Return a many-to-many SQL relationship object
 
     Notes:
@@ -114,6 +114,7 @@ def many_to_many_relationship(current_class, other_class, table_prefix=None,
         current_foreign_key,
         other_foreign_key,
         primary_key_tuple,
+        unique=unique,
         ondelete=ondelete
     )
     return db.relationship(
@@ -130,6 +131,7 @@ def get_secondary_table(helper_table_name,
                         first_foreign_key,
                         second_foreign_key,
                         primary_key_tuple,
+                        unique=False,
                         ondelete=None):
     """Create a helper table for a many-to-many relationship
 
@@ -143,6 +145,10 @@ def get_secondary_table(helper_table_name,
     which will also index them.
     :return: A Table object
     """
+    table_args = []
+    if unique:
+        table_args.append(
+            db.UniqueConstraint(first_column_name, second_column_name))
     return db.Table(
         helper_table_name,
         db.Column(
@@ -156,5 +162,6 @@ def get_secondary_table(helper_table_name,
             db.Integer,
             db.ForeignKey(second_foreign_key, ondelete=ondelete),
             primary_key=primary_key_tuple
-        )
+        ),
+        *table_args
     )

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -720,7 +720,7 @@ class DeploymentGroup(CreatedAtMixin, SQLResourceBase):
 
     @declared_attr
     def deployments(cls):
-        return many_to_many_relationship(cls, Deployment)
+        return many_to_many_relationship(cls, Deployment, unique=True)
 
     @property
     def deployment_ids(self):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1121,11 +1121,27 @@ class ExecutionGroup(CreatedAtMixin, SQLResourceBase):
         DeploymentGroup._storage_id, nullable=True)
     workflow_id = db.Column(db.Text, nullable=False)
     concurrency = db.Column(db.Integer, server_default='5', nullable=False)
+    _success_group_fk = foreign_key(DeploymentGroup._storage_id, nullable=True,
+                                    ondelete='SET NULL')
+    _failed_group_fk = foreign_key(DeploymentGroup._storage_id, nullable=True,
+                                   ondelete='SET NULL')
 
     @declared_attr
     def deployment_group(cls):
         return one_to_many_relationship(
             cls, DeploymentGroup, cls._deployment_group_fk)
+
+    @declared_attr
+    def success_group(cls):
+        return one_to_many_relationship(
+            cls, DeploymentGroup, cls._success_group_fk,
+            backref='success_source_execution_group')
+
+    @declared_attr
+    def failed_group(cls):
+        return one_to_many_relationship(
+            cls, DeploymentGroup, cls._failed_group_fk,
+            backref='failed_source_execution_group')
 
     deployment_group_id = association_proxy('deployment_group', 'id')
 

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -1311,6 +1311,103 @@ class ExecutionGroupsTestCase(base_test.BaseServerTestCase):
             assert exc.status == ExecutionState.PENDING
         assert group.status == ExecutionState.PENDING
 
+    @mock.patch('manager_rest.workflow_executor.execute_workflow', mock.Mock())
+    @mock.patch('manager_rest.resource_manager.send_event', mock.Mock())
+    def test_success_group(self):
+        # executions are already terminated when we add success_group, so
+        # they should be in the success group
+        exc_group = self.client.execution_groups.start(
+            deployment_group_id='group1',
+            workflow_id='install',
+        )
+        sm_exc_group = self.sm.get(models.ExecutionGroup, exc_group.id)
+        for exc in sm_exc_group.executions:
+            exc.status = ExecutionState.TERMINATED
+            self.sm.put(exc)
+        self.client.deployment_groups.put('group2')
+        self.client.execution_groups.set_target_group(
+            exc_group.id, success_group='group2')
+        target_group = self.sm.get(models.DeploymentGroup, 'group2')
+        assert len(target_group.deployments) == 1
+
+        # executions terminate after we add the success group
+        exc_group = self.client.execution_groups.start(
+            deployment_group_id='group1',
+            workflow_id='install',
+        )
+        self.client.deployment_groups.put('group3')
+        self.client.execution_groups.set_target_group(
+            exc_group.id, success_group='group3')
+        sm_exc_group = self.sm.get(models.ExecutionGroup, exc_group.id)
+        for exc in sm_exc_group.executions:
+            self.client.executions.update(
+                exc.id, status=ExecutionState.TERMINATED)
+        target_group = self.sm.get(models.DeploymentGroup, 'group3')
+        assert len(target_group.deployments) == 1
+
+        # same as above, but the deployment already is in the target group
+        exc_group = self.client.execution_groups.start(
+            deployment_group_id='group1',
+            workflow_id='install',
+        )
+        self.client.deployment_groups.put('group3', deployment_ids=['dep1'])
+        self.client.execution_groups.set_target_group(
+            exc_group.id, success_group='group3')
+        sm_exc_group = self.sm.get(models.ExecutionGroup, exc_group.id)
+        for exc in sm_exc_group.executions:
+            self.client.executions.update(
+                exc.id, status=ExecutionState.TERMINATED)
+        target_group = self.sm.get(models.DeploymentGroup, 'group3')
+        assert len(target_group.deployments) == 1
+
+    @mock.patch('manager_rest.workflow_executor.execute_workflow', mock.Mock())
+    @mock.patch('manager_rest.resource_manager.send_event', mock.Mock())
+    def test_failed_group(self):
+        # similar to test_success_group, but for the failed group
+        exc_group = self.client.execution_groups.start(
+            deployment_group_id='group1',
+            workflow_id='install',
+        )
+        sm_exc_group = self.sm.get(models.ExecutionGroup, exc_group.id)
+        for exc in sm_exc_group.executions:
+            exc.status = ExecutionState.FAILED
+            self.sm.put(exc)
+        self.client.deployment_groups.put('group2')
+        self.client.execution_groups.set_target_group(
+            exc_group.id, failed_group='group2')
+        target_group = self.sm.get(models.DeploymentGroup, 'group2')
+        assert len(target_group.deployments) == 1
+
+        # executions terminate after we add the success group
+        exc_group = self.client.execution_groups.start(
+            deployment_group_id='group1',
+            workflow_id='install',
+        )
+        self.client.deployment_groups.put('group3')
+        self.client.execution_groups.set_target_group(
+            exc_group.id, failed_group='group3')
+        sm_exc_group = self.sm.get(models.ExecutionGroup, exc_group.id)
+        for exc in sm_exc_group.executions:
+            self.client.executions.update(
+                exc.id, status=ExecutionState.FAILED)
+        target_group = self.sm.get(models.DeploymentGroup, 'group3')
+        assert len(target_group.deployments) == 1
+
+        # same as above, but the deployment already is in the target group
+        exc_group = self.client.execution_groups.start(
+            deployment_group_id='group1',
+            workflow_id='install',
+        )
+        self.client.deployment_groups.put('group3', deployment_ids=['dep1'])
+        self.client.execution_groups.set_target_group(
+            exc_group.id, failed_group='group3')
+        sm_exc_group = self.sm.get(models.ExecutionGroup, exc_group.id)
+        for exc in sm_exc_group.executions:
+            self.client.executions.update(
+                exc.id, status=ExecutionState.FAILED)
+        target_group = self.sm.get(models.DeploymentGroup, 'group3')
+        assert len(target_group.deployments) == 1
+
 
 class TestGenerateID(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Add a way to save exec-group results.

Deployments for which the execution succeeded, are added to the
success target group.
Deployments for which the execution failed, are added to the failure
target group.

Also see the docstring for the rest-client in cloudify-cosmo/cloudify-common#768

We store this in 2 ways: when setting the target groups, to catch
executions that were already finished by then; and also in
update-execution-status, so that other executions are processed
as they finish.