### PR TITLE
RD-2751 Send hooks when execution state changes

### DIFF
--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -346,6 +346,7 @@ class BaseServerTestCase(unittest.TestCase):
                   mock_send_mgmtworker_task),
             patch('manager_rest.workflow_executor._broadcast_mgmtworker_task'),
             patch('manager_rest.workflow_executor.get_client'),
+            patch('manager_rest.resource_manager.send_event'),
         ]
         cls._patchers.extend(amqp_patches)
 


### PR DESCRIPTION
This is as opposed to the previous implementation of the mgmtworker
sending hooks separately. Now, the restservice will send them when
the execution state changes.
It already used to do that on queued, but now it's more general.