### PR TITLE
RD-2248 Creating system filters during upgrade

### DIFF
--- a/packaging/cloudify-rest-service.spec
+++ b/packaging/cloudify-rest-service.spec
@@ -146,6 +146,7 @@ exit 0
 /usr/lib/systemd/system/cloudify-execution-scheduler.service
 
 %attr(750,cfyuser,adm) /opt/manager/scripts/load_permissions.py
+%attr(750,cfyuser,adm) /opt/manager/scripts/create_system_filters.py
 %attr(750,cfyuser,adm) /var/log/cloudify/rest
 %attr(750,cfyuser,adm) /opt/manager/snapshot_status
 %attr(750,cfyuser,adm) /var/log/cloudify/amqp-postgres

--- a/packaging/rest-service/files/opt/manager/scripts/create_system_filters.py
+++ b/packaging/rest-service/files/opt/manager/scripts/create_system_filters.py
@@ -1,0 +1,72 @@
+#!/opt/manager/env/bin/python
+
+import os
+from datetime import datetime
+
+from manager_rest import constants
+from manager_rest.storage import models
+from manager_rest.storage.models_base import db
+from manager_rest.flask_utils import setup_flask_app
+
+
+def create_system_filters():
+    with setup_flask_app().app_context():
+        current_deployment_filters = db.session.query(models.DeploymentsFilter)
+        curr_dep_filters_ids = {dep_filter.id for dep_filter
+                                in current_deployment_filters}
+        if ({'csys-environment-filter', 'csys-service-filter'} ==
+                curr_dep_filters_ids):
+            # System filters already exist
+            return
+        now = datetime.utcnow()
+        creator = db.session.query(models.User).filter_by(
+            id=constants.BOOTSTRAP_ADMIN_ID).first()
+        tenant = db.session.query(models.Tenant).filter_by(
+            id=constants.DEFAULT_TENANT_ID).first()
+        system_filters = [
+            {
+                'id': 'csys-environment-filter',
+                'value': [
+                    {
+                        'key': 'csys-obj-type',
+                        'values': ['environment'],
+                        'operator': 'any_of',
+                        'type': 'label'
+                    },
+                    {
+                        'key': 'csys-obj-parent',
+                        'values': [],
+                        'operator': 'is_null',
+                        'type': 'label'
+                    }
+                ]
+            },
+            {
+                'id': 'csys-service-filter',
+                'value': [
+                    {
+                        'key': 'csys-obj-type',
+                        'values': ['environment'],
+                        'operator': 'is_not',
+                        'type': 'label'
+                    }
+                ]
+            }
+        ]
+        for sys_filter in system_filters:
+            sys_filter['created_at'] = now
+            sys_filter['updated_at'] = now
+            sys_filter['visibility'] = 'global'
+            sys_filter['is_system_filter'] = True
+            sys_filter['creator'] = creator
+            sys_filter['tenant'] = tenant
+            db.session.add(models.DeploymentsFilter(**sys_filter))
+
+        db.session.commit()
+
+
+if __name__ == '__main__':
+    if 'MANAGER_REST_CONFIG_PATH' not in os.environ:
+        os.environ['MANAGER_REST_CONFIG_PATH'] = \
+            "/opt/manager/cloudify-rest.conf"
+    create_system_filters()

--- a/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
@@ -5,6 +5,8 @@ Revises: 396303c07e35
 Create Date: 2021-04-12 09:33:44.399254
 
 """
+from datetime import datetime
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.sql import table, column
@@ -338,7 +340,7 @@ def _drop_depgroup_dep_constraint():
 
 
 def _add_system_filters():
-    now = sa.func.current_timestamp()
+    now = datetime.utcnow()
     op.bulk_insert(deployments_filters_table, [
         dict(
             id='csys-environment-filter',

--- a/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/b92770a7b6ca_5_3_to_6_0.py
@@ -5,42 +5,16 @@ Revises: 396303c07e35
 Create Date: 2021-04-12 09:33:44.399254
 
 """
-from datetime import datetime
-
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.sql import table, column
-from sqlalchemy.dialects import postgresql
 
-from manager_rest import constants
 from manager_rest.storage import models
-from cloudify.models_states import VisibilityState
-from manager_rest.storage.models_base import JSONString, UTCDateTime
 
 # revision identifiers, used by Alembic.
 revision = 'b92770a7b6ca'
 down_revision = '396303c07e35'
 branch_labels = None
 depends_on = None
-
-VISIBILITY_ENUM = postgresql.ENUM(
-    *VisibilityState.STATES,
-    name='visibility_states',
-    create_type=False
-)
-
-
-deployments_filters_table = table(
-    'deployments_filters',
-    column('id', sa.Text),
-    column('value', JSONString()),
-    column('visibility', VISIBILITY_ENUM),
-    column('created_at', UTCDateTime()),
-    column('updated_at', UTCDateTime()),
-    column('_tenant_id', sa.Integer),
-    column('_creator_id', sa.Integer),
-    column('is_system_filter', sa.Boolean),
-)
 
 
 def upgrade():
