### PR TITLE
RD-2273 queued exec inte-tests: handle changed timezones

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -312,6 +312,7 @@ class ResourceManager(object):
             .order_by(executions.created_at.asc())
             .limit(5)
             .with_for_update(of=executions)
+            .all()
         )
         # deployments we've already emitted an execution for - only emit 1
         # execution per deployment

--- a/rest-service/manager_rest/storage/models_base.py
+++ b/rest-service/manager_rest/storage/models_base.py
@@ -58,11 +58,13 @@ class UTCDateTime(db.TypeDecorator):
                 return '{0}.000Z'.format(value.isoformat())
 
     def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
         if isinstance(value, text_type):
-            # SQLite only accepts datetime objects
+            value = value.strip('Z')
             return date_parser.parse(value)
         else:
-            return value
+            return value.replace(tzinfo=None)
 
 
 class JSONString(db.TypeDecorator):

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -198,7 +198,8 @@ class EventsAlternativeTimezoneTest(EventsTest):
         )
         # restart all users of the db so that they get a new session which
         # uses the just-set timezone
-        docker.execute(self.env.container_id,
+        docker.execute(
+            self.env.container_id,
             self.get_service_management_command() +
             ' restart cloudify-amqp-postgres cloudify-restservice '
             'cloudify-execution-scheduler'
@@ -222,8 +223,8 @@ class EventsAlternativeTimezoneTest(EventsTest):
             "ALTER DATABASE cloudify_db SET TIME ZONE '{}'"
             .format(self.original_tz)
         )
-        service_command = self.get_service_management_command()
-        docker.execute(self.env.container_id,
+        docker.execute(
+            self.env.container_id,
             self.get_service_management_command() +
             ' restart cloudify-amqp-postgres cloudify-restservice '
             'cloudify-execution-scheduler'


### PR DESCRIPTION
We store datetimes (specifically: execution.created_at) as timestamps
without tz. That is great.

However, when we send datetimes to the db, we send them WITH the
timestamp (which happens to be +0000). That doesn't fit.

Specifically, it breaks this comparison: https://github.com/cloudify-cosmo/cloudify-manager/blob/bfeeb857eac91d56d0af3c75df2f73e65e5cb8d1/rest-service/manager_rest/resource_manager.py#L1057
It compares the column (no tz) to the datetime in the query (with tz).
Postgres does this by converting the no-tz datetime into a with-tz
timestamp, using the db's currently set tz. That works well when the
db's tz is UTC, but breaks otherwise.

And indeed, in the events test, we set the db's tz to Asia/Jerusalem.
That just happens to be + from UTC, so in the queued test, execution2
might have been queued after execution1, but it still compares as if
it was queued before it. And so, execution1 never runs, because
it sees execution2 before it.

So I fix it in two ways:
1. (2nd commit) send the datetime without tz to the db (same as 
it is stored), so all datetime comparisons will now work fine, no matter
the db's tz.
2. (3rd commit) the timezone test will actually clean up after itself