### PR TITLE
RD-2846 Drop useless .asdict calls

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v1/deployments.py
@@ -74,11 +74,6 @@ class DeploymentsId(SecuredResource):
             deployment_id,
             include=_include
         )
-        if _include and 'workflows' in _include:  # Similar to CY-760
-            result = result._asdict()
-            result['workflows'] = models.Deployment._list_workflows(
-                result['workflows'],
-            )
         return result
 
     @swagger.operation(

--- a/rest-service/manager_rest/rest/resources_v2/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v2/deployments.py
@@ -77,18 +77,6 @@ class Deployments(resources_v1.Deployments):
             filter_rules=filter_rules,
             load_relationships=True,
         )
-
-        if _include and 'workflows' in _include:
-            # Because we coerce this into a list in the model, but our ORM
-            # won't return a model instance when filtering results, we have
-            # to coerce this here as well. This is unpleasant.
-            for index, item in enumerate(result.items):
-                r = item._asdict()
-                r['workflows'] = models.Deployment._list_workflows(
-                    r['workflows'],
-                )
-                result.items[index] = r
-
         return result
 
 


### PR DESCRIPTION
The orm now does return actual orm objects from this, not keyedtuples,
so this quip is unnecessary.