### PR TITLE
RD-2961 Fix execution schedules in tests

### DIFF
--- a/tests/integration_tests/tests/utils.py
+++ b/tests/integration_tests/tests/utils.py
@@ -247,9 +247,10 @@ def run_postgresql_command(container_id, cmd):
 
 def generate_scheduled_for_date():
     now = datetime.utcnow()
-    # Schedule the execution for 1 minute in the future, or 2 in case it's past
-    # 20 seconds after a whole minute.
-    minutes_in_the_future = 1 if now.second <= 20 else 2
+    # Because seconds (and milliseconds) are trimmed from the `scheduled_for`
+    # timestamp, let us be more generous by adding more time in case it is
+    # "almost a full minute".
+    minutes_in_the_future = 1 if now.second <= 40 else 2
     scheduled_for = now + timedelta(minutes=minutes_in_the_future)
     return scheduled_for.strftime('%Y%m%d%H%M+0000')
 

--- a/tests/integration_tests/tests/utils.py
+++ b/tests/integration_tests/tests/utils.py
@@ -247,8 +247,10 @@ def run_postgresql_command(container_id, cmd):
 
 def generate_scheduled_for_date():
     now = datetime.utcnow()
-    # Schedule the execution for 1 minute in the future
-    scheduled_for = now + timedelta(minutes=1)
+    # Schedule the execution for 1 minute in the future, or 2 in case it's past
+    # 20 seconds after a whole minute.
+    minutes_in_the_future = 1 if now.second <= 20 else 2
+    scheduled_for = now + timedelta(minutes=minutes_in_the_future)
     return scheduled_for.strftime('%Y%m%d%H%M+0000')
 
 


### PR DESCRIPTION
We used to schedule executions for the next minute from now, but
trimming seconds from the timestamp.  That resulted in executions being
scheduled in a few seconds (or milliseconds even).  This patch fixes
that.