### PR TITLE
RD-2328 snap-res: populate deployment statuses via sql

### DIFF
--- a/rest-service/manager_rest/snapshot_utils.py
+++ b/rest-service/manager_rest/snapshot_utils.py
@@ -27,8 +27,7 @@ def _set_latest_execution():
     upd_query = (
         dep_table.update()
         .values(
-            _latest_execution_fk=
-            select([
+            _latest_execution_fk=select([
                 exc_table.c._storage_id
             ]).where(
                 exc_table.c._deployment_fk == dep_table.c._storage_id

--- a/rest-service/manager_rest/snapshot_utils.py
+++ b/rest-service/manager_rest/snapshot_utils.py
@@ -4,25 +4,119 @@ Functions that are called from snapshot-(usually restore), which are always
 ran from the restservice virtualenv, put here for easy testing.
 """
 
-from manager_rest import resource_manager
-from manager_rest.storage import (
-    models,
-    get_storage_manager,
-    db
-)
+from cloudify.models_states import DeploymentState
+from sqlalchemy import select, exists, and_, or_
+from manager_rest.storage import models, db
+
+
+dep_table = models.Deployment.__table__
+exc_table = models.Execution.__table__
+ni_table = models.NodeInstance.__table__
+nodes_table = models.Node.__table__
+execution_states = {}
+for exc_state, dep_state in DeploymentState.EXECUTION_STATES_SUMMARY.items():
+    execution_states.setdefault(dep_state, []).append(exc_state)
+
+
+def _set_latest_execution():
+    """Set .latest_execution for all deployments
+
+    Find the latest execution based on the created_at field, and set it
+    for each deployment.
+    """
+    upd_query = (
+        dep_table.update()
+        .values(
+            _latest_execution_fk=
+            select([
+                exc_table.c._storage_id
+            ]).where(
+                exc_table.c._deployment_fk == dep_table.c._storage_id
+            ).order_by(
+                exc_table.c.created_at.desc()
+            ).limit(1)
+        )
+    )
+    db.session.execute(upd_query)
+
+
+def _set_installation_status():
+    """Set .installation_status on all deployments.
+
+    This is based on the dep's node instances: if all are started,
+    the installation status is ACTIVE, otherwise INACTIVE
+    """
+    update_all_query = (
+        dep_table.update()
+        .values(installation_status=DeploymentState.ACTIVE)
+    )
+    upd_query = (
+        dep_table.update()
+        .where(exists(
+            select([1])
+            .select_from(ni_table.join(nodes_table))
+            .where(and_(
+                nodes_table.c._deployment_fk == dep_table.c._storage_id,
+                ni_table.c.state != 'started',
+            ))
+        ))
+        .values(installation_status=DeploymentState.INACTIVE)
+    )
+    db.session.execute(update_all_query)
+    db.session.execute(upd_query)
+
+
+def _set_deployment_status():
+    """Set .deployment_status for each deployment
+
+    This is based on both the installation status, and the latest
+    execution's status. This logic must match the if ladder in
+    Deployment.evaluate_deployment_status.
+
+    There's conditions for every of the target statuses, and for each,
+    we also add a "where deployment_status is None" filter, which gives
+    this `if/else` semantics. (if a deployment hits one status, it won't
+    hit another)
+    """
+    reset_query = dep_table.update().values(deployment_status=None)
+    db.session.execute(reset_query)
+
+    in_progress_condition = exc_table.c.status.in_(
+        execution_states[DeploymentState.IN_PROGRESS])
+    req_attention_condition = or_(
+        dep_table.c.installation_status == DeploymentState.INACTIVE,
+        exc_table.c.status.in_(execution_states[DeploymentState.FAILED]),
+    )
+    for condition, target_status in [
+        (in_progress_condition, DeploymentState.IN_PROGRESS),
+        (req_attention_condition, DeploymentState.REQUIRE_ATTENTION),
+        (None, DeploymentState.GOOD)
+    ]:
+        conditions = [
+            dep_table.c._latest_execution_fk == exc_table.c._storage_id,
+            dep_table.c.deployment_status.is_(None)
+        ]
+        if condition is not None:
+            conditions.append(condition)
+        query = (
+            dep_table.update()
+            .where(exists(
+                select([1]).where(and_(*conditions))
+            ))
+            .values(deployment_status=target_status)
+        )
+        db.session.execute(query)
 
 
 def populate_deployment_statuses():
-    sm = get_storage_manager()
-    rm = resource_manager.ResourceManager(sm)
-    deployments = sm.list(models.Deployment, get_all_results=True)
-    for dep in deployments:
-        latest_execution = \
-            db.session.query(
-                models.Execution
-            ).filter(
-                models.Execution._deployment_fk == dep._storage_id
-            ).order_by(
-                models.Execution.created_at.desc()
-            ).limit(1).one()
-        rm.update_deployment_statuses(latest_execution)
+    """Set the 6.0-new status fields for all deployments.
+
+    This is to be called after a snapshot-restore, to compute the new
+    fields: .latest_execution, .installation_status and .deployment_status
+
+    Note that unlike rm.update_deployment_statuses, this does not propagate
+    to parents - that is because pre-6.0, there were no parent deployments.
+    """
+    _set_latest_execution()
+    _set_installation_status()
+    _set_deployment_status()

--- a/rest-service/manager_rest/snapshot_utils.py
+++ b/rest-service/manager_rest/snapshot_utils.py
@@ -1,0 +1,28 @@
+"""Snapshot-related utilities.
+
+Functions that are called from snapshot-(usually restore), which are always
+ran from the restservice virtualenv, put here for easy testing.
+"""
+
+from manager_rest import resource_manager
+from manager_rest.storage import (
+    models,
+    get_storage_manager,
+    db
+)
+
+
+def populate_deployment_statuses():
+    sm = get_storage_manager()
+    rm = resource_manager.ResourceManager(sm)
+    deployments = sm.list(models.Deployment, get_all_results=True)
+    for dep in deployments:
+        latest_execution = \
+            db.session.query(
+                models.Execution
+            ).filter(
+                models.Execution._deployment_fk == dep._storage_id
+            ).order_by(
+                models.Execution.created_at.desc()
+            ).limit(1).one()
+        rm.update_deployment_statuses(latest_execution)

--- a/rest-service/manager_rest/test/infrastructure/test_snapshot_utils.py
+++ b/rest-service/manager_rest/test/infrastructure/test_snapshot_utils.py
@@ -1,0 +1,168 @@
+from datetime import datetime
+from cloudify.models_states import DeploymentState, ExecutionState
+from manager_rest.test import base_test
+from manager_rest.storage import models, db
+
+from manager_rest.snapshot_utils import populate_deployment_statuses
+
+
+class TestSnapshotDeploymentStatus(base_test.BaseServerTestCase):
+    def setUp(self):
+        super(TestSnapshotDeploymentStatus, self).setUp()
+        self._tenant = models.Tenant()
+        self._user = models.User()
+
+    def tearDown(self):
+        db.session.rollback()
+        super(TestSnapshotDeploymentStatus, self).tearDown()
+
+    def _make_deployment(self):
+        bp = models.Blueprint(tenant=self._tenant, creator=self._user)
+        dep = models.Deployment(
+            blueprint=bp,
+            creator=self._user,
+            tenant=self._tenant,
+            display_name='',
+        )
+        db.session.add(dep)
+        db.session.flush()
+        return dep
+
+    def _make_node(self, dep):
+        node = models.Node(
+            deployment=dep,
+            deploy_number_of_instances=0,
+            max_number_of_instances=1,
+            min_number_of_instances=1,
+            number_of_instances=1,
+            planned_number_of_instances=1,
+            type='cloudify.nodes.Root',
+            creator=self._user,
+            tenant=self._tenant,
+        )
+        db.session.add(node)
+        db.session.flush()
+        return node
+
+    def _make_instance(self, node, state='uninitialized'):
+        ni = models.NodeInstance(
+            node=node,
+            state=state,
+            creator=self._user,
+            tenant=self._tenant
+        )
+        db.session.add(ni)
+        db.session.flush()
+        return ni
+
+    def test_latest_execution_empty(self):
+        dep = self._make_deployment()
+        populate_deployment_statuses()
+        dep = models.Deployment.query.get(dep._storage_id)
+        assert dep.latest_execution is None
+
+    def test_latest_execution_one(self):
+        dep = self._make_deployment()
+        exc = models.Execution(deployment=dep, workflow_id='x')
+        db.session.add(exc)
+        db.session.flush()
+        populate_deployment_statuses()
+        db.session.refresh(dep)
+        assert dep.latest_execution == exc
+
+    def test_latest_execution_multiple(self):
+        dep1 = self._make_deployment()
+        dep2 = self._make_deployment()
+        exc1 = models.Execution(deployment=dep1, workflow_id='x')
+        exc2 = models.Execution(deployment=dep2, workflow_id='x',
+                                created_at=datetime(2020, 1, 1))
+        exc3 = models.Execution(deployment=dep2, workflow_id='x',
+                                created_at=datetime(2019, 1, 1))
+        db.session.add_all([exc1, exc2, exc3])
+        db.session.flush()
+        populate_deployment_statuses()
+        db.session.refresh(dep1)
+        db.session.refresh(dep2)
+        assert dep1.latest_execution == exc1
+        assert dep2.latest_execution == exc2
+
+    def test_node_instances_empty(self):
+        dep = self._make_deployment()
+        populate_deployment_statuses()
+        db.session.refresh(dep)
+        assert dep.installation_status == DeploymentState.ACTIVE
+
+    def test_node_instances_not_started(self):
+        dep = self._make_deployment()
+        node = self._make_node(dep)
+        self._make_instance(node)
+        self._make_instance(node, state='started')
+        populate_deployment_statuses()
+        db.session.refresh(dep)
+        assert dep.installation_status == DeploymentState.INACTIVE
+
+    def test_node_instances_started(self):
+        dep = self._make_deployment()
+        node = self._make_node(dep)
+        self._make_instance(node, state='started')
+        populate_deployment_statuses()
+        db.session.refresh(dep)
+        assert dep.installation_status == DeploymentState.ACTIVE
+
+    def test_node_instances_multiple(self):
+        dep1 = self._make_deployment()
+        dep2 = self._make_deployment()
+        node1 = self._make_node(dep1)
+        node2 = self._make_node(dep2)
+        self._make_instance(node1)
+        self._make_instance(node1, state='started')
+        self._make_instance(node2, state='started')
+        self._make_instance(node2, state='started')
+        populate_deployment_statuses()
+        db.session.refresh(dep1)
+        db.session.refresh(dep2)
+        assert dep1.installation_status == DeploymentState.INACTIVE
+        assert dep2.installation_status == DeploymentState.ACTIVE
+
+    def test_deployment_status_good(self):
+        dep = self._make_deployment()
+        exc = models.Execution(
+            deployment=dep, workflow_id='x', status=ExecutionState.TERMINATED)
+        db.session.add(exc)
+        db.session.flush()
+        populate_deployment_statuses()
+        db.session.refresh(dep)
+        assert dep.deployment_status == DeploymentState.GOOD
+
+    def test_deployment_status_in_progress(self):
+        dep = self._make_deployment()
+        exc = models.Execution(
+            deployment=dep, workflow_id='x', status=ExecutionState.STARTED)
+        db.session.add(exc)
+        db.session.flush()
+        populate_deployment_statuses()
+        db.session.refresh(dep)
+        assert dep.deployment_status == DeploymentState.IN_PROGRESS
+
+    def test_deployment_status_failed_execution(self):
+        dep = self._make_deployment()
+        exc = models.Execution(
+            deployment=dep, workflow_id='x', status=ExecutionState.FAILED)
+        db.session.add(exc)
+        db.session.flush()
+        populate_deployment_statuses()
+        db.session.refresh(dep)
+        assert dep.deployment_status == DeploymentState.REQUIRE_ATTENTION
+
+    def test_deployment_status_inactive(self):
+        dep = self._make_deployment()
+        node = self._make_node(dep)
+        self._make_instance(node)
+        exc = models.Execution(
+            deployment=dep, workflow_id='x', status=ExecutionState.TERMINATED)
+        db.session.add(dep)
+        db.session.add(exc)
+        db.session.flush()
+        populate_deployment_statuses()
+        db.session.refresh(dep)
+        assert dep.deployment_status == DeploymentState.REQUIRE_ATTENTION

--- a/workflows/cloudify_system_workflows/snapshots/populate_deployment_statuses.py
+++ b/workflows/cloudify_system_workflows/snapshots/populate_deployment_statuses.py
@@ -3,6 +3,7 @@ from manager_rest import config
 from manager_rest.flask_utils import setup_flask_app
 from manager_rest.constants import SECURITY_FILE_LOCATION
 from manager_rest.snapshot_utils import populate_deployment_statuses
+from manager_rest.storage import db
 
 
 os.environ['MANAGER_REST_CONFIG_PATH'] = '/opt/manager/cloudify-rest.conf'
@@ -12,3 +13,4 @@ if __name__ == '__main__':
     with setup_flask_app().app_context():
         config.instance.load_configuration()
         populate_deployment_statuses()
+        db.session.commit()

--- a/workflows/cloudify_system_workflows/snapshots/populate_deployment_statuses.py
+++ b/workflows/cloudify_system_workflows/snapshots/populate_deployment_statuses.py
@@ -1,36 +1,14 @@
 import os
-
 from manager_rest import config
-from manager_rest import resource_manager
-from manager_rest.storage import (
-    models,
-    get_storage_manager,
-    db
-)
 from manager_rest.flask_utils import setup_flask_app
 from manager_rest.constants import SECURITY_FILE_LOCATION
+from manager_rest.snapshot_utils import populate_deployment_statuses
+
 
 os.environ['MANAGER_REST_CONFIG_PATH'] = '/opt/manager/cloudify-rest.conf'
 os.environ['MANAGER_REST_SECURITY_CONFIG_PATH'] = SECURITY_FILE_LOCATION
 
-
-def _populate_deployment_statuses():
-    sm = get_storage_manager()
-    rm = resource_manager.ResourceManager(sm)
-    deployments = sm.list(models.Deployment, get_all_results=True)
-    for dep in deployments:
-        latest_execution = \
-            db.session.query(
-                models.Execution
-            ).filter(
-                models.Execution._deployment_fk == dep._storage_id
-            ).order_by(
-                models.Execution.created_at.desc()
-            ).limit(1).one()
-        rm.update_deployment_statuses(latest_execution)
-
-
 if __name__ == '__main__':
     with setup_flask_app().app_context():
         config.instance.load_configuration()
-        _populate_deployment_statuses()
+        populate_deployment_statuses()


### PR DESCRIPTION
Instead of going all python-side, make a few sql queries that do the same.
This is way faster.