### PR TITLE
RD-588 Update error message when ldap is not running

### DIFF
--- a/rest-service/manager_rest/manager_exceptions.py
+++ b/rest-service/manager_rest/manager_exceptions.py
@@ -395,3 +395,8 @@ class BadFilterRule(ManagerException):
             err_filter_rule=self.err_filter_rule,
             err_reason=self.error_reason
         )
+
+
+class NotListeningLDAPServer(ManagerException):
+    error_code = 'not_running_ldap_server'
+    status_code = 400

--- a/rest-service/manager_rest/manager_exceptions.py
+++ b/rest-service/manager_rest/manager_exceptions.py
@@ -399,4 +399,4 @@ class BadFilterRule(ManagerException):
 
 class NotListeningLDAPServer(ManagerException):
     error_code = 'not_running_ldap_server'
-    status_code = 400
+    status_code = 500


### PR DESCRIPTION
Detect the error when LDAP server is not running and display correct message when user trying to set invalid or LDAP server that is not listening 