### PR TITLE
config last-updated query: change the order of the parts

### DIFF
--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -97,9 +97,9 @@ def query_service_settings():
     config/permissions settings available.
     """
     last_updated_subquery = (
-        db.session.query(models.Config.updated_at.label('updated_at'))
+        db.session.query(models.Role.updated_at.label('updated_at'))
         .union_all(
-            db.session.query(models.Role.updated_at.label('updated_at'))
+            db.session.query(models.Config.updated_at.label('updated_at'))
         ).subquery()
     )
     db_config_last_updated = db.session.query(


### PR DESCRIPTION
(This ports one commit from #3149 to 6.1.0)

the query doesn't care which one is first - config or roles, but
we always unconditionally lock the roles table in snap-res.
And if config is first, that's not locked by snap-res if the
snapshot is older than 4.6, and so there might be a deadlock between
this, and the snapshot itself