### PR TITLE
RD-2287 dep-groups: also template display_name

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -1171,6 +1171,10 @@ class DeploymentGroupsId(SecuredResource):
                 pass
             new_id = new_id or '{group_id}-{uuid}'
 
+        display_name_template = ''
+        if isinstance(new_dep_spec.get('display_name'), str):
+            display_name_template = new_dep_spec['display_name']
+
         for template, replace, makes_unique, makes_variable in [
             ('{group_id}', group.id, False, False),
             ('{uuid}', uuid.uuid4(), True, True),
@@ -1182,6 +1186,12 @@ class DeploymentGroupsId(SecuredResource):
                 new_id = new_id.replace(template, str(replace))
                 is_unique |= makes_unique
                 has_variable |= makes_variable
+            if template in display_name_template:
+                display_name_template = \
+                    display_name_template.replace(template, str(replace))
+
+        if display_name_template:
+            new_dep_spec['display_name'] = display_name_template
 
         if not has_variable:
             raise manager_exceptions.ConflictError(

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -1392,3 +1392,18 @@ class TestGenerateID(unittest.TestCase):
         new_id, _ = self._generate_id(
             group, {'id': '{site_name}-{uuid}', 'site_name': 'a'})
         assert new_id.startswith('a-')
+
+    def test_display_name(self):
+        group = models.DeploymentGroup(id='g1')
+        group.default_blueprint = self._mock_blueprint()
+        dep_spec = {'display_name': '{group_id}'}
+        self._generate_id(group, dep_spec)
+        assert dep_spec['display_name'] == 'g1'
+
+    def test_display_name_same_uuid(self):
+        group = models.DeploymentGroup(id='g1')
+        group.default_blueprint = self._mock_blueprint()
+        dep_spec = {'id': '{group_id}-{uuid}',
+                    'display_name': '{group_id}-{uuid}'}
+        new_id, _ = self._generate_id(group, dep_spec)
+        assert dep_spec['display_name'] == new_id


### PR DESCRIPTION
This ports #3007 to 6.0.0

Same as the ID is templated, also template display_name.
Note that display_name will only be templated if it's passed in the
spec (no DSL support) and if it's just a string (no intrinsic
functions support)