### PR TITLE
replace datetime.now() calls with datetime.utcnow()

### DIFF
--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -311,7 +311,7 @@ class Config(object):
                 'name': entry.name,
                 'scope': entry.scope,
                 'value': value,
-                'updated_at': datetime.now(),
+                'updated_at': datetime.utcnow(),
                 '_updater_id': current_user.id,
             })
         session.bulk_update_mappings(models.Config, config_mappings)

--- a/rest-service/manager_rest/plugins_update/manager.py
+++ b/rest-service/manager_rest/plugins_update/manager.py
@@ -80,7 +80,7 @@ class PluginsUpdateManager(object):
                 return f'{description}\n{comment}'
             return comment
 
-        timestamp = datetime.now().strftime('%Y%m%dT%H%M%S.%f')
+        timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%S.%f')
         temp_blueprint_id = f'plugins-update-{timestamp}-{blueprint.id}'
         kwargs = {
             'application_file_name': blueprint.main_file_name,

--- a/rest-service/manager_rest/security/authentication.py
+++ b/rest-service/manager_rest/security/authentication.py
@@ -57,7 +57,7 @@ class Authentication(object):
 
     @staticmethod
     def _increment_failed_logins_counter(user):
-        user.last_failed_login_at = datetime.now()
+        user.last_failed_login_at = datetime.utcnow()
         user.failed_logins_counter += 1
         user_datastore.commit()
 
@@ -82,7 +82,7 @@ class Authentication(object):
             # (User + Password), otherwise the counter will be reset on
             # every UI refresh (every 4 sec) and accounts won't be locked.
             user.failed_logins_counter = 0
-            now = datetime.now()
+            now = datetime.utcnow()
             if not user.last_login_at:
                 user.first_login_at = now
             user.last_login_at = now

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -481,7 +481,7 @@ class User(SQLModelBase, UserMixin):
                 minutes=config.instance.account_lock_period)
             last_failed_login = date_parser.parse(
                 self.last_failed_login_at, ignoretz=True)
-            if last_failed_login + lockout_period > datetime.now():
+            if last_failed_login + lockout_period > datetime.utcnow():
                 return True
         return False
 

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -905,7 +905,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
             id='dep1',
             display_name='dep1',
             blueprint=bp,
-            created_at=datetime.now()
+            created_at=datetime.utcnow()
         ))
         new_attributes = {
             'description': 'descr1',
@@ -931,7 +931,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
             display_name='dep1',
             blueprint=bp,
             description='d1',
-            created_at=datetime.now()
+            created_at=datetime.utcnow()
         ))
         with self.assertRaisesRegex(CloudifyClientError, 'already set'):
             self.client.deployments.set_attributes('dep1', description='d2')
@@ -998,7 +998,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
         self.assertListEqual(filtered_dep_ids, ['born-with-schedules'])
 
         self.client.execution_schedules.create(
-            'custom-sc', dep_2.id, 'install', since=datetime.now(), count=1)
+            'custom-sc', dep_2.id, 'install', since=datetime.utcnow(), count=1)
         self.client.execution_schedules.delete('sc1', dep_1.id)
 
         # now each deployment has 1 schedule
