### PR TITLE
RD-2414 Set executions to failed when they can't run

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -257,8 +257,8 @@ class ResourceManager(object):
                 execution.deployment,
                 execution.workflow_id
             )
-        except (manager_exceptions.IllegalExecutionParametersError,
-                manager_exceptions.NonexistentWorkflowError) as e:
+            execution.render_context()  # try this here to fail early
+        except Exception as e:
             execution.status = ExecutionState.FAILED
             execution.error = str(e)
             return False

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -252,6 +252,12 @@ class ResourceManager(object):
             return True
         self.sm.refresh(execution.deployment)
         try:
+            if execution and execution.deployment and \
+                    execution.deployment.create_execution:
+                create_execution = execution.deployment.create_execution
+                if create_execution.status == ExecutionState.FAILED:
+                    raise RuntimeError('create_deployment_environment failed')
+
             execution.merge_workflow_parameters(
                 execution.parameters,
                 execution.deployment,

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -980,12 +980,18 @@ class ResourceManager(object):
                 if not self._refresh_execution(execution):
                     return
 
-        workflow_executor.execute_workflow(
-            execution,
-            bypass_maintenance=bypass_maintenance,
-            wait_after_fail=wait_after_fail,
-            handler=send_handler,
-        )
+        try:
+            workflow_executor.execute_workflow(
+                execution,
+                bypass_maintenance=bypass_maintenance,
+                wait_after_fail=wait_after_fail,
+                handler=send_handler,
+            )
+        except Exception as e:
+            execution.status = ExecutionState.FAILED
+            execution.error = str(e)
+            self.sm.update(execution)
+            return
 
         workflow = execution.get_workflow()
         is_cascading_workflow = workflow.get('is_cascading', False)


### PR DESCRIPTION
If create-dep-env fails, the other executions for that deployment can't
run, so set them failed, because otherwise they're pending forever.

Actually, this does it in 3 (!) ways, to also catch other kinds of errors
as well.