### PR TITLE
RD-2524 Use OR operator for search_name and search

### DIFF
--- a/rest-service/manager_rest/rest/resources_v2/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v2/deployments.py
@@ -61,10 +61,6 @@ class Deployments(resources_v1.Deployments):
             '_get_all_results',
             request.args.get('_get_all_results', False)
         )
-        search_on_id_or_display_name = rest_utils.verify_and_convert_bool(
-            '_search_on_id_or_display_name',
-            request.args.get('_search_on_id_or_display_name', False)
-        )
         filters, _include = rest_utils.modify_deployments_list_args(filters,
                                                                     _include)
         filter_rules = get_filter_rules_from_filter_id(
@@ -78,8 +74,7 @@ class Deployments(resources_v1.Deployments):
             sort=sort,
             all_tenants=all_tenants,
             get_all_results=get_all_results,
-            filter_rules=filter_rules,
-            use_or_on_substr_filters=search_on_id_or_display_name
+            filter_rules=filter_rules
         )
 
         if _include and 'workflows' in _include:

--- a/rest-service/manager_rest/rest/resources_v2/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v2/deployments.py
@@ -61,6 +61,10 @@ class Deployments(resources_v1.Deployments):
             '_get_all_results',
             request.args.get('_get_all_results', False)
         )
+        search_on_id_or_display_name = rest_utils.verify_and_convert_bool(
+            '_search_on_id_or_display_name',
+            request.args.get('_search_on_id_or_display_name', False)
+        )
         filters, _include = rest_utils.modify_deployments_list_args(filters,
                                                                     _include)
         filter_rules = get_filter_rules_from_filter_id(
@@ -74,7 +78,8 @@ class Deployments(resources_v1.Deployments):
             sort=sort,
             all_tenants=all_tenants,
             get_all_results=get_all_results,
-            filter_rules=filter_rules
+            filter_rules=filter_rules,
+            use_or_on_substr_filters=search_on_id_or_display_name
         )
 
         if _include and 'workflows' in _include:

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -18,7 +18,7 @@ from functools import wraps
 from collections import OrderedDict
 from contextlib import contextmanager
 from flask_security import current_user
-from sqlalchemy import or_ as sql_or, inspect, func
+from sqlalchemy import or_ as sql_or, and_ as sql_and, inspect, func
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from flask import current_app, has_request_context
@@ -166,7 +166,8 @@ class SQLStorageManager(object):
                       filters,
                       substr_filters,
                       all_tenants,
-                      filter_rules):
+                      filter_rules,
+                      use_or_on_substr_filters):
         """Add filter clauses to the query
 
         :param query: Base SQL query
@@ -181,7 +182,8 @@ class SQLStorageManager(object):
         query = self._add_tenant_filter(query, model_class, all_tenants)
         query = self._add_permissions_filter(query, model_class)
         query = self._add_value_filter(query, filters)
-        query = self._add_substr_filter(query, substr_filters)
+        query = self._add_substr_filter(query, substr_filters,
+                                        use_or_on_substr_filters)
         query = self._add_filter_rules(query, model_class, filter_rules)
         return query
 
@@ -210,15 +212,22 @@ class SQLStorageManager(object):
                 query = query.filter(column == value)
         return query
 
-    def _add_substr_filter(self, query, filters):
+    def _add_substr_filter(self, query, filters,
+                           use_or_on_substr_filters=False):
+        substr_conditions = []
         for column, value in filters.items():
             column, value = self._update_case_insensitive(column, value, True)
             if isinstance(value, text_type):
-                query = query.filter(column.contains(value))
+                substr_conditions.append(column.contains(value))
             else:
                 raise manager_exceptions.BadParametersError(
                     'Substring filtering is only supported for strings'
                 )
+        if use_or_on_substr_filters:
+            query.filter(sql_or(*substr_conditions))
+        else:
+            query.filter(sql_and(*substr_conditions))
+
         return query
 
     @staticmethod
@@ -352,7 +361,8 @@ class SQLStorageManager(object):
                    all_tenants=None,
                    distinct=None,
                    filter_rules=None,
-                   default_sorting=True):
+                   default_sorting=True,
+                   use_or_on_substr_filters=False):
         """Get an SQL query object based on the params passed
 
         :param model_class: SQL DB table class
