### PR TITLE
RD-2486 Throw an error if the blueprint dir already exists

### DIFF
--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -245,6 +245,7 @@ class BaseServerTestCase(unittest.TestCase):
         self.initialize_provider_context()
         self._setup_current_user()
         self.addCleanup(self._drop_db, keep_tables=['config'])
+        self.addCleanup(self._clean_tmpdir)
 
     @staticmethod
     def _drop_db(keep_tables=None):
@@ -261,6 +262,12 @@ class BaseServerTestCase(unittest.TestCase):
                 continue
             server.db.session.execute(table.delete())
         server.db.session.commit()
+
+    def _clean_tmpdir(self):
+        shutil.rmtree(os.path.join(self.tmpdir, 'blueprints'),
+                      ignore_errors=True)
+        shutil.rmtree(os.path.join(self.tmpdir, 'uploaded-blueprints'),
+                      ignore_errors=True)
 
     @classmethod
     def _mock_verify_role(cls):

--- a/rest-service/manager_rest/upload_manager.py
+++ b/rest-service/manager_rest/upload_manager.py
@@ -622,8 +622,15 @@ class UploadedBlueprintsManager(UploadedDataManager):
             FILE_SERVER_BLUEPRINTS_FOLDER,
             tenant)
         mkdirs(tenant_dir)
-        shutil.move(os.path.join(file_server_root, app_dir),
-                    os.path.join(tenant_dir, blueprint_id))
+        bp_from = os.path.join(file_server_root, app_dir)
+        bp_dir = os.path.join(tenant_dir, blueprint_id)
+        try:
+            # use os.rename - bp_from is already in file_server_root, ie.
+            # same filesystem as the target dir
+            os.rename(bp_from, bp_dir)
+        except OSError as e:  # eg. directory not empty
+            shutil.rmtree(bp_from)
+            raise manager_exceptions.ConflictError(str(e))
         self._process_plugins(file_server_root, blueprint_id)
 
     @staticmethod

--- a/workflows/cloudify_system_workflows/blueprint.py
+++ b/workflows/cloudify_system_workflows/blueprint.py
@@ -193,7 +193,16 @@ def upload(ctx, **kwargs):
     }
     if plan.get('description'):
         update_dict['description'] = plan['description']
-    client.blueprints.update(blueprint_id, update_dict=update_dict)
+    try:
+        client.blueprints.update(blueprint_id, update_dict=update_dict)
+    except Exception as e:
+        error_msg = 'Failed uploading blueprint - {}'.format(e)
+        client.blueprints.update(
+            blueprint_id,
+            update_dict={'state': BlueprintUploadState.FAILED_UPLOADING,
+                         'error': error_msg,
+                         'error_traceback': traceback.format_exc()})
+        raise
 
 
 def extract_parser_context(context, resolver_parameters):


### PR DESCRIPTION
This ports #3107 to 5.2.3

* use os.rename rather than shutil.move for the last move

this last rename of the dir is always inside of a single filesystem,
under /opt/manager/resources, so we can use os.rename directly

the difference is if the target directory already exists:
* target/ doesnt exist:
    * os.rename just renames the dir
    * so does shutil.move, and indeed it does use os.rename under
      the hood
* target/ exists and is empty
    * os.rename just stomps over the empty dir
    * so does shutil.move
* target/ exists and is not empty
    * os.rename throws an OSError
    * shutil.move moves the source dir INTO the target dir, so that
      we have target/source/   - THAT IS WRONG!

That last part is not what we want, because then we end up with
blueprints in an additional subdirectory, and then, of course scripts
and files from the blueprint can't be found under their expected
locations.

This happens in a cluster, with replication lag, where you had
a blueprint that you removed, and you upload a blueprint with the
same name. Then the old directory might have not been removed yet
on all the cluster nodes.

* Translate that error to a blueprint error

When the error from the first commit is thrown, make sure to mark
the blueprint as failed.

* tests: clean the tmpdir after each test

similar to how we drop the db, also the tmpdir needs to be cleaned.
Weird that it never caused any problems before!