### PR TITLE
mgmtworker workflow consumer: don't update operation state

### DIFF
--- a/mgmtworker/mgmtworker/worker.py
+++ b/mgmtworker/mgmtworker/worker.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import logging
 import argparse
+from contextlib import contextmanager
 
 from cloudify import broker_config, dispatch
 from cloudify.logs import setup_agent_logger
@@ -61,6 +62,12 @@ class CloudifyWorkflowConsumer(CloudifyOperationConsumer):
     routing_key = 'workflow'
     handler = dispatch.WorkflowHandler
     late_ack = True
+
+    @contextmanager
+    def _update_operation_state(self, ctx):
+        # noop - override superclass method, which tries to update the
+        # operation state: we're not working with operations, but workflows
+        yield
 
     def handle_task(self, full_task):
         if self.is_scheduled_execution(full_task):


### PR DESCRIPTION
This deals with workflows/executions, not with operations. It ends up
trying to fetch the operation, using the execution id instead (haha),
gets a 404, and carries on, assuming the operation isn't stored.

I mean, it's not an operation. Just don't do it. Override the
method to do nothing instead.

A better solution would probably be to not use a inheritance hierarchy
here (why is a workflow consumer a child of an operation consumer?)
but for now, this removes the 1-per-execution 404 call in the rest logs