### PR TITLE
RD-2471 Force blueprint deletion regardless of state

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -682,7 +682,7 @@ class ResourceManager(object):
 
         if blueprint.state in BlueprintUploadState.FAILED_STATES:
             return self.sm.delete(blueprint)
-        if (blueprint.state and
+        if (blueprint.state and not force and
                 blueprint.state != BlueprintUploadState.UPLOADED):
             # don't allow deleting blueprints while still uploading,
             # so we don't leave a dirty file system


### PR DESCRIPTION
In case a blueprint is being deleted with a `force` flag, don't worry
about its status.  Just delete it.