### PR TITLE
RD-2828 events list: default sort to timestamp

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -272,7 +272,9 @@ class Events(SecuredResource):
                 _, sort_direction = dict(sort).popitem()
             else:
                 sort_direction = 'asc'
-            query = Events._apply_sort(query, {'timestamp': sort_direction})
+            query = Events._apply_sort(query, {
+                'timestamp': sort_direction, '_storage_id': sort_direction
+            })
             query = (
                 query
                 .limit(bindparam('limit'))

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -272,7 +272,7 @@ class Events(SecuredResource):
                 _, sort_direction = dict(sort).popitem()
             else:
                 sort_direction = 'asc'
-            query = Events._apply_sort(query, {'_storage_id': sort_direction})
+            query = Events._apply_sort(query, {'timestamp': sort_direction})
             query = (
                 query
                 .limit(bindparam('limit'))


### PR DESCRIPTION
No real reason to go by storage_id, which isn't technically guaranteed
to have any application-level meaning. I'm not sure this will fix the
inte-test which is only failing on jenkins, but it's a good idea to
do this anyway.