### PR TITLE
operation events: use the context name for event.operation

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/operations.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/operations.py
@@ -194,7 +194,7 @@ class OperationsId(SecuredResource):
             event_type=event_type,
             message=message,
             message_code=None,
-            operation=operation.name,
+            operation=context.get('operation', {}).get('name'),
             node_id=context.get('node_id'),
             source_id=context.get('source_id'),
             target_id=context.get('target_id'),


### PR DESCRIPTION
operation.name is the task name eg `plugin.module.task`, while the
context one is the interface name eg `cloudify.interfaces.lifecycle.create`

inte-tests assert that we use the latter, so yeah, thats what it's
supposed to be

(eg `integration_tests/tests/agentless_tests/test_task_retries.py::TaskRetriesTest::test_operation_retry`)