@@ -52,11 +26,9 @@ def upgrade():
     _add_depgroups_creation_counter()
     _add_execgroups_dep_fks()
     _create_depgroup_dep_constraint()
-    _add_system_filters()
 
 
 def downgrade():
-    _drop_system_filters()
     _drop_depgroup_dep_constraint()
     _drop_execgroups_dep_fks()
     _drop_depgroups_creation_counter()
@@ -336,68 +308,4 @@ def _drop_depgroup_dep_constraint():
         op.f('deployment_groups_deployments_deployment_group_id_key'),
         'deployment_groups_deployments',
         type_='unique'
-    )
-
-
-def _add_system_filters():
-    now = datetime.utcnow()
-    op.bulk_insert(deployments_filters_table, [
-        dict(
-            id='csys-environment-filter',
-            value=[
-                {
-                    'key': 'csys-obj-type',
-                    'values': ['environment'],
-                    'operator': 'any_of',
-                    'type': 'label'
-                },
-                {
-                    'key': 'csys-obj-parent',
-                    'values': [],
-                    'operator': 'is_null',
-                    'type': 'label'
-                }
-            ],
-            visibility=VisibilityState.GLOBAL,
-            created_at=now,
-            updated_at=now,
-            _tenant_id=constants.DEFAULT_TENANT_ID,
-            _creator_id=constants.BOOTSTRAP_ADMIN_ID,
-            is_system_filter=True
-        ),
-        dict(
-            id='csys-service-filter',
-            value=[
-                {
-                    'key': 'csys-obj-type',
-                    'values': ['environment'],
-                    'operator': 'is_not',
-                    'type': 'label'
-                }
-            ],
-            visibility=VisibilityState.GLOBAL,
-            created_at=now,
-            updated_at=now,
-            _tenant_id=constants.DEFAULT_TENANT_ID,
-            _creator_id=constants.BOOTSTRAP_ADMIN_ID,
-            is_system_filter=True
-        )
-    ])
-
-
-def _drop_system_filters():
-    op.execute(
-        deployments_filters_table
-        .delete()
-        .where(
-            (deployments_filters_table.c.id == op.inline_literal('csys-environment-filter')) # NOQA
-        )
-    )
-
-    op.execute(
-        deployments_filters_table
-        .delete()
-        .where(
-            (deployments_filters_table.c.id == op.inline_literal('csys-service-filter')) # NOQA
-        )
     )

--- a/workflows/cloudify_system_workflows/snapshots/constants.py
+++ b/workflows/cloudify_system_workflows/snapshots/constants.py
@@ -71,6 +71,7 @@ V_5_0_5 = ManagerVersion('5.0.5')
 V_5_1_0 = ManagerVersion('5.1.0')
 V_5_2_0 = ManagerVersion('5.2.0')
 V_5_3_0 = ManagerVersion('5.3.0')
+V_6_0_0 = ManagerVersion('6.0.0')
 
 
 class VisibilityState(object):

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -56,6 +56,7 @@ from .constants import (
     V_4_6_0,
     V_5_0_5,
     V_5_3_0,
+    V_6_0_0,
     SECURITY_FILE_LOCATION,
     SECURITY_FILENAME,
     REST_AUTHORIZATION_CONFIG_PATH,
@@ -155,6 +156,7 @@ class SnapshotRestore(object):
                 self._update_deployment_statuses()
                 self._update_node_instance_indices()
                 self._set_default_user_profile_flags()
+                self._create_system_filters()
 
             if self._restore_certificates:
                 self._restore_certificate()
@@ -232,6 +234,11 @@ class SnapshotRestore(object):
         ctx.logger.info('Updating roles and permissions')
         if os.path.exists(REST_AUTHORIZATION_CONFIG_PATH):
             utils.run(['/opt/manager/scripts/load_permissions.py'])
+
+    def _create_system_filters(self):
+        ctx.logger.info('Creating system filters')
+        if self._snapshot_version < V_6_0_0:
+            utils.run(['/opt/manager/scripts/create_system_filters.py'])
 
     def _update_deployment_statuses(self):
         ctx.logger.info('Updating deployment statuses.')


### PR DESCRIPTION
We would like to create default system filters that will allow the UI to filter environments and services easily. 
The first try was to just create them during the manager installation, but the created filters were gone after snapshot restore.  This PR fixes it.
The first idea for the fix was to create the system filters during the alembic upgrade. This doesn't work as `default_tenant` tenant and `admin` user are created only after the upgrade and are necessary for the creation of the filters. 
The second fix, that does work, is using a script for creating the system filters during installation, `cfy_manager upgrade`, and snapshot restore. 

This PR needs to be merged before its associated one, https://github.com/cloudify-cosmo/cloudify-manager-install/pull/1160, in order for its CI to pass.