### PR TITLE
Don't upgrade to werkzeug 2.0.0 version

### DIFF
--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -40,7 +40,8 @@ install_requires = [
     'jsonschema==3.0.0',
     'SQLAlchemy==1.3.19',
     'cachetools==3.1.0',
-    'email-validator>1.0.0,<2.0.0'
+    'email-validator>1.0.0,<2.0.0',
+    'werkzeug>1,<2',
 ]
 
 


### PR DESCRIPTION
Werkzeug 2.0.0 (released on 11th May 2021) relies on typing.NoReturn
attribute.  It was introduced in Python 3.6.5 while the integration
tests run with Python 3.6.0:

```
created virtual environment CPython3.6.0.final.0-64
```

We might think about upgrading testing environment one day, but for the
time being this patch might just be good enough.