### PR TITLE
Restart exporters before re-scraping data

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_manager_status.py
+++ b/tests/integration_tests/tests/agentless_tests/test_manager_status.py
@@ -36,8 +36,12 @@ class TestManagerStatus(AgentlessTestCase):
 
     def test_status_response(self):
         # Force Prometheus to scrape the statuses
+        self.restart_service('blackbox_exporter')
+        self.restart_service('postgres_exporter')
+        self.restart_service('node_exporter')
+        time.sleep(1.5)
         self.execute_on_manager('bash -c "pkill -SIGHUP prometheus"')
-        time.sleep(1)
+        time.sleep(0.5)
 
         manager_status = self.client.manager.get_status()
         self.assertEqual(manager_status['status'], ServiceStatus.HEALTHY)


### PR DESCRIPTION
Exporters are responsible for presenting Prometheus with services'
metrics.  We should make sure these metrics are up-to-date before
scraping them.