### PR TITLE
Fix profile context in integration tests

### DIFF
--- a/tests/integration_tests/framework/utils.py
+++ b/tests/integration_tests/framework/utils.py
@@ -62,9 +62,8 @@ def sh_bake(command):
 
 
 def get_profile_context(container_id):
-    container_ip = docker.get_manager_ip(container_id)
     profile_context_cmd =\
-        'cat /root/.cloudify/profiles/{0}/context.json'.format(container_ip)
+        'cat /root/.cloudify/profiles/manager-local/context.json'
     return json.loads(docker.execute(container_id, profile_context_cmd))
 
 


### PR DESCRIPTION
The profile context path has changed between v5.2.2 and v5.2.3, so we should also change it in the integration tests.