### PR TITLE
RD-2758 Add a script to substitute import lines in blueprints

### DIFF
--- a/rest-service/manager_rest/shell/common.py
+++ b/rest-service/manager_rest/shell/common.py
@@ -1,0 +1,152 @@
+from os import environ
+from os.path import exists, isfile, join
+import typing
+
+import yaml
+
+from manager_rest.constants import (FILE_SERVER_BLUEPRINTS_FOLDER,
+                                    FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER,
+                                    SUPPORTED_ARCHIVE_TYPES)
+from manager_rest.flask_utils import (setup_flask_app, set_admin_current_user,
+                                      get_tenant_by_name, set_tenant_in_app)
+from manager_rest.storage import models
+from manager_rest import config
+
+DEFAULT_TENANT = 'default_tenant'
+END_POS = 'end_pos'
+MAX_IMPORT_TOKEN_LENGTH = 200
+REST_HOME_DIR = '/opt/manager'
+REST_CONFIG_PATH = join(REST_HOME_DIR, 'cloudify-rest.conf')
+REST_SECURITY_CONFIG_PATH = join(REST_HOME_DIR, 'rest-security.conf')
+START_POS = 'start_pos'
+
+
+class UpdateException(Exception):
+    pass
+
+
+def setup_environment():
+    for value, envvar in [
+        (REST_CONFIG_PATH, 'MANAGER_REST_CONFIG_PATH'),
+        (REST_SECURITY_CONFIG_PATH, 'MANAGER_REST_SECURITY_CONFIG_PATH'),
+    ]:
+        if value is not None:
+            environ[envvar] = value
+
+    app = setup_flask_app()
+    with app.app_context():
+        config.instance.load_configuration()
+    set_admin_current_user(app)
+    set_tenant_in_app(get_tenant_by_name(DEFAULT_TENANT))
+
+
+def blueprint_file_name(blueprint: models.Blueprint) -> str:
+    return join(
+        config.instance.file_server_root,
+        FILE_SERVER_BLUEPRINTS_FOLDER,
+        blueprint.tenant.name,
+        blueprint.id,
+        blueprint.main_file_name
+    )
+
+
+def archive_file_name(blueprint: models.Blueprint) -> str:
+    for arc_type in SUPPORTED_ARCHIVE_TYPES:
+        # attempting to find the archive file on the file system
+        local_path = join(
+            config.instance.file_server_root,
+            FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER,
+            blueprint.tenant.name,
+            blueprint.id,
+            '{0}.{1}'.format(blueprint.id, arc_type))
+
+        if isfile(local_path):
+            archive_type = arc_type
+            break
+    else:
+        raise UpdateException("Could not find blueprint's archive; "
+                              "Blueprint ID: {0}".format(blueprint.id))
+    return join(
+        config.instance.file_server_root,
+        FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER,
+        blueprint.tenant.name,
+        blueprint.id,
+        '{0}.{1}'.format(blueprint.id, archive_type)
+    )
+
+
+def blueprint_updated_file_name(blueprint: models.Blueprint) -> str:
+    base_file_name = '.'.join(blueprint.main_file_name.split('.')[:-1])
+    index = 0
+    updated_file_name = '{0}-new.yaml'.format(base_file_name)
+    while exists(join(
+        config.instance.file_server_root,
+        FILE_SERVER_BLUEPRINTS_FOLDER,
+        blueprint.tenant.name,
+        blueprint.id,
+        updated_file_name)):
+        updated_file_name = '{0}-{1:02d}.yaml'.format(base_file_name, index)
+        index += 1
+    return join(
+        config.instance.file_server_root,
+        FILE_SERVER_BLUEPRINTS_FOLDER,
+        blueprint.tenant.name,
+        blueprint.id,
+        updated_file_name
+    )
+
+
+def blueprint_diff_file_name(blueprint: models.Blueprint) -> str:
+    base_file_name = '.'.join(blueprint.main_file_name.split('.')[:-1])
+    index = 0
+    diff_file_name = '{0}.diff'.format(base_file_name)
+    while exists(join(
+        config.instance.file_server_root,
+        FILE_SERVER_BLUEPRINTS_FOLDER,
+        blueprint.tenant.name,
+        blueprint.id,
+        diff_file_name)):
+        diff_file_name = '{0}-{1:02d}.diff'.format(base_file_name, index)
+        index += 1
+    return join(
+        config.instance.file_server_root,
+        FILE_SERVER_BLUEPRINTS_FOLDER,
+        blueprint.tenant.name,
+        blueprint.id,
+        diff_file_name
+    )
+
+
+def get_imports_position(blueprint_file: typing.BinaryIO) -> tuple:
+    level, start_pos, end_pos = 0, 0, 0
+    imports_token = None
+    blueprint_file.seek(0, 0)
+    for t in yaml.scan(blueprint_file):
+        if isinstance(t, (yaml.tokens.BlockMappingStartToken,
+                          yaml.tokens.BlockSequenceStartToken,
+                          yaml.tokens.FlowMappingStartToken,
+                          yaml.tokens.FlowSequenceStartToken)):
+            level += 1
+        if isinstance(t, (yaml.tokens.BlockEndToken,
+                          yaml.tokens.FlowMappingEndToken,
+                          yaml.tokens.FlowSequenceEndToken)):
+            level -= 1
+
+        if isinstance(t, yaml.tokens.ScalarToken):
+            if level == 1 and t.value == 'imports':
+                imports_token = t
+                start_pos = t.end_mark.index + 1
+                continue
+
+            token_length = t.end_mark.index - t.start_mark.index
+
+            if level >= 1 and imports_token and \
+                token_length < MAX_IMPORT_TOKEN_LENGTH:
+                if not start_pos:
+                    start_pos = t.start_mark.index
+                end_pos = t.end_mark.index
+
+        if isinstance(t, yaml.tokens.KeyToken) and imports_token:
+            break
+
+    return start_pos, end_pos

