### PR TITLE
inte-tests: set subgraph_retries config in the retries test

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_task_retries.py
+++ b/tests/integration_tests/tests/agentless_tests/test_task_retries.py
@@ -31,6 +31,7 @@ class TaskRetriesTest(AgentlessTestCase):
 
     def configure(self, retries, retry_interval):
         self.client.manager.put_config('task_retries', retries)
+        self.client.manager.put_config('subgraph_retries', 0)
         self.client.manager.put_config('task_retry_interval', retry_interval)
 
     def test_retries_and_retry_interval(self):


### PR DESCRIPTION
those tests assert on the amount of retries done, so they need
to set a known amount of retries beforehand

recently i've changed the amount in #3058 for all tests, and these
retry tests, still assume the previous amounts were in place