### PR TITLE
RD-2416 Fix is_not and is_null filter operators

### DIFF
--- a/rest-service/manager_rest/test/endpoints/test_filters.py
+++ b/rest-service/manager_rest/test/endpoints/test_filters.py
@@ -53,7 +53,11 @@ class FiltersFunctionalityBaseCase(base_test.BaseServerTestCase):
         super().setUp()
         self.resource_model = resource_model
 
-    def _test_labels_filters_applied(self, res_1_id, res_2_id, res_3_id):
+    def _test_labels_filters_applied(self,
+                                     res_1_id,
+                                     res_2_id,
+                                     res_3_id,
+                                     res_4_id):
         self.assert_filters_applied([('a', ['b'], LabelsOperator.ANY_OF,
                                       'label')],
                                     {res_1_id, res_2_id}, self.resource_model)
@@ -76,10 +80,11 @@ class FiltersFunctionalityBaseCase(base_test.BaseServerTestCase):
                                       'label')],
                                     {res_1_id}, self.resource_model)
         self.assert_filters_applied([('a', [], LabelsOperator.IS_NULL,
-                                      'label')], {res_3_id},
+                                      'label')], {res_3_id, res_4_id},
                                     self.resource_model)
         self.assert_filters_applied([('c', ['z'], LabelsOperator.IS_NOT,
-                                      'label')], {res_1_id, res_3_id},
+                                      'label')],
+                                    {res_1_id, res_3_id, res_4_id},
                                     self.resource_model)
 
     def test_filter_rule_not_dictionary_fails(self):
@@ -154,7 +159,9 @@ class BlueprintsFiltersFunctionalityCase(FiltersFunctionalityBaseCase):
                                               blueprint_id='bp_2')
         bp_3 = self.put_blueprint_with_labels(self.LABELS_3,
                                               blueprint_id='bp_3')
-        self._test_labels_filters_applied(bp_1['id'], bp_2['id'], bp_3['id'])
+        bp_4 = self.put_blueprint(blueprint_id='bp_4')
+        self._test_labels_filters_applied(bp_1['id'], bp_2['id'], bp_3['id'],
+                                          bp_4['id'])
 
 
 @attr(client_min_version=3.1, client_max_version=base_test.LATEST_API_VERSION)
@@ -176,7 +183,9 @@ class DeploymentFiltersFunctionalityCase(FiltersFunctionalityBaseCase):
         dep3 = self.put_deployment_with_labels(self.LABELS_3,
                                                resource_id='res_3',
                                                site_name='other_site')
-        self._test_labels_filters_applied(dep1.id, dep2.id, dep3.id)
+        _, _, _, dep4 = self.put_deployment(deployment_id='res_4',
+                                            blueprint_id='res_4')
+        self._test_labels_filters_applied(dep1.id, dep2.id, dep3.id, dep4.id)
         self.assert_filters_applied(
             [('a', ['b'], LabelsOperator.ANY_OF, 'label'),
              ('c', ['y', 'z'], LabelsOperator.NOT_ANY_OF, 'label')], {dep1.id})


### PR DESCRIPTION
The `is_not` and `is_null` filter operators didn't consider resources with no labels. This PR fixes it by using the resource table `_storage_id` column instead of the labels table `_labeled_model_fk` column. 