### PR TITLE
RD-2686 Add deployment_display_name to events list

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -330,6 +330,7 @@ class Events(SecuredResource):
                 select_column('reported_timestamp'),
                 Blueprint.id.label('blueprint_id'),
                 Deployment.id.label('deployment_id'),
+                Deployment.display_name.label('deployment_display_name'),
                 Execution.id.label('execution_id'),
                 ExecutionGroup.id.label('execution_group_id'),
                 Execution.workflow_id.label('workflow_id'),


### PR DESCRIPTION
Besides `deployment_id`, a `deployment_display_name` will be used in our
UI to make the widgets more user-friendly and readable.

This patch adds `Deployment.display_name` field as a part of the
Manager's response to the `GET /events` request.