### PR TITLE
snap-res: restore current execution by appending the dump

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/postgres.py
+++ b/workflows/cloudify_system_workflows/snapshots/postgres.py
@@ -81,6 +81,7 @@ class Postgres(object):
         dump_file = self._prepend_dump(
             dump_file, deferrable_roles_constraints + clear_tables_queries)
 
+        self._append_dump(dump_file, self._get_execution_restore_query())
         # Remove users/roles associated with 5.0.5 status reporter
         delete_status_reporter = self._get_status_reporter_deletes()
         self._append_dump(dump_file, '\n'.join(delete_status_reporter))
@@ -310,9 +311,6 @@ class Postgres(object):
         status_reporter_roles_path = self.dump_status_reporter_roles(
             tempdir)
         return status_reporter_roles_path, status_reporter_users_path
-
-    def restore_current_execution(self):
-        self.run_query(self._get_execution_restore_query())
 
     def init_current_execution_data(self):
         response = self.run_query("SELECT created_at, token "

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -548,7 +548,6 @@ class SnapshotRestore(object):
         postgres.restore_config_tables(config_dump_path)
         if not self._permissions_exist(postgres):
             postgres.restore_permissions_table(permissions_dump_path)
-        postgres.restore_current_execution()
         try:
             self._restore_stage(postgres, self._tempdir, stage_revision)
         except Exception as e:


### PR DESCRIPTION
We must avoid having the db in a state in which we can't send in
requests. If we restore the dump first, and only then run the
restore-current-execution query, then in the time between those
two calls, requests can't be run. And since the events/logs are
a rest request now, any `ctx.logger` call between those two, will fail.

To avoid that, just restore the current execution in the same call
as restoring the dump.