### PR TITLE
inte-tests: limit the gunicorn worker count

### DIFF
--- a/tests/integration_tests/framework/docker.py
+++ b/tests/integration_tests/framework/docker.py
@@ -16,6 +16,9 @@ validations:
     skip_validations: true
 sanity:
     skip_sanity: true
+restservice:
+    gunicorn:
+        max_worker_count: 4
 service_management: {0}
 """.format(service_management))
     command = [


### PR DESCRIPTION
This makes the inte-tests containers a bit lighter, while
still having it run pretty much just as fast