### PR TITLE
RD-2486 Throw an error if the blueprint dir already exists

### DIFF
--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -296,6 +296,7 @@ class BaseServerTestCase(unittest.TestCase):
         self.initialize_provider_context()
         self._setup_current_user()
         self.addCleanup(self._drop_db, keep_tables=['config'])
+        self.addCleanup(self._clean_tmpdir)
 
     @staticmethod
     def _drop_db(keep_tables=None):
@@ -312,6 +313,12 @@ class BaseServerTestCase(unittest.TestCase):
                 continue
             server.db.session.execute(table.delete())
         server.db.session.commit()
+
+    def _clean_tmpdir(self):
+        shutil.rmtree(os.path.join(self.tmpdir, 'blueprints'),
+                      ignore_errors=True)
+        shutil.rmtree(os.path.join(self.tmpdir, 'uploaded-blueprints'),
+                      ignore_errors=True)
 
     @classmethod
     def _mock_verify_role(cls):

--- a/rest-service/manager_rest/upload_manager.py
+++ b/rest-service/manager_rest/upload_manager.py
@@ -625,8 +625,15 @@ class UploadedBlueprintsManager(UploadedDataManager):
             FILE_SERVER_BLUEPRINTS_FOLDER,
             tenant)
         mkdirs(tenant_dir)
-        shutil.move(os.path.join(file_server_root, app_dir),
-                    os.path.join(tenant_dir, blueprint_id))
+        bp_from = os.path.join(file_server_root, app_dir)
+        bp_dir = os.path.join(tenant_dir, blueprint_id)
+        try:
+            # use os.rename - bp_from is already in file_server_root, ie.
+            # same filesystem as the target dir
+            os.rename(bp_from, bp_dir)
+        except OSError as e:  # eg. directory not empty
+            shutil.rmtree(bp_from)
+            raise manager_exceptions.ConflictError(str(e))
         self._process_plugins(file_server_root, blueprint_id)
 
     @staticmethod

--- a/workflows/cloudify_system_workflows/blueprint.py
+++ b/workflows/cloudify_system_workflows/blueprint.py
@@ -199,7 +199,16 @@ def upload(ctx, **kwargs):
         update_dict['description'] = plan['description']
     if labels:
         update_dict['labels'] = labels
-    client.blueprints.update(blueprint_id, update_dict=update_dict)
+    try:
+        client.blueprints.update(blueprint_id, update_dict=update_dict)
+    except Exception as e:
+        error_msg = 'Failed uploading blueprint - {}'.format(e)
+        client.blueprints.update(
+            blueprint_id,
+            update_dict={'state': BlueprintUploadState.FAILED_UPLOADING,
+                         'error': error_msg,
+                         'error_traceback': traceback.format_exc()})
+        raise
 
 
 def extract_parser_context(context, resolver_parameters):


### PR DESCRIPTION
The first commit explains it, so see there.

The second commit makes sure that the error gets propagated
to the user.