### PR TITLE
tests_executions: add more wait-for-execution

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_executions.py
+++ b/tests/integration_tests/tests/agentless_tests/test_executions.py
@@ -290,6 +290,8 @@ class ExecutionsTest(AgentlessTestCase):
         self._assert_execution_status_in(
             snapshot_2.id, [Execution.PENDING, Execution.STARTED])
         self._assert_execution_status(execution.id, Execution.QUEUED)
+        self.wait_for_execution_to_end(snapshot_2)
+        self.wait_for_execution_to_end(execution)
 
     def test_queue_exec_from_queue_while_exec_in_same_dep_is_running(self):
         """
@@ -333,6 +335,8 @@ class ExecutionsTest(AgentlessTestCase):
         self._assert_execution_status_in(
             execution_1.id, [Execution.PENDING, Execution.STARTED])
         self._assert_execution_status(execution_2.id, Execution.QUEUED)
+        self.wait_for_execution_to_end(execution_1)
+        self.wait_for_execution_to_end(execution_2)
 
     def test_run_exec_from_queue_while_exec_in_diff_dep_is_running(self):
         """
@@ -459,6 +463,7 @@ class ExecutionsTest(AgentlessTestCase):
             snapshot_2.id, [Execution.PENDING, Execution.STARTED])
         self._assert_execution_status(execution.id, Execution.QUEUED)
         self.wait_for_execution_to_end(snapshot_2)
+        self.wait_for_execution_to_end(execution)
 
     def test_fail_to_delete_deployment_of_queued_execution(self):
         """


### PR DESCRIPTION
Similar to #3018 - waiting for executions to end.

With this, every test in test_executions.py, cleans up after itself,
ie. waits for all of its exeuctions to end.

Otherwise, those executions will be left running in the mgmtworker,
but cleaned up from the db, which will just result in 401s in the log,
when the mgmtworker tries to actually run them. Ugly.

(and no, we can't "clean" the mgmtworker, there's no way to do that)