### PR TITLE
RD-2913 snap-res: pause restservice as well

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_snapshots.py
+++ b/tests/integration_tests/tests/agent_tests/test_snapshots.py
@@ -46,7 +46,7 @@ class TestSnapshots(AgentTestCase):
     def _create_snapshot(self):
         snapshot_id = 's{0}'.format(uuid.uuid4())
         execution = self.client.snapshots.create(snapshot_id, False, False)
-        self.wait_for_event(execution, CREATE_SNAPSHOT_SUCCESS_MSG)
+        self.wait_for_execution_to_end(execution)
         return snapshot_id
 
     def _undeploy(self, states, deployments):

--- a/tests/integration_tests/tests/agent_tests/test_snapshots.py
+++ b/tests/integration_tests/tests/agent_tests/test_snapshots.py
@@ -57,10 +57,9 @@ class TestSnapshots(AgentTestCase):
     def _restore_snapshot(self, states, deployments, snapshot_id):
         # force restore since the manager will be unclean between tests
         execution = self.client.snapshots.restore(snapshot_id, force=True)
-        # give the database some time to downgrade/upgrade before running
-        # requests to avoid the deadlock described in CY-1455
-        time.sleep(15)
         self.wait_for_event(execution, RESTORE_SNAPSHOT_SUCCESS_MSG)
+        # still give some time for the post-restore actions to run
+        time.sleep(15)
         for state in states:
             self.assertEqual(len(self.client.agents.list(state=state)), 1)
         agent_list = self.client.agents.list(state=states)
@@ -91,8 +90,8 @@ class TestSnapshots(AgentTestCase):
 
     def _restore_snapshot_multitenant(self, snapshot_id):
         execution = self.client.snapshots.restore(snapshot_id, force=True)
-        time.sleep(15)
         self.wait_for_event(execution, RESTORE_SNAPSHOT_SUCCESS_MSG)
+        time.sleep(15)
         agents_list = self.client.agents.list(
             _all_tenants=True, deployment_id=['mt_default', 'mt_new'])
         self.assertEqual(len(agents_list.items), 2)

--- a/workflows/cloudify_system_workflows/snapshots/postgres.py
+++ b/workflows/cloudify_system_workflows/snapshots/postgres.py
@@ -25,7 +25,7 @@ from cloudify.workflows import ctx
 from cloudify.cryptography_utils import encrypt
 from cloudify.exceptions import NonRecoverableError
 
-from .constants import ADMIN_DUMP_FILE, LICENSE_DUMP_FILE, V_4_6_0, V_5_1_0
+from .constants import ADMIN_DUMP_FILE, LICENSE_DUMP_FILE
 from .utils import run as run_shell, db_schema
 
 POSTGRESQL_DEFAULT_PORT = 5432

--- a/workflows/cloudify_system_workflows/snapshots/postgres.py
+++ b/workflows/cloudify_system_workflows/snapshots/postgres.py
@@ -527,13 +527,7 @@ class Postgres(object):
         all_tables = [table for table in all_tables if
                       table not in self._TABLES_TO_KEEP]
 
-        tables_to_lock = ['users', 'roles']
-        if snapshot_version > V_4_6_0:
-            tables_to_lock.append('config')
-        if snapshot_version > V_5_1_0:
-            tables_to_lock.append('maintenance_mode')
         queries = (
-            ['LOCK TABLE {0};'.format(', '.join(tables_to_lock))] +
             [self._TRUNCATE_QUERY.format(table) for table in all_tables
              if table != 'users'] +
             ['DELETE FROM users;']

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -171,7 +171,11 @@ class SnapshotRestore(object):
         """Stop db-using services for the duration of this context"""
         # While the snapshot is being restored, the database is downgraded
         # and upgraded back, and these services must not attempt to use it
-        to_pause = ['cloudify-amqp-postgres', 'cloudify-execution-scheduler']
+        to_pause = [
+            'cloudify-amqp-postgres',
+            'cloudify-execution-scheduler',
+            'cloudify-restservice'
+        ]
         for service in to_pause:
             utils.run_service(self._service_management, 'stop', service)
         try:
@@ -179,6 +183,7 @@ class SnapshotRestore(object):
         finally:
             for service in to_pause:
                 utils.run_service(self._service_management, 'start', service)
+            self._wait_for_rest_to_restart()
 
     def _generate_new_rest_token(self):
         """

--- a/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/workflows/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -67,6 +67,35 @@ from .constants import (
 from .utils import is_later_than_now, parse_datetime_string
 
 
+class BufferLogger(object):
+    def __init__(self):
+        self._buffer = []
+
+    def send(self):
+        for method, args, kwargs in self._buffer:
+            getattr(ctx.logger, method)(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return lambda *a, **kw: self._buffer.append((name, a, kw))
+
+
+@contextmanager
+def buffer_logs():
+    """Buffer all ctx.logger calls, and send them after exiting this.
+
+    This is needed for when the restservice is stopped, so that logs are
+    only sent after it's started again.
+    """
+    original_logger = ctx._logger
+    buffer_logger = BufferLogger()
+    ctx._logger = buffer_logger
+    try:
+        yield
+    finally:
+        ctx._logger = original_logger
+        buffer_logger.send()
+
+
 class SnapshotRestore(object):
     SCHEMA_REVISION_4_0 = '333998bc1627'
 
@@ -131,7 +160,7 @@ class SnapshotRestore(object):
                 utils.sudo(DENY_DB_CLIENT_CERTS_SCRIPT)
                 self._service_management = \
                     json.loads(postgres.get_service_management())
-                with self._pause_services():
+                with buffer_logs(), self._pause_services():
                     self._restore_db(
                         postgres,
                         schema_revision,


### PR DESCRIPTION
The deadlocks are too much, man.
Just pause the restservice as well, and then, there's no concurrent
access.

Reading the db while it's being downgraded is a bad idea anyway.