### PR TITLE
inte-tests: wait for executions to finished in the 2-scheduled test

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_executions.py
+++ b/tests/integration_tests/tests/agentless_tests/test_executions.py
@@ -847,8 +847,9 @@ class ExecutionsTest(AgentlessTestCase):
         self.assertEqual(schedule.workflow_id, 'install')
         self.assertIn('install_', schedule.id)
 
-        self.wait_for_scheduled_execution_to_fire(dep_id)
+        exc = self.wait_for_scheduled_execution_to_fire(dep_id)
         self.client.execution_schedules.delete(schedule.id, dep_id)
+        self.wait_for_execution_to_end(exc)
 
     def test_schedule_execution_snapshot_running_multi_tenant(self):
         """
@@ -999,10 +1000,11 @@ class ExecutionsTest(AgentlessTestCase):
                                      schedule=scheduled_time)
         self.client.executions.update(execution1.id, Execution.TERMINATED)
 
-        self.wait_for_scheduled_execution_to_fire(dep_id)
+        exc = self.wait_for_scheduled_execution_to_fire(dep_id)
         schedule = self.client.execution_schedules.list(
             deployment_id=dep.id)[0]
         self.client.execution_schedules.delete(schedule.id, dep_id)
+        self.wait_for_execution_to_end(exc)
 
     @retry(wait_fixed=1000, stop_max_attempt_number=120)
     def wait_for_scheduled_execution_to_fire(self, deployment_id):

--- a/tests/integration_tests/tests/agentless_tests/test_executions.py
+++ b/tests/integration_tests/tests/agentless_tests/test_executions.py
@@ -910,14 +910,16 @@ class ExecutionsTest(AgentlessTestCase):
         self.client.executions.start(deployment_id=dep2_id,
                                      workflow_id='install',
                                      schedule=scheduled_time)
-        self.wait_for_scheduled_execution_to_fire(dep1_id)
-        self.wait_for_scheduled_execution_to_fire(dep2_id)
+        exc1 = self.wait_for_scheduled_execution_to_fire(dep1_id)
+        exc2 = self.wait_for_scheduled_execution_to_fire(dep2_id)
         schedule1 = self.client.execution_schedules.list(
             deployment_id=dep1.id)[0]
         schedule2 = self.client.execution_schedules.list(
             deployment_id=dep2.id)[0]
         self.client.execution_schedules.delete(schedule1.id, dep1_id)
         self.client.execution_schedules.delete(schedule2.id, dep2_id)
+        self.wait_for_execution_to_end(exc1)
+        self.wait_for_execution_to_end(exc2)
 
     def test_schedule_execution_while_snapshot_running_same_tenant(self):
         dsl_path = resource('dsl/sleep_workflows.yaml')


### PR DESCRIPTION
this tests schedules 2 executions, waits for them to start, and
finishes. Instead, it must wait for them to end. If it doesn't, then
they might just start installing the plugin, the next test will see
"oh the plugin is being installed, ok", this already-finished test
will stop due to the db cleanup, all kinds of weird interactions.
Let's just avoid all of that.