### PR TITLE
Force Prometheus re-scraping before testing status

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_manager_status.py
+++ b/tests/integration_tests/tests/agentless_tests/test_manager_status.py
@@ -35,6 +35,10 @@ SERVICES = {
 class TestManagerStatus(AgentlessTestCase):
 
     def test_status_response(self):
+        # Force Prometheus to scrape the statuses
+        self.execute_on_manager('bash -c "pkill -SIGHUP prometheus"')
+        time.sleep(1)
+
         manager_status = self.client.manager.get_status()
         self.assertEqual(manager_status['status'], ServiceStatus.HEALTHY)
 


### PR DESCRIPTION
Sometimes tests `test_status_*_inactive` would make Prometheus report a
particular service as inactive.  Its polling/scraping mechanism is not
designed to deal with a swift changes in the services' statuses, i.e. it
takes time to update them.

Restarting Prometheus forces it to re-scrape the statuses.