### PR TITLE
inte-tests: use the non-deprecated rest-client call

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_runtime_functions.py
+++ b/tests/integration_tests/tests/agentless_tests/test_runtime_functions.py
@@ -108,12 +108,13 @@ class TestRuntimeFunctionEvaluation(AgentlessTestCase):
             }
         if add_flag:
             params['runtime_only_evaluation'] = True
-        dep_update = self.client.deployment_updates.update_with_existing_blueprint(
-            deployment_id=deployment.id,
-            blueprint_id='updated_blueprint',
-            inputs={'input1': self.CHANGED_VALUE, 'fail_create': False},
-            **params
-        )
+        dep_update = self.client.deployment_updates\
+            .update_with_existing_blueprint(
+                deployment_id=deployment.id,
+                blueprint_id='updated_blueprint',
+                inputs={'input1': self.CHANGED_VALUE, 'fail_create': False},
+                **params
+            )
         execution = self.client.executions.get(dep_update.execution_id)
         self.wait_for_execution_to_end(execution)
         dep_update = self.client.deployment_updates.finalize_commit(

--- a/tests/integration_tests/tests/agentless_tests/test_runtime_functions.py
+++ b/tests/integration_tests/tests/agentless_tests/test_runtime_functions.py
@@ -97,6 +97,7 @@ class TestRuntimeFunctionEvaluation(AgentlessTestCase):
                 "prop2: '{0}'".format(self.BASE_VALUE),
                 "prop2: '{0}'".format(self.CHANGED_VALUE))
             new_bp.write(bp_content)
+        self.upload_blueprint_resource(new_bp.name, 'updated_blueprint')
 
         params = {}
         if skip:
@@ -107,9 +108,9 @@ class TestRuntimeFunctionEvaluation(AgentlessTestCase):
             }
         if add_flag:
             params['runtime_only_evaluation'] = True
-        dep_update = self.client.deployment_updates.update(
+        dep_update = self.client.deployment_updates.update_with_existing_blueprint(
             deployment_id=deployment.id,
-            blueprint_or_archive_path=new_bp.name,
+            blueprint_id='updated_blueprint',
             inputs={'input1': self.CHANGED_VALUE, 'fail_create': False},
             **params
         )


### PR DESCRIPTION
Use .update_with_existing_blueprints instead of .update