### PR TITLE
RD-2773 Autoload relationships when listing executions

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -88,7 +88,8 @@ class ResourceManager(object):
 
     def list_executions(self, include=None, is_include_system_workflows=False,
                         filters=None, pagination=None, sort=None,
-                        all_tenants=False, get_all_results=False):
+                        all_tenants=False, get_all_results=False,
+                        load_relationships=False):
         filters = filters or {}
         is_system_workflow = filters.get('is_system_workflow')
         if is_system_workflow:
@@ -105,7 +106,8 @@ class ResourceManager(object):
             pagination=pagination,
             sort=sort,
             all_tenants=all_tenants,
-            get_all_results=get_all_results
+            get_all_results=get_all_results,
+            load_relationships=load_relationships,
         )
 
     def update_deployment_statuses(self, latest_execution):

--- a/rest-service/manager_rest/rest/resources_v2/executions.py
+++ b/rest-service/manager_rest/rest/resources_v2/executions.py
@@ -76,5 +76,6 @@ class Executions(resources_v1.Executions):
             is_include_system_workflows=is_include_system_workflows,
             include=_include,
             all_tenants=all_tenants,
-            get_all_results=get_all_results
+            get_all_results=get_all_results,
+            load_relationships=True,
         )

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -957,6 +957,12 @@ class Execution(CreatedAtMixin, SQLResourceBase):
                                         server_default='false')
     execution_group_id = association_proxy('execution_groups', 'id')
 
+    @classproperty
+    def autoload_relationships(cls):
+        return [
+            cls.deployment,
+        ]
+
     def __repr__(self):
         return (
             f'<Execution id=`{self.id}` tenant=`{self.tenant_name}` '


### PR DESCRIPTION
Similar to #3168 but for executions. Then, `cfy exe li` is going to
be just one query to fetch executions, not 1+n.

I'm only linking it to that jira so that we can find this PR easily in
case we want to port 2773 into a 6.1.1 or something.