### PR TITLE
RD-2751 events create: allow passing in execution id

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3/events.py
+++ b/rest-service/manager_rest/rest/resources_v3/events.py
@@ -49,12 +49,17 @@ class Events(v2_Events):
         request_dict = rest_utils.get_json_and_verify_params({
             'events': {'optional': True},
             'logs': {'optional': True},
+            'execution_id': {'optional': True},
         })
         sm = get_storage_manager()
         exc = current_execution._get_current_object()
         if exc is None:
-            raise manager_exceptions.UnauthorizedError(
-                'events can only be created by an execution')
+            exc_id = request_dict.get('execution_id')
+            if exc_id is None:
+                raise manager_exceptions.ConflictError(
+                    'No execution passed, and not authenticated by '
+                    'an execution token')
+            exc = sm.get(models.Execution, request_dict.get('execution_id'))
         exc_params = {
             '_execution_fk': exc._storage_id,
             '_tenant_id': exc._tenant_id,

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -950,7 +950,7 @@ class EventsTest(base_test.BaseServerTestCase):
     def test_create_event_not_execution(self):
         with pytest.raises(CloudifyClientError) as cm:
             self.client.events.create(events=[])
-        assert cm.value.status_code == 401
+        assert cm.value.status_code == 409
 
     def test_create_event_with_execution(self):
         tenant = Tenant.query.first()


### PR DESCRIPTION
For requests authenticated by the rest token, the execution id
must be passed in separately.

The other side of this is cloudify-cosmo/cloudify-common#829