### PR TITLE
RD-2661 Detach current_execution/current_tenant from the session

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3/events.py
+++ b/rest-service/manager_rest/rest/resources_v3/events.py
@@ -22,6 +22,7 @@ from manager_rest import manager_exceptions
 from manager_rest.storage import get_storage_manager, models, db
 from manager_rest.security.authorization import authorize
 from manager_rest.rest import rest_utils
+from manager_rest.rest.rest_decorators import detach_globals
 from manager_rest.execution_token import current_execution
 
 
@@ -43,6 +44,7 @@ class Events(v2_Events):
     UNUSED_FIELDS = ['id', 'node_id', 'message_code']
 
     @authorize('event_create', allow_if_execution=True)
+    @detach_globals
     def post(self):
         request_dict = rest_utils.get_json_and_verify_params({
             'events': {'optional': True},

--- a/rest-service/manager_rest/rest/resources_v3_1/operations.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/operations.py
@@ -27,7 +27,8 @@ from manager_rest.rest.rest_utils import (
 )
 from manager_rest.rest.rest_decorators import (
     marshal_with,
-    paginate
+    paginate,
+    detach_globals,
 )
 from manager_rest.storage import (
     get_storage_manager,
@@ -88,6 +89,7 @@ class OperationsId(SecuredResource):
 
     @authorize('operations', allow_if_execution=True)
     @marshal_with(models.Operation)
+    @detach_globals
     def patch(self, operation_id, **kwargs):
         request_dict = get_json_and_verify_params({
             'state': {'type': text_type},

--- a/rest-service/manager_rest/rest/rest_decorators.py
+++ b/rest-service/manager_rest/rest/rest_decorators.py
@@ -582,7 +582,9 @@ def detach_globals(f):
     """
     @wraps(f)
     def wrapper(*args, **kwargs):
-        db.session.expunge(current_execution)
-        db.session.expunge(current_tenant)
+        if current_execution:
+            db.session.expunge(current_execution)
+        if current_tenant:
+            db.session.expunge(current_tenant)
         return f(*args, **kwargs)
     return wrapper

--- a/rest-service/manager_rest/rest/rest_decorators.py
+++ b/rest-service/manager_rest/rest/rest_decorators.py
@@ -39,7 +39,8 @@ from cloudify._compat import text_type
 from cloudify.models_states import ExecutionState
 from ..security.authentication import authenticator
 from manager_rest import config, manager_exceptions
-from manager_rest.storage.models_base import SQLModelBase
+from manager_rest.utils import current_tenant
+from manager_rest.storage.models_base import SQLModelBase, db
 from manager_rest.execution_token import current_execution
 from manager_rest.rest.rest_utils import (
     normalize_value,
@@ -564,5 +565,24 @@ def not_while_cancelling(f):
             ExecutionState.KILL_CANCELLING
         }:
             raise manager_exceptions.ForbiddenWhileCancelling()
+        return f(*args, **kwargs)
+    return wrapper
+
+
+def detach_globals(f):
+    """Detach current_execution and current_tenant from the db session.
+
+    This means the current_execution and current_tenant objects can be
+    used in multiple transactions, and they won't be automatically reloaded
+    from the db - saving a query, but not loading additional relationships.
+
+    Use this when access to current_* is limited to direct attributes
+    (not relationships) and the request must avoid additional queries
+    for performance reasons.
+    """
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        db.session.expunge(current_execution)
+        db.session.expunge(current_tenant)
         return f(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
See the docstring.

For now, only the most-heavily-used endpoints are going to use
this, and other endpoints can still benefit from auto-loading if
they so wish.