### PR TITLE
Set execution status to FAILED if global/dependencies checks fail

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -235,12 +235,17 @@ class ResourceManager(object):
         amqp_client.add_handler(handler)
         with amqp_client:
             for execution in to_run:
-                if execution.is_system_workflow:
-                    self._execute_system_workflow(
-                        execution, queue=True, send_handler=handler)
-                else:
-                    self.execute_workflow(
-                        execution, queue=True, send_handler=handler)
+                try:
+                    if execution.is_system_workflow:
+                        self._execute_system_workflow(
+                            execution, queue=True, send_handler=handler)
+                    else:
+                        self.execute_workflow(
+                            execution, queue=True, send_handler=handler)
+                except Exception as e:
+                    current_app.logger.warning(
+                        'Could not dequeue execution %s: %s',
+                        execution, e)
 
     def _refresh_execution(self, execution: models.Execution) -> bool:
         """Prepare the execution to be started.

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -965,9 +965,16 @@ class ResourceManager(object):
                          send_handler: 'SendHandler' = None):
         with self.sm.transaction():
             if execution.deployment:
-                self._check_allow_global_execution(execution.deployment)
-                self._verify_dependencies_not_affected(
-                    execution.workflow_id, execution.deployment, force)
+                try:
+                    self._check_allow_global_execution(execution.deployment)
+                    self._verify_dependencies_not_affected(
+                        execution.workflow_id, execution.deployment, force)
+                except Exception as e:
+                    execution.status = ExecutionState.FAILED
+                    execution.error = str(e)
+                    self.sm.update(execution)
+                    db.session.commit()
+                    raise
 
             should_queue = queue
             if not allow_overlapping_running_wf:


### PR DESCRIPTION
If these checks fail, set the status to failed, and raise.
As opposed to leaving the execution in 'pending'.

Force commit there so that we can commit even though we raise.