### PR TITLE
RD-2913 inte-tests: clean up agent snapshot tests

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_snapshots.py
+++ b/tests/integration_tests/tests/agent_tests/test_snapshots.py
@@ -13,11 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 import uuid
 import pytest
-
-from cloudify_rest_client.executions import Execution
 
 from integration_tests import AgentTestCase
 from cloudify.models_states import AgentState

--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -15,12 +15,10 @@
 
 import os
 import time
-import json
 import pytest
 import pickle
 import binascii
 
-import requests
 from collections import Counter
 
 from integration_tests.framework import utils
@@ -28,11 +26,9 @@ from integration_tests import AgentlessTestCase
 
 from cloudify.snapshots import STATES
 from cloudify.models_states import AgentState
-
 from manager_rest.constants import DEFAULT_TENANT_NAME
-
 from cloudify_rest_client.executions import Execution
-from cloudify_rest_client.exceptions import CloudifyClientError
+
 
 pytestmark = pytest.mark.group_snapshots
 SNAPSHOTS = 'http://cloudify-tests-files.s3-eu-west-1.amazonaws.com/snapshots/'

--- a/tests/integration_tests/tests/test_cases.py
+++ b/tests/integration_tests/tests/test_cases.py
@@ -27,6 +27,7 @@ from contextlib import contextmanager
 
 import wagon
 import pytest
+import requests
 from retrying import retry
 from requests.exceptions import ConnectionError
 
@@ -387,7 +388,6 @@ class BaseTestCase(unittest.TestCase):
                     )
                 )
         return execution
-
 
     def _wait_for_restore_marker_file_to_be_created(self, timeout_seconds=40):
         self.logger.debug("Waiting for snapshot restore marker to be "


### PR DESCRIPTION
Use a common method for waiting on the snapshot.