### PR TITLE
inte-tests config: add some retries

### DIFF
--- a/tests/integration_tests/resources/scripts/prepare_reset_storage.py
+++ b/tests/integration_tests/resources/scripts/prepare_reset_storage.py
@@ -9,9 +9,9 @@ from manager_rest.flask_utils import setup_flask_app
 
 MANAGER_CONFIG = {
     'workflow': {
-        'task_retries': 0,
-        'task_retry_interval': 0,
-        'subgraph_retries': 0
+        'task_retries': 5,
+        'task_retry_interval': 1,
+        'subgraph_retries': 5,
     },
 }
 


### PR DESCRIPTION
In inte-tests, we set the manager config to have 0 retries and 0
retry-interval; this saves some time on failing tests (don't want
to wait the default 15 minutes), but is too unrealistic. Actual
usage of the manager will of course always have some retries.

These settings try to be more realistic, while still being as fast
as possible.