### PR TITLE
RD-2273 queued exec inte-tests: handle changed timezones, 6.0.0

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -312,6 +312,7 @@ class ResourceManager(object):
             .order_by(executions.created_at.asc())
             .limit(5)
             .with_for_update(of=executions)
+            .all()
         )
         # deployments we've already emitted an execution for - only emit 1
         # execution per deployment

--- a/rest-service/manager_rest/storage/models_base.py
+++ b/rest-service/manager_rest/storage/models_base.py
@@ -58,11 +58,13 @@ class UTCDateTime(db.TypeDecorator):
                 return '{0}.000Z'.format(value.isoformat())
 
     def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
         if isinstance(value, text_type):
-            # SQLite only accepts datetime objects
+            value = value.strip('Z')
             return date_parser.parse(value)
         else:
-            return value
+            return value.replace(tzinfo=None)
 
 
 class JSONString(db.TypeDecorator):

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -198,7 +198,8 @@ class EventsAlternativeTimezoneTest(EventsTest):
         )
         # restart all users of the db so that they get a new session which
         # uses the just-set timezone
-        docker.execute(self.env.container_id,
+        docker.execute(
+            self.env.container_id,
             self.get_service_management_command() +
             ' restart cloudify-amqp-postgres cloudify-restservice '
             'cloudify-execution-scheduler'
@@ -222,8 +223,8 @@ class EventsAlternativeTimezoneTest(EventsTest):
             "ALTER DATABASE cloudify_db SET TIME ZONE '{}'"
             .format(self.original_tz)
         )
-        service_command = self.get_service_management_command()
-        docker.execute(self.env.container_id,
+        docker.execute(
+            self.env.container_id,
             self.get_service_management_command() +
             ' restart cloudify-amqp-postgres cloudify-restservice '
             'cloudify-execution-scheduler'


### PR DESCRIPTION
This ports #3027 to 6.0.0. See there for explanation.