### PR TITLE
RD-2598 Don't set a queued execution as latest (yet)

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -987,13 +987,6 @@ class ResourceManager(object):
                     execution, force, queue)
 
             if should_queue:
-                if not execution.deployment.installation_status:
-                    execution.deployment.installation_status =\
-                        DeploymentState.INACTIVE
-                execution.deployment.deployment_status =\
-                    DeploymentState.IN_PROGRESS
-                execution.deployment.latest_execution = execution
-                self.sm.update(execution.deployment)
                 self._workflow_queued(execution)
                 return execution
             if execution.deployment:


### PR DESCRIPTION
This ports #3169 to 6.1.0

* RD-2598 Don't set a queued execution as latest (yet)

When an execution is queued, that is usually because there's another
one for that deployment already running. We'll keep that running one
as the "latest", and the one that is queued, will become the
.latest_execution once it starts running.

I don't think there was a compelling reason to have a queued execution
be already the "latest", we just said "might as well", but the other
way around makes more sense. And if there's several executions
queued, why would any of them be latest and not the others?
Remember that the order in which several queued executions will
actually run, might not yet be known at the time of queueing them,
because they might belong to exec-groups, and the actual running
order will be influenced by that as well.

Anyway, the real reason for this change is that updating that FK in
that transaction seems to be what causes the RD-2598 deadlock, because
now this transaction locks both the deployment and the execution for
update; I'm not sure what is the other side of the deadlock, but it's
probably locking the execution-and-then-deployment in update_execution_status

* don't update the deployment at all

the execution getting queued is just not the right place.
Either no execution runs, in which case just relax and wait a second,
the deployment will be "in progress" when it starts.
..or an execution is already running, in which case, no need to stomp
over whatever the running execution has set.