### PR TITLE
snap-res fix_db_ssh.py: s/.node_instances/.instances/

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/fix_snapshot_ssh_db.py
+++ b/workflows/cloudify_system_workflows/snapshots/fix_snapshot_ssh_db.py
@@ -94,7 +94,7 @@ def main(original_string, secret_name):
     res = sm.list(model_class=Deployment, get_all_results=True)
     for deployment in res:
         for node in deployment.nodes:
-            for node_instance in node.node_instances:
+            for node_instance in node.instances:
                 runtime_properties = node_instance.runtime_properties
                 changed = update_agent_properties(runtime_properties,
                                                   original_string,


### PR DESCRIPTION
That's what the backref is called. We used to have both, now we only
have .instances
Funnily, this was the only usage in c-manager, so I'm going to just
keep the one, then.