### PR TITLE
RD-2532 Make test_environments less flaky

### DIFF
--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -782,7 +782,8 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
             from_dependencies = self.sm.list(
                 models.DeploymentLabelsDependencies,
                 filters={'target_deployment_id': v},
-                get_all_results=True
+                get_all_results=True,
+                locking=True,
             )
             if not from_dependencies:
                 continue

--- a/tests/integration_tests/tests/agentless_tests/test_environments.py
+++ b/tests/integration_tests/tests/agentless_tests/test_environments.py
@@ -2,8 +2,6 @@ import time
 
 import pytest
 
-from retrying import retry
-
 from integration_tests import AgentlessTestCase
 from integration_tests.tests.utils import get_resource as resource
 

--- a/tests/integration_tests/tests/agentless_tests/test_environments.py
+++ b/tests/integration_tests/tests/agentless_tests/test_environments.py
@@ -75,7 +75,6 @@ class EnvironmentTest(AgentlessTestCase):
             sub_environments_count
         )
 
-    @retry(wait_fixed=3000, stop_max_attempt_number=3)
     def _verify_statuses_and_count_for_deployment(self,
                                                   deployment_id,
                                                   deployment_status,

--- a/tests/integration_tests/tests/agentless_tests/test_environments.py
+++ b/tests/integration_tests/tests/agentless_tests/test_environments.py
@@ -715,10 +715,12 @@ class EnvironmentTest(AgentlessTestCase):
             'dsl/simple_deployment_with_parents.yaml',
             'updated-blueprint'
         )
-        self.client.deployment_updates.update_with_existing_blueprint(
+        dep_up = self.client.deployment_updates.update_with_existing_blueprint(
             deployment.id,
             blueprint_id='updated-blueprint'
         )
+        self.wait_for_execution_to_end(
+            self.client.executions.get(dep_up.execution_id))
         self._verify_statuses_and_count_for_deployment(
             environment_1.id,
             deployment_status=DeploymentState.GOOD,


### PR DESCRIPTION
1. Fix an actual race in `propagate_deployment_statuses`
2. Fix a tests-only race, by waiting for the update to finish
3. Now the retry isn't needed! (it wouldn't help 1 anyway)