### PR TITLE
Pre-release fixes (dependencies and such)

### DIFF
--- a/cloudify_types/setup.py
+++ b/cloudify_types/setup.py
@@ -30,7 +30,7 @@ setup(
     description='Various special Cloudify types implementation.',
     install_requires=[
         'cloudify-common==5.2.2',
-        'requests==2.21.0',
+        'requests>=2.25.0,<3.0.0',
         'PyYAML==5.3.1'
     ]
 )

--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     'python-dateutil==2.5.3',
     'voluptuous==0.9.3',
     'pika==1.1.0',
-    'cryptography==3.3.1',
+    'cryptography==3.3.2',
     'psycopg2==2.7.4',
     'pytz==2018.4',
     'packaging==17.1',

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -27,7 +27,6 @@ setup(
         'pika==1.1.0',
         'fasteners==0.13.0',
         'sh==1.11',
-        'awscli==1.11.14',
         'docker==4.0.2',
         'requests>=2.18,<3.0.0',
         'pytest'

--- a/workflows/setup.py
+++ b/workflows/setup.py
@@ -28,7 +28,7 @@ setup(
         'cloudify-common==5.2.2',
         'retrying==1.3.3',
         'psycopg2==2.7.4',
-        'cryptography==3.3.1',
+        'cryptography==3.3.2',
         'python-dateutil==2.5.3',
         'pytz==2018.4',
     ]


### PR DESCRIPTION
There are different versions of some of the dependencies in other
repositories (cloudify-common, cloudify-agent, cloudify-cli).  This
patch upgrades those in cloudify-manager as well.