### PR TITLE
Fix searches tests flakiness

### DIFF
--- a/rest-service/manager_rest/test/endpoints/test_searches.py
+++ b/rest-service/manager_rest/test/endpoints/test_searches.py
@@ -20,7 +20,7 @@ class SearchesTestCase(base_test.BaseServerTestCase):
         deployments = self.client.deployments.list(
             filter_rules=self.FILTER_RULES)
         self.assertEqual(len(deployments), 1)
-        self.assertEqual(deployments[0], dep1)
+        self.assertEqual(deployments[0].id, dep1.id)
         self.assert_metadata_filtered(deployments, 1)
 
     def test_list_deployments_with_filter_rules_upper(self):
@@ -76,7 +76,7 @@ class SearchesTestCase(base_test.BaseServerTestCase):
         deployments = self.client.deployments.list(
             filter_rules=self.FILTER_RULES, filter_id=self.FILTER_ID)
         self.assertEqual(len(deployments), 1)
-        self.assertEqual(deployments[0], dep1)
+        self.assertEqual(deployments[0].id, dep1.id)
         self.assert_metadata_filtered(deployments, 1)
 
     def test_searches_with_search_and_filter_rules(self):
@@ -90,7 +90,7 @@ class SearchesTestCase(base_test.BaseServerTestCase):
         deployments = self.client.deployments.list(
             filter_rules=filter_rules_bp1, _search='dep1')
         self.assertEqual(len(deployments), 1)
-        self.assertEqual(deployments[0], dep1)
+        self.assertEqual(deployments[0].id, dep1.id)
         deployments = self.client.deployments.list(
             filter_rules=filter_rules_bp1, _search='dep2')
         self.assertEqual(len(deployments), 0)


### PR DESCRIPTION
The searches unit tests failed on Jenkins with the following error 
```
AssertionError: {'id'[12805 chars] 'val1', 'created_at': '2021-05-11T11:19:52.75[393 chars]': 0} != {'id'[12805 chars] 'val2', 'created_at': '2021-05-11T11:19:52.75[393 chars]': 0}
```` 
I think this happens due to minor time changes. To solve this we can just assert the IDs are equal, instead of the whole object, and the test functionallity will stay the same.