### PR TITLE
operation events: fetch retry count from the right place

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/operations.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/operations.py
@@ -172,8 +172,8 @@ class OperationsId(SecuredResource):
             return
         if exception is not None:
             operation.parameters.setdefault('error', str(exception))
-        current_retries = context.get('current_retries') or 0
-        total_retries = context.get('total_retries') or 0
+        current_retries = operation.parameters.get('current_retries') or 0
+        total_retries = operation.parameters.get('total_retries') or 0
 
         try:
             message = common_events.format_event_message(


### PR DESCRIPTION
it is in parameters directly, as stored in here: https://github.com/cloudify-cosmo/cloudify-common/blob/master/cloudify/workflows/tasks.py#L240