### PR TITLE
RD-2746 snap-res agents: use the searches endpoint

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/agents.py
+++ b/workflows/cloudify_system_workflows/snapshots/agents.py
@@ -52,8 +52,8 @@ class Agents(object):
         client = get_rest_client()
         agents = client.agents.list(_all_tenants=True)
         agent_ids = [agent.id for agent in agents.items]
-        node_instances = client.node_instances.list(id=agent_ids,
-                                                    _all_tenants=True)
+        node_instances = client.node_instances.search(
+            agent_ids, _all_tenants=True)
         for instance in node_instances:
             self._add_node_instance_to_result(instance, result)
         self._dump_result_to_file(tempdir, result)


### PR DESCRIPTION
With enough node-instances, the .list call will break when passing the
list of ids in the URL. Instead, use the endpoint that goes by POST