### PR TITLE
RD-2721 build-pod: increase the amount of connections to the test DB

### DIFF
--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -26,6 +26,9 @@ spec:
     image: circleci/postgres:9.5-alpine
     ports:
       - containerPort: 5432
+    args:
+      - "-c"
+      - "max_connections=800"
     env:
     - name: POSTGRES_USER
       value: cloudify


### PR DESCRIPTION
it seems we leak some connections. This isn't a fix, but a workaround,
hopefully we can fix the leak and then this can be reverted.