### PR TITLE
RD-2929 inte-tests: wait for all execs in component tests

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/component/test_component_auto_inc_suffix.py
+++ b/tests/integration_tests/tests/agentless_tests/component/test_component_auto_inc_suffix.py
@@ -20,13 +20,17 @@ import pytest
 from cloudify_rest_client.executions import Execution
 
 from integration_tests import AgentlessTestCase
-from integration_tests.tests.utils import get_resource as resource
-from integration_tests.tests.utils import wait_for_blueprint_upload
+from integration_tests.tests.utils import (
+  get_resource as resource,
+  wait_for_blueprint_upload,
+  wait_for_executions
+)
 
 pytestmark = pytest.mark.group_service_composition
 
 
 @pytest.mark.usefixtures('cloudmock_plugin')
+@wait_for_executions
 class ComponentScaleCreation(AgentlessTestCase):
     component_name = 'component'
     basic_blueprint_id = 'basic'

--- a/tests/integration_tests/tests/agentless_tests/component/test_component_basics.py
+++ b/tests/integration_tests/tests/agentless_tests/component/test_component_basics.py
@@ -20,14 +20,18 @@ import pytest
 from cloudify_rest_client.exceptions import CloudifyClientError
 
 from integration_tests import AgentlessTestCase
-from integration_tests.tests.utils import (get_resource as resource,
-                                           upload_mock_plugin,
-                                           wait_for_blueprint_upload)
+from integration_tests.tests.utils import (
+    get_resource as resource,
+    upload_mock_plugin,
+    wait_for_blueprint_upload,
+    wait_for_executions,
+)
 
 pytestmark = pytest.mark.group_service_composition
 
 
 @pytest.mark.usefixtures('cloudmock_plugin')
+@wait_for_executions
 class ComponentTypeTest(AgentlessTestCase):
     component_name = 'component'
     basic_blueprint_id = 'basic'
@@ -107,6 +111,7 @@ capabilities:
                           deployment_id)
 
 
+@wait_for_executions
 class ComponentPluginsTest(AgentlessTestCase):
     TEST_PACKAGE_NAME = 'cloudify-script-plugin'
     TEST_PACKAGE_VERSION = '1.2'
@@ -194,6 +199,7 @@ node_templates:
 
 
 @pytest.mark.usefixtures('cloudmock_plugin')
+@wait_for_executions
 class ComponentSecretsTypesTest(AgentlessTestCase):
     basic_blueprint_id = 'basic'
 
@@ -240,6 +246,7 @@ node_templates:
         self.assertEqual(self.client.secrets.get('regex')['value'], u'^.$')
 
 
+@wait_for_executions
 class ComponentInputsTypesTest(AgentlessTestCase):
     basic_blueprint_id = 'basic'
 
@@ -345,6 +352,7 @@ node_templates:
                           blueprint_path, deployment_id=deployment_id)
 
 
+@wait_for_executions
 class ComponentTypeFailuresTest(AgentlessTestCase):
 
     def test_component_creation_with_not_existing_blueprint_id(self):

--- a/tests/integration_tests/tests/agentless_tests/component/test_component_cascading.py
+++ b/tests/integration_tests/tests/agentless_tests/component/test_component_cascading.py
@@ -26,12 +26,15 @@ from integration_tests.tests.utils import (
     verify_deployment_env_created,
     do_retries,
     get_resource as resource,
-    wait_for_blueprint_upload)
+    wait_for_blueprint_upload,
+    wait_for_executions,
+)
 
 pytestmark = pytest.mark.group_service_composition
 
 
 @pytest.mark.usefixtures('testmockoperations_plugin')
+@wait_for_executions
 class ComponentCascadingCancelAndResume(AgentlessTestCase):
     def _wait_for_component_deployment(self,
                                        deployment_id,
@@ -300,6 +303,7 @@ node_templates:
 
 
 @pytest.mark.usefixtures('mock_workflows_plugin')
+@wait_for_executions
 class ComponentCascadingWorkflows(AgentlessTestCase):
     component_blueprint_with_nothing_workflow = """
 tosca_definitions_version: cloudify_dsl_1_3

--- a/tests/integration_tests/tests/agentless_tests/shared_resource/test_relationship_running_workflow.py
+++ b/tests/integration_tests/tests/agentless_tests/shared_resource/test_relationship_running_workflow.py
@@ -14,13 +14,17 @@
 import pytest
 
 from integration_tests import AgentlessTestCase
-from integration_tests.tests.utils import get_resource as resource
-from integration_tests.tests.utils import wait_for_blueprint_upload
+from integration_tests.tests.utils import (
+    get_resource as resource,
+    wait_for_blueprint_upload,
+    wait_for_executions
+)
 
 pytestmark = pytest.mark.group_service_composition
 
 
 @pytest.mark.usefixtures('mock_workflows_plugin')
+@wait_for_executions
 class TestRelationshipRunningRemoteWorkflow(AgentlessTestCase):
     shared_resource_blueprint = """
 tosca_definitions_version: cloudify_dsl_1_3

--- a/tests/integration_tests/tests/agentless_tests/shared_resource/test_shared_resource_type.py
+++ b/tests/integration_tests/tests/agentless_tests/shared_resource/test_shared_resource_type.py
@@ -14,10 +14,12 @@
 
 import pytest
 from integration_tests import AgentlessTestCase
+from integration_tests.tests.utils import wait_for_executions
 
 pytestmark = pytest.mark.group_service_composition
 
 
+@wait_for_executions
 class TestSharedResourceType(AgentlessTestCase):
     def setUp(self):
         super(TestSharedResourceType, self).setUp()


### PR DESCRIPTION
Component tests like to leave executions running when they finish,
because there's still executions in the component deployments.
Let's make sure they all finish and don't interact with the framework
or other tests.