### PR TITLE
RD-523 Optimize the operation-update call

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2116,28 +2116,24 @@ class ResourceManager(object):
                                  get_all_results=True,
                                  all_tenants=True)[0]
         graph = models.TasksGraph(
-            id=uuid.uuid4().hex,
             name=name,
             _execution_fk=execution._storage_id,
             created_at=utils.get_formatted_timestamp(),
             _tenant_id=execution._tenant_id,
             _creator_id=execution._creator_id
         )
-        self.sm.put(graph)
+        db.session.add(graph)
         if operations:
-            created_at = utils.get_formatted_timestamp()
             created_ops = []
             for operation in operations:
                 operation.setdefault('state', 'pending')
                 op = models.Operation(
                     tenant=utils.current_tenant,
                     creator=current_user,
-                    _tasks_graph_fk=graph._storage_id,
-                    created_at=created_at,
+                    tasks_graph=graph,
                     **operation)
                 created_ops.append(op)
                 db.session.add(op)
-            self.sm._safe_commit()
         if execution.total_operations is None:
             execution.total_operations = 0
             execution.finished_operations = 0

--- a/rest-service/manager_rest/rest/resources_v3_1/operations.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/operations.py
@@ -159,11 +159,13 @@ class TasksGraphsId(SecuredResource):
             'execution_id': {'type': text_type, 'required': True},
             'operations': {'required': False}
         })
-        tasks_graph = get_resource_manager().create_tasks_graph(
-            name=params['name'],
-            execution_id=params['execution_id'],
-            operations=params.get('operations', [])
-        )
+        sm = get_storage_manager()
+        with sm.transaction():
+            tasks_graph = get_resource_manager().create_tasks_graph(
+                name=params['name'],
+                execution_id=params['execution_id'],
+                operations=params.get('operations', [])
+            )
         return tasks_graph, 201
 
     @authorize('operations')

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1832,7 +1832,9 @@ class TasksGraph(SQLResourceBase):
             unique=True
         ),
     )
+    is_id_unique = False
 
+    id = db.Column(db.Text, index=True, default=lambda: str(uuid.uuid4()))
     name = db.Column(db.Text, index=True)
     created_at = db.Column(UTCDateTime, nullable=False, index=True)
 
@@ -1845,12 +1847,13 @@ class TasksGraph(SQLResourceBase):
     execution_id = association_proxy('execution', 'id')
 
 
-class Operation(SQLResourceBase):
+class Operation(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'operations'
+    is_id_unique = False
 
+    id = db.Column(db.Text, index=True, default=lambda: str(uuid.uuid4()))
     name = db.Column(db.Text)
     state = db.Column(db.Text, nullable=False)
-    created_at = db.Column(UTCDateTime, nullable=False, index=True)
 
     dependencies = db.Column(db.ARRAY(db.Text))
     type = db.Column(db.Text)


### PR DESCRIPTION
This makes the endpoint slightly faster, saving on the order of 3ms
per call (and one roundtrip, if the db is remote).

Instead of fetching-and-updating the execution operation counts,
use a sql UPDATE query. We never retrieve the former count, so
no need for locking.

Best see each commit separately