### PR TITLE
snap-res refresh_roles: store timestamps in utc

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_events.py
+++ b/tests/integration_tests/tests/agent_tests/test_events.py
@@ -20,25 +20,17 @@ import pytest
 
 from integration_tests import AgentTestWithPlugins
 from integration_tests.tests.utils import get_resource as resource
-from integration_tests.tests.utils import run_postgresql_command
+from integration_tests.tests.agentless_tests.test_events import (
+    _SetAlternateTimezone
+)
+
 
 pytestmark = pytest.mark.group_events_logs
 
 
 @pytest.mark.usefixtures('dockercompute_plugin')
-class TimezoneTest(AgentTestWithPlugins):
-
+class TimezoneTest(_SetAlternateTimezone, AgentTestWithPlugins):
     """Events test cases using an alternative timezone (Asia/Jerusalem)."""
-
-    TIMEZONE = 'Asia/Jerusalem'
-
-    def setUp(self):
-        """Update postgres timezone and create a deployment."""
-        super(TimezoneTest, self).setUp()
-        run_postgresql_command(
-            self.env.container_id,
-            "ALTER USER cloudify SET TIME ZONE '{}'".format(self.TIMEZONE)
-        )
 
     def test_event_timezone(self):
         """Check timestamp values in agent machine.

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -183,10 +183,7 @@ class EventsTest(AgentlessTestCase):
         return test_deployment.id
 
 
-class EventsAlternativeTimezoneTest(EventsTest):
-
-    """Events test cases using an alternative timezone (Asia/Jerusalem)."""
-
+class _SetAlternateTimezone(object):
     TIMEZONE = 'Asia/Jerusalem'
 
     def setUp(self):
@@ -213,13 +210,13 @@ class EventsAlternativeTimezoneTest(EventsTest):
 
         time.sleep(1)   # give time for services to restart
         self.start_timestamp = datetime.utcnow().isoformat()
-        super(EventsAlternativeTimezoneTest, self).setUp()
+        super().setUp()
         # log storing is async, add a few seconds to allow for that
         self.stop_timestamp = \
             (datetime.utcnow() + timedelta(seconds=3)).isoformat()
 
     def tearDown(self):
-        super(EventsAlternativeTimezoneTest, self).tearDown()
+        super().tearDown()
         run_postgresql_command(
             self.env.container_id,
             "ALTER DATABASE cloudify_db SET TIME ZONE '{}'"
@@ -231,6 +228,10 @@ class EventsAlternativeTimezoneTest(EventsTest):
             ' restart cloudify-amqp-postgres cloudify-restservice '
             'cloudify-execution-scheduler'
         )
+
+
+class EventsAlternativeTimezoneTest(_SetAlternateTimezone, EventsTest):
+    """Events test cases using an alternative timezone (Asia/Jerusalem)."""
 
     def test_timestamp_in_utc(self):
         """Make sure events timestamp field is in UTC."""

--- a/workflows/cloudify_system_workflows/snapshots/postgres.py
+++ b/workflows/cloudify_system_workflows/snapshots/postgres.py
@@ -244,7 +244,9 @@ class Postgres(object):
         This is useful for when the snapshot restored permissions for some
         roles, so that the restservice knows to reload them.
         """
-        self.run_query("UPDATE public.roles SET updated_at=NOW()")
+        self.run_query(
+            "UPDATE public.roles SET updated_at=NOW() AT TIME ZONE 'UTC'"
+        )
 
     def dump_config_tables(self, tempdir):
         pg_dump_bin = os.path.join(self._bin_dir, 'pg_dump')


### PR DESCRIPTION
this sets to NOW(), but it needs to set in utc, because we use utc
everywhere, when using that column