### PR TITLE
amqp-postgres: ignore hook messages

### DIFF
--- a/amqp-postgres/amqp_postgres/amqp_consumer.py
+++ b/amqp-postgres/amqp_postgres/amqp_consumer.py
@@ -66,6 +66,9 @@ class AMQPLogsEventsConsumer(object):
 
     def process(self, channel, method, properties, body):
         try:
+            if method.routing_key == 'events.hooks':
+                channel.basic_ack(method.delivery_tag)
+                return
             parsed_body = json.loads(body)
             self._message_processor(parsed_body, method.exchange,
                                     (channel, method.delivery_tag))


### PR DESCRIPTION
ever since cloudify-cosmo/cloudify-common#830 we don't send a hook
together with the actual event text message. The hook is sent
separately by the restservice, and the event text message is
created by the mgmtworker.
This led to the message being printed twice, once by the mgmtworker's
event, and once by the amqp-postgres catching the hook. So let's have
it not print the hook.