### PR TITLE
snapshot-restore: avoid using the db when downgraded

### DIFF
--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -97,9 +97,9 @@ def query_service_settings():
     config/permissions settings available.
     """
     last_updated_subquery = (
-        db.session.query(models.Config.updated_at.label('updated_at'))
+        db.session.query(models.Role.updated_at.label('updated_at'))
         .union_all(
-            db.session.query(models.Role.updated_at.label('updated_at'))
+            db.session.query(models.Config.updated_at.label('updated_at'))
         ).subquery()
     )
     db_config_last_updated = db.session.query(

--- a/tests/integration_tests/resources/scripts/follow_events.py
+++ b/tests/integration_tests/resources/scripts/follow_events.py
@@ -48,7 +48,7 @@ def make_notify_func(conn):
                 begin
                     perform pg_notify(
                         'event_inserted'::text,
-                        row_to_json(NEW)::text
+                        substring(row_to_json(NEW)::text from 0 for 6000)
                     );
                     return NEW;
                 end;

--- a/workflows/cloudify_system_workflows/snapshots/postgres.py
+++ b/workflows/cloudify_system_workflows/snapshots/postgres.py
@@ -91,7 +91,8 @@ class Postgres(object):
             'NOT DEFERRABLE')
         self._append_dump(dump_file, '\n'.join(immediate_roles_constraints))
         with db_schema(schema_revision, config=config):
-            clear_tables_queries = self._get_clear_tables_queries(snapshot_version)
+            clear_tables_queries = self._get_clear_tables_queries(
+                snapshot_version)
             dump_file = self._prepend_dump(
                 dump_file, deferrable_roles_constraints + clear_tables_queries)
             self._restore_dump(dump_file, self._db_name)

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -539,12 +539,14 @@ class SnapshotRestore(object):
         if self._snapshot_version <= V_4_6_0:
             mgr_tables_dump_path = postgres.dump_manager_tables(self._tempdir)
         permissions_dump_path = postgres.dump_permissions_table(self._tempdir)
+        ctx.logger.info('Restoring DB')
         admin_user_update_command = postgres.restore(
             self._tempdir, schema_revision,
             premium_enabled=self._premium_enabled,
             config=self._config, snapshot_version=self._snapshot_version)
         if not self._license_exists(postgres):
             postgres.restore_license_from_dump(self._tempdir)
+        ctx.logger.info('DB restored')
         if self._snapshot_version <= V_4_6_0:
             postgres.restore_manager_tables(mgr_tables_dump_path)
         postgres.restore_config_tables(config_dump_path)

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -543,6 +543,8 @@ class SnapshotRestore(object):
             self._tempdir, schema_revision,
             premium_enabled=self._premium_enabled,
             config=self._config, snapshot_version=self._snapshot_version)
+        if not self._license_exists(postgres):
+            postgres.restore_license_from_dump(self._tempdir)
         if self._snapshot_version <= V_4_6_0:
             postgres.restore_manager_tables(mgr_tables_dump_path)
         postgres.restore_config_tables(config_dump_path)
@@ -557,8 +559,6 @@ class SnapshotRestore(object):
                 raise
         if composer_revision:
             self._restore_composer(postgres, self._tempdir, composer_revision)
-        if not self._license_exists(postgres):
-            postgres.restore_license_from_dump(self._tempdir)
         ctx.logger.info('Successfully restored database')
         # This is returned so that we can decide whether to restore the admin
         # user depending on whether we have the hash salt

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -599,26 +599,22 @@ class SnapshotRestore(object):
     def _restore_stage(self, postgres, tempdir, migration_version):
         if not self._premium_enabled:
             return
-        ctx.logger.info('Restoring stage DB')
         npm.clear_db(STAGE_APP, STAGE_USER)
         npm.downgrade_app_db(STAGE_APP, STAGE_USER, migration_version)
         try:
             postgres.restore_stage(tempdir)
         finally:
             npm.upgrade_app_db(STAGE_APP, STAGE_USER)
-        ctx.logger.debug('Stage DB restored')
 
     def _restore_composer(self, postgres, tempdir, migration_version):
         if not (self._snapshot_version >= V_4_2_0 and self._premium_enabled):
             return
-        ctx.logger.info('Restoring composer DB')
         npm.clear_db(COMPOSER_APP, COMPOSER_USER)
         npm.downgrade_app_db(COMPOSER_APP, COMPOSER_USER, migration_version)
         try:
             postgres.restore_composer(tempdir)
         finally:
             npm.upgrade_app_db(COMPOSER_APP, COMPOSER_USER)
-        ctx.logger.debug('Composer DB restored')
 
     def _should_clean_old_db_for_3_x_snapshot(self):
         """The one case in which the DB should be cleared is when restoring

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -539,10 +539,10 @@ class SnapshotRestore(object):
         if self._snapshot_version <= V_4_6_0:
             mgr_tables_dump_path = postgres.dump_manager_tables(self._tempdir)
         permissions_dump_path = postgres.dump_permissions_table(self._tempdir)
-        with utils.db_schema(schema_revision, config=self._config):
-            admin_user_update_command = postgres.restore(
-                self._tempdir, premium_enabled=self._premium_enabled,
-                snapshot_version=self._snapshot_version)
+        admin_user_update_command = postgres.restore(
+            self._tempdir, schema_revision,
+            premium_enabled=self._premium_enabled,
+            config=self._config, snapshot_version=self._snapshot_version)
         if self._snapshot_version <= V_4_6_0:
             postgres.restore_manager_tables(mgr_tables_dump_path)
         postgres.restore_config_tables(config_dump_path)

--- a/workflows/cloudify_system_workflows/snapshots/utils.py
+++ b/workflows/cloudify_system_workflows/snapshots/utils.py
@@ -203,12 +203,9 @@ def run(command, ignore_failures=False, redirect_output_path=None, cwd=None):
         command = shlex.split(command)
     command_str = ' '.join(command)
 
-    ctx.logger.debug('Running command: {0}'.format(command_str))
     stderr = subprocess.PIPE
     stdout = subprocess.PIPE
     if redirect_output_path:
-        ctx.logger.debug('Command: {0} Redirect output to: {1}'.
-                         format(' '.join(command), redirect_output_path))
         with open(redirect_output_path, 'a') as output:
             proc = subprocess.Popen(command, stdout=output, stderr=stderr,
                                     cwd=cwd)


### PR DESCRIPTION
Spend as little time with the db/restservice in an unusable state, and
don't attempt to use it during that time.

See each commit for details.