### PR TITLE
RD-2916 deployments GET: automatically include `id` if needed

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v1/deployments.py
@@ -63,18 +63,9 @@ class DeploymentsId(SecuredResource):
     @authorize('deployment_get')
     @marshal_with(models.Deployment)
     def get(self, deployment_id, _include=None, **kwargs):
-        """
-        Get deployment by id
-        """
-        if _include:
-            if {'labels', 'deployment_groups'}.intersection(_include):
-                _include = None
-        result = get_storage_manager().get(
-            models.Deployment,
-            deployment_id,
-            include=_include
-        )
-        return result
+        """Get deployment by id"""
+        return get_storage_manager().get(
+            models.Deployment, deployment_id, include=_include)
 
     @swagger.operation(
         responseClass=models.Deployment,

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -319,6 +319,7 @@ class DeploymentsId(resources_v1.DeploymentsId):
         # always return the deployment if `all_sub_deployments` is True
         if args.all_sub_deployments:
             return deployment
+        deployment = deployment.to_response(include=_include)
         return self._populate_direct_deployment_counts_and_statuses(deployment)
 
 

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -314,9 +314,8 @@ class DeploymentsId(resources_v1.DeploymentsId):
         args = rest_utils.get_args_and_verify_arguments([
             Argument('all_sub_deployments', type=boolean, default=True),
         ])
-        deployment = super(DeploymentsId, self).get(
-            deployment_id, _include=_include, kwargs=kwargs
-        )
+        deployment = get_storage_manager().get(
+            models.Deployment, deployment_id, include=_include)
         # always return the deployment if `all_sub_deployments` is True
         if args.all_sub_deployments:
             return deployment

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -314,6 +314,11 @@ class DeploymentsId(resources_v1.DeploymentsId):
         args = rest_utils.get_args_and_verify_arguments([
             Argument('all_sub_deployments', type=boolean, default=True),
         ])
+        if not args.all_sub_deployments \
+                and _include and ('id' not in _include):
+            # we will need to use id in the _populate_direct method, so it
+            # must be included
+            _include.append('id')
         deployment = get_storage_manager().get(
             models.Deployment, deployment_id, include=_include)
         # always return the deployment if `all_sub_deployments` is True


### PR DESCRIPTION
If `?all_sub_deployments=false`, we will need `id`, so include it
automatically, if it's not included otherwise