### PR TITLE
RD-2891 Operation events: also store events for subgraphs

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/operations.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/operations.py
@@ -168,7 +168,7 @@ class OperationsId(SecuredResource):
         try:
             context = operation.parameters['task_kwargs']['kwargs'][
                 '__cloudify_context']
-        except (KeyError, TypeError) as e:
+        except (KeyError, TypeError):
             context = {}
         if exception is not None:
             operation.parameters.setdefault('error', str(exception))

--- a/rest-service/manager_rest/rest/resources_v3_1/operations.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/operations.py
@@ -178,6 +178,7 @@ class OperationsId(SecuredResource):
         try:
             message = common_events.format_event_message(
                 operation.name,
+                operation.type,
                 operation.state,
                 result,
                 exception,

--- a/rest-service/manager_rest/rest/resources_v3_1/operations.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/operations.py
@@ -161,15 +161,15 @@ class OperationsId(SecuredResource):
 
     def _insert_event(self, operation, result=None, exception=None,
                       exception_causes=None):
-        if operation.type != 'RemoteWorkflowTask':
+        if operation.type not in ('RemoteWorkflowTask', 'SubgraphTask'):
             return
         if not current_execution:
             return
         try:
             context = operation.parameters['task_kwargs']['kwargs'][
                 '__cloudify_context']
-        except (KeyError, TypeError):
-            return
+        except (KeyError, TypeError) as e:
+            context = {}
         if exception is not None:
             operation.parameters.setdefault('error', str(exception))
         current_retries = operation.parameters.get('current_retries') or 0

--- a/tests/integration_tests/tests/agentless_tests/test_executions.py
+++ b/tests/integration_tests/tests/agentless_tests/test_executions.py
@@ -13,6 +13,7 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
+import re
 import time
 import uuid
 import pytest
@@ -799,27 +800,23 @@ class ExecutionsTest(AgentlessTestCase):
         self.assertDictEqual(invocations[0], {'before-sleep': None})
 
     def test_dry_run_execution(self):
-        expected_messages = {
-            "Starting 'install' workflow execution (dry run)",
+        expected_messages = [
+            "Starting 'install' workflow execution \\(dry run\\)",
+            "Subgraph started '[^\']+' \\(dry run\\)",
             "Validating node instance before creation: nothing to do",
             "Precreating node instance: nothing to do",
             "Creating node instance",
-            "Sending task 'cloudmock.tasks.provision'",
-            "Task started 'cloudmock.tasks.provision'",
-            "Task succeeded 'cloudmock.tasks.provision (dry run)'",
+            "Task succeeded 'cloudmock.tasks.provision' \\(dry run\\)",
             "Node instance created",
             "Configuring node instance: nothing to do",
             "Starting node instance",
-            "Sending task 'cloudmock.tasks.start'",
-            "Task started 'cloudmock.tasks.start'",
-            "Task succeeded 'cloudmock.tasks.start (dry run)'",
-            "Sending task 'cloudmock.tasks.get_state'",
-            "Task started 'cloudmock.tasks.get_state'",
-            "Task succeeded 'cloudmock.tasks.get_state (dry run)'",
+            "Task succeeded 'cloudmock.tasks.start' \\(dry run\\)",
+            "Task succeeded 'cloudmock.tasks.get_state' \\(dry run\\)",
             "Poststarting node instance: nothing to do",
             "Node instance started",
-            "'install' workflow execution succeeded (dry run)"
-        }
+            "Subgraph succeeded '[^\']+' \\(dry run\\)",
+            "'install' workflow execution succeeded \\(dry run\\)",
+        ]
 
         dsl_path = resource("dsl/basic.yaml")
         _, execution_id = self.deploy_application(dsl_path,
@@ -830,9 +827,13 @@ class ExecutionsTest(AgentlessTestCase):
         # "terminated", because it arrives via a different mechanism
         time.sleep(3)
         events = self.client.events.list(execution_id=execution_id)
-        event_messages = {event['message'] for event in events}
-
-        self.assertEqual(event_messages, expected_messages)
+        event_messages = [event['message'] for event in events]
+        self.assertEqual(len(event_messages), len(expected_messages))
+        for message, expected_regex in zip(event_messages, expected_messages):
+            self.assertIsNotNone(
+                re.match(expected_regex, message),
+                "{0!r} did not match {1!r}".format(message, expected_regex)
+            )
 
         # We expect the instances to remain unchaged after a dry run
         for instance in self.client.node_instances.list():

--- a/tests/integration_tests/tests/agentless_tests/test_executions.py
+++ b/tests/integration_tests/tests/agentless_tests/test_executions.py
@@ -802,7 +802,7 @@ class ExecutionsTest(AgentlessTestCase):
     def test_dry_run_execution(self):
         expected_messages = [
             "Starting 'install' workflow execution \\(dry run\\)",
-            "Subgraph started '[^\']+' \\(dry run\\)",
+            "Subgraph started '[^']+' \\(dry run\\)",
             "Validating node instance before creation: nothing to do",
             "Precreating node instance: nothing to do",
             "Creating node instance",
@@ -814,7 +814,7 @@ class ExecutionsTest(AgentlessTestCase):
             "Task succeeded 'cloudmock.tasks.get_state' \\(dry run\\)",
             "Poststarting node instance: nothing to do",
             "Node instance started",
-            "Subgraph succeeded '[^\']+' \\(dry run\\)",
+            "Subgraph succeeded '[^']+' \\(dry run\\)",
             "'install' workflow execution succeeded \\(dry run\\)",
         ]
 


### PR DESCRIPTION
Use the new format_event_message API introduced in cloudify-cosmo/cloudify-common#842

Also fix the dry-run test