### PR TITLE
RD-2900 Replace `@property` in models with ORM attributes

### DIFF
--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -157,7 +157,7 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         self.sm.put(dep)
 
         serialized_dep = dep.to_response()
-        self.assertEqual(35, len(serialized_dep))
+        self.assertEqual(36, len(serialized_dep))
         self.assertEqual(dep.id, serialized_dep['id'])
         self.assertEqual(dep.created_at, serialized_dep['created_at'])
         self.assertEqual(dep.updated_at, serialized_dep['updated_at'])
@@ -175,6 +175,7 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         serialized_dep.pop('environment_type')
         serialized_dep.pop('latest_execution_total_operations')
         serialized_dep.pop('latest_execution_finished_operations')
+        serialized_dep.pop('has_sub_deployments')
 
         # Deprecated columns, for backwards compatibility -
         # was added to the response


### PR DESCRIPTION
Not all of them just yet, but several interesting ones.

Replace `@property`, which can not be used in `_include` or `_sort`,
with ORM-instrumented descriptors instead, which can.

For the most part it'll be assoc_proxy, which also makes it shorter!