### PR TITLE
Revert default sorting

### DIFF
--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -153,9 +153,10 @@ class SQLStorageManager(object):
                     query = query.order_by(order(column))
                 else:
                     query = query.order_by(column)
-        default_sort = model_class.default_sort_column()
-        if default_sort:
-            query = query.order_by(default_sort)
+        else:
+            default_sort = model_class.default_sort_column()
+            if default_sort:
+                query = query.order_by(default_sort)
         return query
 
     def _filter_query(self,

--- a/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_labels_dependencies.py
@@ -584,14 +584,11 @@ class DeploymentLabelsDependenciesTest(BaseServerTestCase):
         self.assertEqual(deployment.sub_services_count, 2)
 
     def test_csys_env_type(self):
-        _, _, _, dep1 = self.put_deployment(deployment_id='dep1')
-        self.assertEqual(dep1.environment_type, '')
-
-        dep2 = self.put_deployment_with_labels([{'key1': 'val1'},
+        dep1 = self.put_deployment_with_labels([{'key1': 'val1'},
                                                 {'key2': 'val3'},
                                                 {'key3': 'val3'}],
-                                               'dep2')
-        self.assertEqual(dep2.environment_type, '')
+                                               'dep1')
+        self.assertEqual(dep1.environment_type, '')
 
         subcloud = self.put_deployment_with_labels(
             [{'csys-env-type': 'subcloud'},
@@ -616,4 +613,4 @@ class DeploymentLabelsDependenciesTest(BaseServerTestCase):
 
         deployments = self.client.deployments.list(sort='environment_type')
         self.assertEqual([dep.id for dep in deployments],
-                         ['dep1', 'dep2', 'basic', 'controller', 'subcloud'])
+                         ['dep1', 'basic', 'controller', 'subcloud'])


### PR DESCRIPTION
Default sorting fails when evaluating queries that use `GROUP BY`, such as `summary`. This is reverted in this PR.

**Nevertheless**, this also means that when sorting deployments bt `environment_type`, deployments with `environment_type=''` will be sorted arbitrarily. https://cloudifysource.atlassian.net/browse/RD-2389