### PR TITLE
RD-2937 dep-update: also update capabilities

### DIFF
--- a/rest-service/manager_rest/deployment_update/manager.py
+++ b/rest-service/manager_rest/deployment_update/manager.py
@@ -296,6 +296,8 @@ class DeploymentUpdateManager(object):
         deployment.runtime_only_evaluation = dep_update.runtime_only_evaluation
         if dep_update.new_blueprint:
             deployment.blueprint = dep_update.new_blueprint
+        deployment.capabilities = \
+            dep_update.deployment_plan.get('capabilities', {})
         self.sm.update(deployment)
 
         # Execute the default 'update' workflow or a custom workflow using


### PR DESCRIPTION
Capabilities is another attribute to be changed on the updated
deployment, and it's very trivial to do so, it was just missed before.