### PR TITLE
WDR-35 Enable sorting by environment type

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -467,7 +467,6 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
             flask_fields.Nested(ExecutionSchedule.resource_fields))
         fields['deployment_groups'] = flask_fields.List(flask_fields.String)
         fields['latest_execution_status'] = flask_fields.String()
-        fields['environment_type'] = flask_fields.String()
         fields['latest_execution_total_operations'] = flask_fields.Integer()
         fields['latest_execution_finished_operations'] = flask_fields.Integer()
         return fields
@@ -484,7 +483,6 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         dep_dict['latest_execution_status'] = self.latest_execution_status
         if not dep_dict.get('installation_status'):
             dep_dict['installation_status'] = DeploymentState.INACTIVE
-        dep_dict['environment_type'] = self.environment_type
         dep_dict['latest_execution_total_operations'] = \
             self.latest_execution_total_operations
         dep_dict['latest_execution_finished_operations'] = \

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -684,10 +684,9 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         labels_table = DeploymentLabel.__table__
         env_type_stmt = (
             select([labels_table.c.value]).
-            select_from(
-                labels_table.outerjoin(
-                cls, labels_table.c._labeled_model_fk == cls._storage_id)).
-            where(labels_table.c.key == 'csys-env-type').
+            where(db.and_(
+                    labels_table.c.key == 'csys-env-type',
+                    labels_table.c._labeled_model_fk == cls._storage_id)).
             distinct().
             limit(1)
         )

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -153,10 +153,9 @@ class SQLStorageManager(object):
                     query = query.order_by(order(column))
                 else:
                     query = query.order_by(column)
-        else:
-            default_sort = model_class.default_sort_column()
-            if default_sort:
-                query = query.order_by(default_sort)
+        default_sort = model_class.default_sort_column()
+        if default_sort:
+            query = query.order_by(default_sort)
         return query
 
     def _filter_query(self,

--- a/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
@@ -596,11 +596,11 @@ class DeploymentLabelsDependenciesTest(BaseServerTestCase):
         self.put_deployment_with_labels([{'csys-env-type': 'acidic'},
                                          {'key2': 'val2'},
                                          {'key3': 'val3'}],
-                                        'acidic')
+                                        'basic')
         self.put_deployment_with_labels([{'csys-env-type': 'controller'},
                                          {'key1': 'val1'},
                                          {'key3': 'val3'}],
                                         'controller')
         deployments = self.client.deployments.list(sort='environment_type')
         self.assertEqual([dep.id for dep in deployments],
-                         ['dep1', 'dep2', 'acidic', 'controller', 'subcloud'])
+                         ['dep1', 'dep2', 'basic', 'controller', 'subcloud'])

--- a/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
@@ -584,23 +584,36 @@ class DeploymentLabelsDependenciesTest(BaseServerTestCase):
         self.assertEqual(deployment.sub_services_count, 2)
 
     def test_csys_env_type(self):
-        self.put_deployment(deployment_id='dep1')
-        self.put_deployment_with_labels([{'key1': 'val1'},
-                                         {'key2': 'val3'},
-                                         {'key3': 'val3'}],
-                                        'dep2')
-        self.put_deployment_with_labels([{'csys-env-type': 'subcloud'},
-                                         {'key1': 'val1'},
-                                         {'key2': 'val2'}],
-                                        'subcloud')
-        self.put_deployment_with_labels([{'csys-env-type': 'acidic'},
-                                         {'key2': 'val2'},
-                                         {'key3': 'val3'}],
-                                        'basic')
-        self.put_deployment_with_labels([{'csys-env-type': 'controller'},
-                                         {'key1': 'val1'},
-                                         {'key3': 'val3'}],
-                                        'controller')
+        _, _, _, dep1 = self.put_deployment(deployment_id='dep1')
+        self.assertEqual(dep1.environment_type, '')
+
+        dep2 = self.put_deployment_with_labels([{'key1': 'val1'},
+                                                {'key2': 'val3'},
+                                                {'key3': 'val3'}],
+                                                'dep2')
+        self.assertEqual(dep2.environment_type, '')
+
+        subcloud = self.put_deployment_with_labels(
+            [{'csys-env-type': 'subcloud'},
+             {'key1': 'val1'},
+             {'key2': 'val2'}],
+            'subcloud')
+        self.assertEqual(subcloud.environment_type, 'subcloud')
+
+        basic = self.put_deployment_with_labels(
+            [{'csys-env-type': 'basic'},
+             {'key2': 'val2'},
+             {'key3': 'val3'}],
+            'basic')
+        self.assertEqual(basic.environment_type, 'basic')
+
+        controller = self.put_deployment_with_labels(
+            [{'csys-env-type': 'controller'},
+             {'key1': 'val1'},
+             {'key3': 'val3'}],
+            'controller')
+        self.assertEqual(controller.environment_type, 'controller')
+
         deployments = self.client.deployments.list(sort='environment_type')
         self.assertEqual([dep.id for dep in deployments],
                          ['dep1', 'dep2', 'basic', 'controller', 'subcloud'])

--- a/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
@@ -590,7 +590,7 @@ class DeploymentLabelsDependenciesTest(BaseServerTestCase):
         dep2 = self.put_deployment_with_labels([{'key1': 'val1'},
                                                 {'key2': 'val3'},
                                                 {'key3': 'val3'}],
-                                                'dep2')
+                                               'dep2')
         self.assertEqual(dep2.environment_type, '')
 
         subcloud = self.put_deployment_with_labels(

--- a/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
@@ -582,3 +582,25 @@ class DeploymentLabelsDependenciesTest(BaseServerTestCase):
         deployment = self.client.deployments.get('env')
         self.assertEqual(deployment.sub_environments_count, 3)
         self.assertEqual(deployment.sub_services_count, 2)
+
+    def test_csys_env_type(self):
+        self.put_deployment(deployment_id='dep1')
+        self.put_deployment_with_labels([{'key1': 'val1'},
+                                         {'key2': 'val3'},
+                                         {'key3': 'val3'}],
+                                        'dep2')
+        self.put_deployment_with_labels([{'csys-env-type': 'subcloud'},
+                                         {'key1': 'val1'},
+                                         {'key2': 'val2'}],
+                                        'subcloud')
+        self.put_deployment_with_labels([{'csys-env-type': 'acidic'},
+                                         {'key2': 'val2'},
+                                         {'key3': 'val3'}],
+                                        'acidic')
+        self.put_deployment_with_labels([{'csys-env-type': 'controller'},
+                                         {'key1': 'val1'},
+                                         {'key3': 'val3'}],
+                                        'controller')
+        deployments = self.client.deployments.list(sort='environment_type')
+        self.assertEqual([dep.id for dep in deployments],
+                         ['dep1', 'dep2', 'acidic', 'controller', 'subcloud'])


### PR DESCRIPTION
Deployments cannot be sorted by `environment_type` because it is defined as a `property` and not as a `resource_field` of the table. 
This PR fixes it by defining `environment_type` as `hybrid_property`, which according to [this line](https://github.com/cloudify-cosmo/cloudify-manager/blob/master/rest-service/manager_rest/storage/models_base.py#L216) counts as a `resource_field`, and thus solves the issue.