--- a/rest-service/manager_rest/shell/common.py
+++ b/rest-service/manager_rest/shell/common.py
@@ -8,13 +8,13 @@ from tempfile import TemporaryDirectory, mktemp
 
 import yaml
 
+from manager_rest import config
 from manager_rest.constants import (FILE_SERVER_BLUEPRINTS_FOLDER,
                                     FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER,
                                     SUPPORTED_ARCHIVE_TYPES)
 from manager_rest.flask_utils import (setup_flask_app, set_admin_current_user,
                                       get_tenant_by_name, set_tenant_in_app)
 from manager_rest.storage import models
-from manager_rest import config
 
 DEFAULT_TENANT = 'default_tenant'
 END_POS = 'end_pos'
@@ -188,18 +188,10 @@ def write_blueprint_diff(from_file_name: str,
                                    timezone.utc)
         return t.astimezone().isoformat()
 
-    try:
-        with open(from_file_name, 'r') as from_file:
-            from_lines = from_file.readlines()
-    except (FileNotFoundError, PermissionError) as ex:
-        raise UpdateException('Cannot read a blueprint file {0}: {1}'.format(
-                              from_file_name, ex))
-    try:
-        with open(to_file_name, 'r') as to_file:
-            to_lines = to_file.readlines()
-    except (FileNotFoundError, PermissionError) as ex:
-        raise UpdateException('Cannot read a blueprint file {0}: {1}'.format(
-                              from_file_name, ex))
+    with open(from_file_name, 'r') as from_file:
+        from_lines = from_file.readlines()
+    with open(to_file_name, 'r') as to_file:
+        to_lines = to_file.readlines()
     diff = difflib.context_diff(
         from_lines,
         to_lines,
@@ -208,14 +200,8 @@ def write_blueprint_diff(from_file_name: str,
         file_mtime(from_file_name),
         file_mtime(to_file_name)
     )
-    try:
-        with open(diff_file_name, 'w') as diff_file:
-            diff_file.writelines(diff)
-    except (FileNotFoundError, PermissionError) as ex:
-        raise UpdateException('Cannot write a diff file {0}: {1}'.format(
-                              diff_file_name, ex))
-    print('An diff file was generated for your change: {0}'.format(
-          diff_file_name))
+    with open(diff_file_name, 'w') as diff_file:
+        diff_file.writelines(diff)
 
 
 def format_from_file_name(file_name: str) -> typing.Optional[str]:

--- a/rest-service/manager_rest/shell/common.py
+++ b/rest-service/manager_rest/shell/common.py
@@ -218,6 +218,7 @@ def format_from_file_name(file_name: str) -> typing.Optional[str]:
             (file_name_split[-2].upper() == 'TAR' and
              file_name_split[-1].upper() == 'GZ'):
         return 'gztar'
+    return None
 
 
 def update_archive(blueprint: models.Blueprint, updated_file_name: str):

--- a/rest-service/manager_rest/shell/common.py
+++ b/rest-service/manager_rest/shell/common.py
@@ -79,12 +79,11 @@ def blueprint_updated_file_name(blueprint: models.Blueprint) -> str:
     base_file_name = '.'.join(blueprint.main_file_name.split('.')[:-1])
     index = 0
     updated_file_name = '{0}-new.yaml'.format(base_file_name)
-    while exists(join(
-        config.instance.file_server_root,
-        FILE_SERVER_BLUEPRINTS_FOLDER,
-        blueprint.tenant.name,
-        blueprint.id,
-        updated_file_name)):
+    while exists(join(config.instance.file_server_root,
+                      FILE_SERVER_BLUEPRINTS_FOLDER,
+                      blueprint.tenant.name,
+                      blueprint.id,
+                      updated_file_name)):
         updated_file_name = '{0}-{1:02d}.yaml'.format(base_file_name, index)
         index += 1
     return join(
@@ -100,12 +99,11 @@ def blueprint_diff_file_name(blueprint: models.Blueprint) -> str:
     base_file_name = '.'.join(blueprint.main_file_name.split('.')[:-1])
     index = 0
     diff_file_name = '{0}.diff'.format(base_file_name)
-    while exists(join(
-        config.instance.file_server_root,
-        FILE_SERVER_BLUEPRINTS_FOLDER,
-        blueprint.tenant.name,
-        blueprint.id,
-        diff_file_name)):
+    while exists(join(config.instance.file_server_root,
+                      FILE_SERVER_BLUEPRINTS_FOLDER,
+                      blueprint.tenant.name,
+                      blueprint.id,
+                      diff_file_name)):
         diff_file_name = '{0}-{1:02d}.diff'.format(base_file_name, index)
         index += 1
     return join(
@@ -140,8 +138,9 @@ def get_imports_position(blueprint_file: typing.BinaryIO) -> tuple:
 
             token_length = t.end_mark.index - t.start_mark.index
 
-            if level >= 1 and imports_token and \
-                token_length < MAX_IMPORT_TOKEN_LENGTH:
+            if (level >= 1
+                    and imports_token
+                    and token_length < MAX_IMPORT_TOKEN_LENGTH):
                 if not start_pos:
                     start_pos = t.start_mark.index
                 end_pos = t.end_mark.index

--- a/rest-service/manager_rest/shell/common.py
+++ b/rest-service/manager_rest/shell/common.py
@@ -150,3 +150,13 @@ def get_imports_position(blueprint_file: typing.BinaryIO) -> tuple:
             break
 
     return start_pos, end_pos
+
+
+def get_line_separator(blueprint_file: typing.BinaryIO) -> str:
+    blueprint_file.seek(0, 0)
+    blueprint_excerpt = blueprint_file.read(1000)
+    if b'\r\n' in blueprint_excerpt:
+        return '\r\n'
+    if b'\r' in blueprint_excerpt:
+        return '\r'
+    return '\n'

--- a/rest-service/manager_rest/shell/substitute_import_lines.py
+++ b/rest-service/manager_rest/shell/substitute_import_lines.py
@@ -3,7 +3,6 @@ import logging
 import shutil
 import sys
 import typing
-from copy import copy
 from os.path import basename, join
 
 import click
@@ -27,11 +26,8 @@ class Mapping:
     def matches(self, imports: typing.List[str]) -> bool:
         if len(imports) != len(self._from):
             return False
-        imports_copy = copy(imports)
-        while imports_copy:
-            if imports_copy.pop() not in self._from:
-                return False
-        return len(imports_copy) == 0
+        return all(part in self._from for part in imports) \
+            and all(part in imports for part in self._from)
 
     def replacement(self, separator='\n'):
         replacement = separator.join(f'  - {line}' for line in self._to)

--- a/rest-service/manager_rest/shell/substitute_import_lines.py
+++ b/rest-service/manager_rest/shell/substitute_import_lines.py
@@ -117,8 +117,8 @@ def correct_blueprint(blueprint: models.Blueprint,
             start_at, end_at = common.get_imports_position(blueprint_file)
             separator = common.get_line_separator(blueprint_file)
     except (FileNotFoundError, PermissionError) as ex:
-        raise common.UpdateException('Cannot load blueprint from {0}: {1}'.format(
-            file_name, ex))
+        raise common.UpdateException('Cannot load blueprint from {0}: {1}'
+                                     .format(file_name, ex))
     update_blueprint(file_name, new_file_name, start_at, end_at,
                      mapping.replacement(separator))
 
@@ -178,8 +178,8 @@ def main(all_tenants, tenant_names, blueprint_ids, mapping_file):
                                 f"blueprint `{blueprint.id}`")
                     correct_blueprint(blueprint, mapping)
                 else:
-                    logger.debug(f"Tenant's `{tenant.name}` blueprint does not "
-                                 f"require upgrading: `{blueprint.id}`")
+                    logger.debug(f"Tenant's `{tenant.name}` blueprint does "
+                                 f"not require upgrading: `{blueprint.id}`")
             except common.UpdateException as ex:
                 logger.error(f"Error updating tenant's {tenant.name} "
                              f"blueprint {blueprint.id}: {ex}")

--- a/rest-service/manager_rest/shell/substitute_import_lines.py
+++ b/rest-service/manager_rest/shell/substitute_import_lines.py
@@ -39,11 +39,12 @@ class Mapping:
 
 
 DEFAULT_MAPPING = [
-    Mapping(src=['http://repo/get/cloudify/4.3/td/types/td-linux-type.yaml',
-                 'http://repo/get/cloudify/4.3/td/types/td-pm2-type.yaml'],
-            dst=['https://repo/get/cloudify/4.3/cloudify/types/types.yaml',
-                 'plugin:td-deploy-plugin-central',
-                 'plugin:td-deploy-plugin']),
+    Mapping(src=['https://example.com/cloudify/5.1.0/types/linux-type.yaml',
+                 'https://example.com/cloudify/5.1.0/types/foo-type.yaml'],
+            dst=['https://www.getcloudify.org/spec/cloudify/5.1.0/types.yaml',
+                 'plugin:example-deploy-plugin',
+                 'plugin:example-linux',
+                 'plugin:example-foo']),
 ]
 
 

--- a/rest-service/manager_rest/shell/substitute_import_lines.py
+++ b/rest-service/manager_rest/shell/substitute_import_lines.py
@@ -158,7 +158,10 @@ def main(all_tenants, tenant_names, blueprint_ids, mapping_file):
     sm = get_storage_manager()
     tenants = sm.list(models.Tenant, get_all_results=True) if all_tenants \
         else [get_tenant_by_name(name) for name in tenant_names]
-    blueprint_filter = {'tenant': None}
+    blueprint_filter = {
+        'tenant': None,
+        'state': 'uploaded',
+    }
     if blueprint_ids:
         blueprint_filter['id'] = blueprint_ids
     mappings = load_mappings(mapping_file) if mapping_file else DEFAULT_MAPPING

--- a/rest-service/manager_rest/shell/substitute_import_lines.py
+++ b/rest-service/manager_rest/shell/substitute_import_lines.py
@@ -34,7 +34,7 @@ class Mapping:
         return len(imports_copy) == 0
 
     def replacement(self, separator='\n'):
-        replacement = separator.join([f'  - {line}' for line in self._to])
+        replacement = separator.join(f'  - {line}' for line in self._to)
         return f'{separator}{replacement}'
 
 

--- a/rest-service/manager_rest/shell/substitute_import_lines.py
+++ b/rest-service/manager_rest/shell/substitute_import_lines.py
@@ -138,7 +138,7 @@ def main(all_tenants, tenant_names, blueprint_ids, mapping_file):
         format='%(asctime)s.%(msecs)03d %(levelname)s '
                '[%(module)s.%(funcName)s] %(message)s',
         datefmt='%H:%M:%S',
-        level=logging.DEBUG)
+        level=logging.INFO)
     logger = logging.getLogger(basename(sys.argv[0]))
 
     if all_tenants and tenant_names:

--- a/rest-service/manager_rest/shell/substitute_import_lines.py
+++ b/rest-service/manager_rest/shell/substitute_import_lines.py
@@ -115,13 +115,7 @@ def correct_blueprint(blueprint: models.Blueprint,
     try:
         with open(file_name, 'rb') as blueprint_file:
             start_at, end_at = common.get_imports_position(blueprint_file)
-            blueprint_excerpt = blueprint_file.read(1000)
-            if b'\r\n' in blueprint_excerpt:
-                separator = '\r\n'
-            elif b'\r' in blueprint_excerpt:
-                separator = '\r'
-            else:
-                separator = '\n'
+            separator = common.get_line_separator(blueprint_file)
     except (FileNotFoundError, PermissionError) as ex:
         raise common.UpdateException('Cannot load blueprint from {0}: {1}'.format(
             file_name, ex))

--- a/rest-service/manager_rest/shell/substitute_import_lines.py
+++ b/rest-service/manager_rest/shell/substitute_import_lines.py
@@ -1,0 +1,192 @@
+"""Substitute import lines in blueprints, based on hardcoded mapping"""
+from copy import copy
+from os.path import basename, join
+import sys
+import typing
+
+import click
+import logging
+import yaml
+
+from manager_rest.flask_utils import get_tenant_by_name, set_tenant_in_app
+from manager_rest.shell import common
+from manager_rest.storage import models, get_storage_manager
+
+DEFAULT_TENANT = 'default_tenant'
+REST_HOME_DIR = '/opt/manager'
+REST_CONFIG_PATH = join(REST_HOME_DIR, 'cloudify-rest.conf')
+REST_SECURITY_CONFIG_PATH = join(REST_HOME_DIR, 'rest-security.conf')
+
+
+class Mapping:
+    def __init__(self, src: typing.List[str], dst: typing.List[str]):
+        self._from = src
+        self._to = dst
+
+    def __str__(self):
+        def get_list_repr(items: typing.List[str], n=32) -> str:
+            def first_n(s: str, n=32) -> str:
+                return f'{s[:n - 3]}...' if len(s) > n - 3 else s
+            if len(items) < 1:
+                return 'empty'
+            elif len(items) == 1:
+                return first_n(items[0], n)
+            else:
+                return first_n(f'{items[0]}, ...', n)
+        return f'Mapping [{get_list_repr(self._from)}] → ' \
+               f'[{get_list_repr(self._to)}]'
+
+    def matches(self, imports: typing.List[str]) -> bool:
+        if len(imports) != len(self._from):
+            return False
+        imports_copy = copy(imports)
+        while imports_copy:
+            if imports_copy.pop() not in self._from:
+                return False
+        return len(imports_copy) == 0
+
+    def replacement(self, separator='\n'):
+        replacement = separator.join([f'  - {line}' for line in self._to])
+        return f'{separator}{replacement}'
+
+
+DEFAULT_MAPPING = [
+    Mapping(['http://repo/get/cloudify/4.3/td/types/td-linux-type.yaml',
+             'http://repo/get/cloudify/4.3/td/types/td-openstack-type.yaml',
+             'http://repo/get/cloudify/4.3/td/types/td-pm2-type.yaml'],
+            ['http://repo/get/cloudify/4.3/cloudify/types/types.yaml',
+             'plugin:td-deploy-plugin-central',
+             'plugin:td-deploy-plugin',
+             'plugin:cloudify-openstack-plugin']),
+]
+
+
+def load_mappings(file_name: str) -> typing.List[Mapping]:
+    try:
+        with open(file_name, 'r') as mapping_file:
+            try:
+                mappings = [Mapping(src=m['from'], dst=m['to'])
+                            for m in yaml.safe_load(mapping_file)]
+            except yaml.YAMLError as ex:
+                raise common.UpdateException(
+                    'Cannot load mappings from {0}: {1}'.format(file_name, ex))
+    except (FileNotFoundError, PermissionError):
+        raise common.UpdateException(
+            'Mappings file {0} cannot be read'.format(file_name))
+    return mappings
+
+
+def find_mapping(blueprint: models.Blueprint,
+                 mappings: typing.List[Mapping],
+                 ) -> typing.Optional[Mapping]:
+    file_name = common.blueprint_file_name(blueprint)
+
+    with open(file_name, 'r') as blueprint_file:
+        try:
+            imports = yaml.safe_load(blueprint_file).get('imports', [])
+        except yaml.YAMLError as ex:
+            raise common.UpdateException(
+                'Cannot load blueprint {0}: {1}'.format(file_name, ex))
+
+    for mapping in mappings:
+        if mapping.matches(imports):
+            return mapping
+
+    return None
+
+
+def update_blueprint(input_file_name: str, output_file_name: str,
+                     start_at: int, end_at: int,
+                     replacement: str):
+    with open(input_file_name, 'rb') as input_file:
+        with open(output_file_name, 'wb') as output_file:
+            content = input_file.read(start_at - input_file.tell())
+            output_file.write(content)
+            output_file.write(replacement.encode('utf-8', 'ignore'))
+            input_file.read(end_at - start_at)
+            content = input_file.read()
+            output_file.write(content)
+
+
+def correct_blueprint(blueprint: models.Blueprint,
+                      mapping: Mapping):
+    file_name = common.blueprint_file_name(blueprint)
+    new_file_name = common.blueprint_updated_file_name(blueprint)
+    try:
+        with open(file_name, 'rb') as blueprint_file:
+            start_at, end_at = common.get_imports_position(blueprint_file)
+            blueprint_excerpt = blueprint_file.read(1000)
+            if b'\r\n' in blueprint_excerpt:
+                separator = '\r\n'
+            elif b'\r' in blueprint_excerpt:
+                separator = '\r'
+            else:
+                separator = '\n'
+    except (FileNotFoundError, PermissionError) as ex:
+        raise common.UpdateException('Cannot load blueprint from {0}: {1}'.format(
+            file_name, ex))
+    update_blueprint(file_name, new_file_name, start_at, end_at,
+                     mapping.replacement(separator))
+
+
+@click.command()
+@click.option('-a', '--all-tenants', is_flag=True,
+              help='Include resources from all tenants.', )
+@click.option('-t', '--tenant-name', 'tenant_names', multiple=True,
+              help='Tenant name; mutually exclusivele with --all-tenants.', )
+@click.option('-b', '--blueprint', 'blueprint_ids',
+              multiple=True, help='Blueprint(s) to update (you can provide '
+                                  'multiple --blueprint(s).')
+@click.option('--mapping', 'mapping_file',
+              help='Provide a mapping defining import lines substitutions.')
+def main(all_tenants, tenant_names, blueprint_ids, mapping_file):
+    logging.basicConfig(
+        format='%(asctime)s.%(msecs)03d %(levelname)s '
+               '[%(module)s.%(funcName)s] %(message)s',
+        datefmt='%H:%M:%S',
+        level=logging.DEBUG)
+    logger = logging.getLogger(basename(sys.argv[0]))
+
+    if all_tenants and tenant_names:
+        logger.critical('--all-tenants and --tenant-name options are '
+                        'mutually exclusive')
+        exit(1)
+    if not tenant_names:
+        tenant_names = (DEFAULT_TENANT,)
+
+    common.setup_environment()
+    sm = get_storage_manager()
+    tenants = sm.list(models.Tenant, get_all_results=True) if all_tenants \
+        else [get_tenant_by_name(name) for name in tenant_names]
+    blueprint_filter = {'tenant': None}
+    if blueprint_ids:
+        blueprint_filter['id'] = blueprint_ids
+    mappings = load_mappings(mapping_file) if mapping_file else DEFAULT_MAPPING
+
+    for tenant in tenants:
+        set_tenant_in_app(get_tenant_by_name(tenant.name))
+        sm = get_storage_manager()
+        blueprint_filter['tenant'] = tenant
+        blueprints = sm.list(
+            models.Blueprint,
+            filters=blueprint_filter,
+            get_all_results=True
+        )
+
+        for blueprint in blueprints:
+            try:
+                mapping = find_mapping(blueprint, mappings)
+                if mapping:
+                    logger.info(f"Updating tenant's `{tenant.name}` "
+                                f"blueprint `{blueprint.id}`")
+                    correct_blueprint(blueprint, mapping)
+                else:
+                    logger.debug(f"Tenant's `{tenant.name}` blueprint does not "
+                                 f"require upgrading: `{blueprint.id}`")
+            except common.UpdateException as ex:
+                logger.error(f"Error updating tenant's {tenant.name} "
+                             f"blueprint {blueprint.id}: {ex}")
+
+
+if __name__ == '__main__':
+    main()

--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -63,6 +63,8 @@ setup(
         'console_scripts': [
             'update-plugin-imports = '
             'manager_rest.shell.update_plugin_imports:main',
+            'substitute-import-lines = '
+            'manager_rest.shell.substitute_import_lines:main',
         ]
     },
     extras_require={


### PR DESCRIPTION
The `substitute_import_lines.py` script can be used to substitute
`imports:` lines in blueprints, prior to running `cfy plugins update`
on these blueprints.  It's somewhat similar to the
`update_plugin_imports.py` - it precedates actual plugins update
workflow.