### PR TITLE
RD-522 Auth: only commit if the user actually changed

### DIFF
--- a/rest-service/manager_rest/security/authentication.py
+++ b/rest-service/manager_rest/security/authentication.py
@@ -86,7 +86,7 @@ class Authentication(object):
             if not user.last_login_at:
                 user.first_login_at = now
             user.last_login_at = now
-        user_datastore.commit()
+            user_datastore.commit()
         return user
 
     def _internal_auth(self, request):


### PR DESCRIPTION
Only commit the transaction if we did any changes to the user:
we don't set login times and counters in requests authenticated
by an execution token.

Committing otherwise means that all objects fetched from the db
before (current execution, current tenant, and the user indeed)
will have to be re-fetched on next access