### PR TITLE
RD-2746 Implement /searches for node-instances

### DIFF
--- a/rest-service/manager_rest/rest/endpoint_mapper.py
+++ b/rest-service/manager_rest/rest/endpoint_mapper.py
@@ -136,6 +136,7 @@ def setup_resources(api):
         'BlueprintsSearches': 'searches/blueprints',
         'Workflows': 'workflows',
         'WorkflowsSearches': 'searches/workflows',
+        'NodeInstancesSearches': 'searches/node-instances',
     }
 
     # Set version endpoint as a non versioned endpoint

--- a/rest-service/manager_rest/rest/filters_utils.py
+++ b/rest-service/manager_rest/rest/filters_utils.py
@@ -34,7 +34,7 @@ FilteredModels = NewType('FilteredModels',
 
 
 def get_filter_rules_from_filter_id(filter_id, filters_model):
-    if not filter_id:
+    if not filter_id or not filters_model:
         return None
 
     validate_inputs({'filter_id': filter_id})

--- a/rest-service/manager_rest/rest/resources_v3_1/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/__init__.py
@@ -118,6 +118,7 @@ from .searches import (  # NOQA
     DeploymentsSearches,
     BlueprintsSearches,
     WorkflowsSearches,
+    NodeInstancesSearches,
 )
 
 from .workflows import (  # NOQA

--- a/rest-service/manager_rest/rest/resources_v3_1/searches.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/searches.py
@@ -197,3 +197,21 @@ class WorkflowsSearches(ResourceSearches):
                               search, filter_id, **kwargs)
 
         return workflows_list_response(result)
+
+
+class NodeInstancesSearches(ResourceSearches):
+    @swagger.operation(**_swagger_searches_docs(models.NodeInstance,
+                                                'node_instances'))
+    @authorize('node_list', allow_all_tenants=True)
+    @rest_decorators.marshal_with(models.NodeInstance)
+    @rest_decorators.paginate
+    @rest_decorators.sortable(models.NodeInstance)
+    @rest_decorators.all_tenants
+    @rest_decorators.search('id')
+    @rest_decorators.filter_id
+    def post(self, _include=None, pagination=None, sort=None,
+             all_tenants=None, search=None, filter_id=None, **kwargs):
+        """List NodeInstances using filter rules"""
+        return super().post(models.NodeInstance, None,
+                            _include, {}, pagination, sort, all_tenants,
+                            search, filter_id, **kwargs)

--- a/rest-service/manager_rest/storage/filters.py
+++ b/rest-service/manager_rest/storage/filters.py
@@ -12,10 +12,11 @@ from .utils import get_column, get_joins
 def add_filter_rules_to_query(query, model_class, filter_rules):
     labels_join_added = False
     joined_columns_set = set()
-    labels_model = model_class.labels_model
     for filter_rule in filter_rules:
         filter_rule_type = filter_rule['type']
-        if filter_rule_type == FilterRuleType.LABEL:
+        if filter_rule_type == FilterRuleType.LABEL \
+                and hasattr(model_class, 'labels_model'):
+            labels_model = model_class.labels_model
             if not labels_join_added:
                 query = query.outerjoin(
                     labels_model,

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1785,6 +1785,10 @@ class NodeInstance(SQLResourceBase):
         self._set_parent(node)
         self.node = node
 
+    @classproperty
+    def allowed_filter_attrs(cls):
+        return ['id']
+
 
 class Agent(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'agents'

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -188,10 +188,7 @@ class SQLStorageManager(object):
     @staticmethod
     def _add_filter_rules(query, model_class, filter_rules):
         if filter_rules:
-            if hasattr(model_class, 'labels_model'):
-                return add_filter_rules_to_query(
-                    query, model_class, filter_rules)
-
+            return add_filter_rules_to_query(query, model_class, filter_rules)
         return query
 
     def _add_value_filter(self, query, filters):


### PR DESCRIPTION
Very similar to already-existing searches, although node-instances have
no filters model (no stored filters) and no labels model (they don't have
labels). So existing infra must be made to be able to work without those.