### PR TITLE
inte-tests: reset subgraph_retries to 0

### DIFF
--- a/tests/integration_tests/resources/scripts/prepare_reset_storage.py
+++ b/tests/integration_tests/resources/scripts/prepare_reset_storage.py
@@ -11,7 +11,7 @@ MANAGER_CONFIG = {
     'workflow': {
         'task_retries': 5,
         'task_retry_interval': 1,
-        'subgraph_retries': 5,
+        'subgraph_retries': 0,
     },
 }
 


### PR DESCRIPTION
this is the default value, so reset-storage should reset it back to
the default value, not to something else