### PR TITLE
dep.latest_execution: declare the column unique

### DIFF
--- a/rest-service/manager_rest/storage/relationships.py
+++ b/rest-service/manager_rest/storage/relationships.py
@@ -21,6 +21,7 @@ def foreign_key(foreign_key_column,
                 index=True,
                 primary_key=False,
                 ondelete='CASCADE',
+                unique=False,
                 **fk_kwargs):
     """Return a ForeignKey object with the relevant
 
@@ -36,6 +37,7 @@ def foreign_key(foreign_key_column,
         nullable=nullable,
         index=index,
         primary_key=primary_key,
+        unique=unique,
     )
 
 

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -418,7 +418,8 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
                                        ondelete='SET NULL',
                                        deferrable=True,
                                        initially='DEFERRED',
-                                       use_alter=True)
+                                       use_alter=True,
+                                       unique=True)
 
     deployment_group_id = association_proxy('deployment_groups', 'id')
 


### PR DESCRIPTION
It is already unique in the migrations: https://github.com/cloudify-cosmo/cloudify-manager/blob/177df8794b0caccb4ad3bcc549a997e923187b5e/resources/rest-service/cloudify/migrations/versions/396303c07e35_5_2_to_5_3.py#L282

Make the code reflect it as well.

With this, `alembic revision --autogenerate` will return empty.