### PR TITLE
RD-2352 Don't start new executions from executions being cancelled

### DIFF
--- a/cloudify_types/cloudify_types/component/component.py
+++ b/cloudify_types/cloudify_types/component/component.py
@@ -18,9 +18,12 @@ import time
 from cloudify import manager, ctx
 from cloudify._compat import urlparse
 from cloudify.constants import COMPONENT
-from cloudify.exceptions import NonRecoverableError
+from cloudify.exceptions import NonRecoverableError, OperationRetry
 from cloudify_rest_client.client import CloudifyClient
-from cloudify_rest_client.exceptions import CloudifyClientError
+from cloudify_rest_client.exceptions import (
+    CloudifyClientError,
+    ForbiddenWhileCancelling,
+)
 from cloudify.deployment_dependencies import (dependency_creator_generator,
                                               create_deployment_dependency)
 
@@ -139,6 +142,8 @@ class Component(object):
 
         try:
             return option_client(**request_args)
+        except ForbiddenWhileCancelling:
+            raise OperationRetry()
         except CloudifyClientError as ex:
             raise NonRecoverableError(
                 'Client action "{0}" failed: {1}.'.format(request_action,

--- a/rest-service/manager_rest/manager_exceptions.py
+++ b/rest-service/manager_rest/manager_exceptions.py
@@ -134,6 +134,10 @@ class ForbiddenError(ManagerException):
     status_code = 403
 
 
+class ForbiddenWhileCancelling(ForbiddenError):
+    error_code = 'forbidden_while_cancelling'
+
+
 class UnsupportedContentTypeError(ManagerException):
     error_code = 'unsupported_content_type_error'
     status_code = 415

--- a/rest-service/manager_rest/rest/resources_v1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v1/executions.py
@@ -28,7 +28,10 @@ from manager_rest.resource_manager import (
     get_resource_manager,
 )
 from manager_rest.rest import requests_schema
-from manager_rest.rest.rest_decorators import marshal_with
+from manager_rest.rest.rest_decorators import (
+    marshal_with,
+    not_while_cancelling
+)
 from manager_rest.rest.rest_utils import (
     get_args_and_verify_arguments,
     get_json_and_verify_params,
@@ -82,6 +85,7 @@ class Executions(SecuredResource):
             filters=deployment_id_filter).items
 
     @authorize('execution_start')
+    @not_while_cancelling
     @marshal_with(models.Execution)
     def post(self, **kwargs):
         """Execute a workflow"""

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -737,6 +737,7 @@ class DeploymentGroupsId(SecuredResource):
 
     @authorize('deployment_group_create')
     @rest_decorators.marshal_with(models.DeploymentGroup, force_get_data=True)
+    @rest_decorators.not_while_cancelling
     def put(self, group_id):
         request_dict = rest_utils.get_json_and_verify_params({
             'description': {'optional': True},
@@ -781,6 +782,7 @@ class DeploymentGroupsId(SecuredResource):
 
     @authorize('deployment_group_update')
     @rest_decorators.marshal_with(models.DeploymentGroup, force_get_data=True)
+    @rest_decorators.not_while_cancelling
     def patch(self, group_id):
         request_dict = rest_utils.get_json_and_verify_params({
             'add': {'optional': True},

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -211,6 +211,7 @@ class DeploymentsId(resources_v1.DeploymentsId):
 
     @authorize('deployment_create')
     @rest_decorators.marshal_with(models.Deployment)
+    @rest_decorators.not_while_cancelling
     def put(self, deployment_id, **kwargs):
         """
         Create a deployment

--- a/rest-service/manager_rest/rest/resources_v3_1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/executions.py
@@ -165,6 +165,7 @@ class ExecutionGroups(SecuredResource):
 
     @authorize('execution_group_create')
     @rest_decorators.marshal_with(models.ExecutionGroup, force_get_data=True)
+    @rest_decorators.not_while_cancelling
     def post(self):
         request_dict = get_json_and_verify_params({
             'deployment_group_id': {'type': str},


### PR DESCRIPTION
The race with components+cancelling is that when we ask to cancel
an execution which contains components, we also cancel the running
component executions.

...but only running component executions!

However, if we cancel the main execution, and only afterwards the
currently running operation, starts the component execution, then
the newly-created execution is of course started and running.

To prevent that, we add the concept of endpoints that are unavailable
to be called from executions-that-are-being-cancelled.
In other words, if an execution has received a cancel request, it can
no longer do things like start new executions, or create deployments.