@@ -1068,7 +1068,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
             blueprint_file_name='blueprint_with_default_schedules.yaml')
 
         self.client.execution_schedules.create(
-            'sc3', deployment.id, 'install', since=datetime.now(), count=1)
+            'sc3', deployment.id, 'install', since=datetime.utcnow(), count=1)
 
         new_blueprint_id = 'updated_schedules'
         self.put_blueprint(

--- a/rest-service/manager_rest/test/endpoints/test_execution_schedules.py
+++ b/rest-service/manager_rest/test/endpoints/test_execution_schedules.py
@@ -13,13 +13,13 @@ class ExecutionSchedulesTestCase(BaseServerTestCase):
     DEPLOYMENT_ID = 'deployment'
     fmt = '%Y-%m-%dT%H:%M:%S.%fZ'
     an_hour_from_now = \
-        datetime.now().replace(microsecond=0) + timedelta(hours=1)
+        datetime.utcnow().replace(microsecond=0) + timedelta(hours=1)
     two_hours_from_now = \
-        datetime.now().replace(microsecond=0) + timedelta(hours=2)
+        datetime.utcnow().replace(microsecond=0) + timedelta(hours=2)
     three_hours_from_now = \
-        datetime.now().replace(microsecond=0) + timedelta(hours=3)
+        datetime.utcnow().replace(microsecond=0) + timedelta(hours=3)
     three_weeks_from_now = \
-        datetime.now().replace(microsecond=0) + timedelta(weeks=3)
+        datetime.utcnow().replace(microsecond=0) + timedelta(weeks=3)
     deployment_id = None
 
     def setUp(self):

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -479,7 +479,7 @@ class ExecutionsTestCase(BaseServerTestCase):
         execution = self.sm.put(models.Execution(
             id=str(uuid.uuid4()),
             _deployment_fk=deployment._storage_id,
-            created_at=datetime.now(),
+            created_at=datetime.utcnow(),
             is_system_workflow=False,
             workflow_id='install',
             status=status,
@@ -489,13 +489,13 @@ class ExecutionsTestCase(BaseServerTestCase):
         tasks_graph = self.sm.put(models.TasksGraph(
             _execution_fk=execution._storage_id,
             name='install',
-            created_at=datetime.now()
+            created_at=datetime.utcnow()
         ))
         operation = self.sm.put(models.Operation(
             _tasks_graph_fk=tasks_graph._storage_id,
             parameters={'current_retries': 20},
             state=cloudify_tasks.TASK_FAILED,
-            created_at=datetime.now()
+            created_at=datetime.utcnow()
         ))
 
         self.client.executions.resume(execution.id, force=True)
@@ -541,7 +541,7 @@ class ExecutionsTestCase(BaseServerTestCase):
         execution = self.sm.put(models.Execution(
             id='execution-1',
             _deployment_fk=deployment._storage_id,
-            created_at=datetime.now(),
+            created_at=datetime.utcnow(),
             is_system_workflow=False,
             workflow_id='install',
             blueprint_id=deployment.blueprint_id
@@ -571,7 +571,7 @@ class ExecutionsTestCase(BaseServerTestCase):
         execution = self.sm.put(models.Execution(
             id='execution-1',
             _deployment_fk=deployment._storage_id,
-            created_at=datetime.now(),
+            created_at=datetime.utcnow(),
             is_system_workflow=False,
             workflow_id='install',
             blueprint_id=deployment.blueprint_id

--- a/rest-service/manager_rest/test/endpoints/test_operations.py
+++ b/rest-service/manager_rest/test/endpoints/test_operations.py
@@ -40,7 +40,7 @@ class OperationsTestCase(base_test.BaseServerTestCase):
         session.commit()
 
         self.execution = models.Execution(
-            created_at=datetime.now(),
+            created_at=datetime.utcnow(),
             id='execution_{}'.format(self.fake.uuid4()),
             is_system_workflow=False,
             workflow_id='install',

--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -238,7 +238,7 @@ class TestTransactions(base_test.BaseServerTestCase):
     def _make_secret(self, id, value):
         # these tests are using secrets, but they could just as well
         # use any other model, we just need to create _something_ in the db
-        now = datetime.now()
+        now = datetime.utcnow()
         return models.Secret(
             id=id,
             value=value,

--- a/rest-service/manager_rest/test/mocks.py
+++ b/rest-service/manager_rest/test/mocks.py
@@ -240,7 +240,7 @@ def _get_or_create_blueprint(storage_manager, blueprint_id):
     except manager_exceptions.NotFoundError:
         blueprint = Blueprint(
             id=blueprint_id,
-            created_at=datetime.now(),
+            created_at=datetime.utcnow(),
             main_file_name='',
             plan={}
         )
@@ -276,7 +276,7 @@ def _get_or_create_node(storage_manager, node_id, deployment):
 def upload_mock_cloudify_license(storage_manager):
     license = License(
         customer_id='mock_customer',
-        expiration_date=datetime.now(),
+        expiration_date=datetime.utcnow(),
         license_edition='Spire',
         cloudify_version='4.6',
         capabilities='mock-capabilities',


### PR DESCRIPTION
there is never a reason to use the local time. Always use utc.
Otherwise we'll have problems comparing those datetimes, when one
is locally-generated, and another comes from a remote system, who
does use utc (eg. the ui)

Also, using local times is a good way to have your time-comparing
tests fail on non-utc machines.