### PR TITLE
RD-2373 Reload permisisons after restoring a snapshot

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/postgres.py
+++ b/workflows/cloudify_system_workflows/snapshots/postgres.py
@@ -238,6 +238,14 @@ class Postgres(object):
     def restore_permissions_table(self, permissions_path):
         self._restore_dump(permissions_path, self._db_name)
 
+    def refresh_roles(self):
+        """Bump updated_at for all roles, so that restservice reloads them
+
+        This is useful for when the snapshot restored permissions for some
+        roles, so that the restservice knows to reload them.
+        """
+        self.run_query("UPDATE public.roles SET updated_at=NOW()")
+
     def dump_config_tables(self, tempdir):
         pg_dump_bin = os.path.join(self._bin_dir, 'pg_dump')
         path = os.path.join(tempdir, 'config.dump')

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -157,6 +157,7 @@ class SnapshotRestore(object):
                 self._update_node_instance_indices()
                 self._set_default_user_profile_flags()
                 self._create_system_filters()
+                postgres.refresh_roles()
 
             if self._restore_certificates:
                 self._restore_certificate()


### PR DESCRIPTION
The snapshot can contain permission changes, so the restservice
must reload them.
Bumping updated_at is enough for it to know that the permissions
(and configs) need to be reloaded.