### PR TITLE
RD-2660 Operations update: return 204

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/operations.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/operations.py
@@ -87,7 +87,6 @@ class OperationsId(SecuredResource):
         return operation, 201
 
     @authorize('operations', allow_if_execution=True)
-    @marshal_with(models.Operation)
     def patch(self, operation_id, **kwargs):
         request_dict = get_json_and_verify_params({
             'state': {'type': text_type},
@@ -112,8 +111,8 @@ class OperationsId(SecuredResource):
                     old_state not in common_constants.TERMINATED_STATES and \
                     instance.state in common_constants.TERMINATED_STATES:
                 self._modify_execution_operations_counts(instance, 1)
-            instance = sm.update(instance, modified_attrs=('state',))
-        return instance
+            sm.update(instance, modified_attrs=('state',))
+        return None, 204
 
     def _on_task_success(self, sm, operation):
         handler = getattr(self, f'_on_success_{operation.type}', None)


### PR DESCRIPTION
The returned operation is unused anyway. Skipping the serialization
saves a few ms.