@@ -381,7 +391,8 @@ class SQLStorageManager(object):
                                    filters,
                                    substr_filters,
                                    all_tenants,
-                                   filter_rules)
+                                   filter_rules,
+                                   use_or_on_substr_filters)
         query = self._sort_query(query, model_class, sort, distinct,
                                  default_sorting)
         return query
@@ -600,7 +611,8 @@ class SQLStorageManager(object):
              get_all_results=False,
              distinct=None,
              locking=False,
-             filter_rules=None):
+             filter_rules=None,
+             use_or_on_substr_filters=False):
         """Return a list of `model_class` results
 
         :param model_class: SQL DB table class
@@ -639,7 +651,8 @@ class SQLStorageManager(object):
                                 sort,
                                 all_tenants,
                                 distinct,
-                                filter_rules)
+                                filter_rules,
+                                use_or_on_substr_filters)
 
         results, total, size, offset = self._paginate(
             query,

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -1125,7 +1125,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
         _, _, _, dep2 = self.put_deployment(deployment_id='dep2',
                                             blueprint_id='bp2',
                                             display_name=dep2_name)
-        dep_list_1 = self.client.deployments.list(_search='dep',
+        dep_list_1 = self.client.deployments.list(_search='dep1',
                                                   _search_name=dep1_name)
         self.assertEqual(len(dep_list_1), 1)
         self.assertEqual(dep_list_1[0].id, dep1.id)
@@ -1140,3 +1140,14 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
         )
         dep = self.sm.get(models.Deployment, 'dep1')
         assert dep.display_name == 'y'
+
+    def test_deployments_list_search_by_search_name_or_id(self):
+        for i in range(3):
+            self.put_deployment(deployment_id=f'dep{i}',
+                                blueprint_id=f'bp{i}',
+                                display_name=f'display{i}')
+
+        dep_list = self.client.deployments.list(_search='dep0',
+                                                _search_name='display1')
+
+        self.assertEqual({dep.id for dep in dep_list}, {'dep0', 'dep1'})

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -1140,14 +1140,3 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
         )
         dep = self.sm.get(models.Deployment, 'dep1')
         assert dep.display_name == 'y'
-
-    def test_deployments_list_search_by_search_name_or_id(self):
-        for i in range(3):
-            self.put_deployment(deployment_id=f'dep{i}',
-                                blueprint_id=f'bp{i}',
-                                display_name=f'display{i}')
-
-        dep_list = self.client.deployments.list(_search='dep0',
-                                                _search_name='display1')
-
-        self.assertEqual({dep.id for dep in dep_list}, {'dep0', 'dep1'})

--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -233,6 +233,23 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         )
         self.assertEqual(20, len(secret_list))
 
+    def test_substr_filter_uses_or_operator(self):
+        now = utils.get_formatted_timestamp()
+        for i in range(3):
+            secret = models.Secret(id=f'secret_{i}',
+                                   value=f'value_{i}',
+                                   created_at=now,
+                                   updated_at=now,
+                                   visibility=VisibilityState.TENANT)
+            self.sm.put(secret)
+
+        secrets_list = self.sm.list(
+            models.Secret,
+            substr_filters={'id': 'secret_0', 'value': 'value_2'}
+        )
+        self.assertEqual({secret.id for secret in secrets_list},
+                         {'secret_0', 'secret_2'})
+
 
 class TestTransactions(base_test.BaseServerTestCase):
     def _make_secret(self, id, value):


### PR DESCRIPTION
This PR adds the functionality of searching on deployment id **_or_** deployment display name by simply making `OR` as the default operator for searches.