### PR TITLE
RD-2832 Don't overwrite the RabbitMQ user on agent_create

### DIFF
--- a/rest-service/manager_rest/amqp_manager.py
+++ b/rest-service/manager_rest/amqp_manager.py
@@ -22,6 +22,7 @@ from cloudify.utils import generate_user_password
 from cloudify.cryptography_utils import encrypt, decrypt
 from cloudify.rabbitmq_client import RabbitMQClient, USERNAME_PATTERN
 
+from manager_rest.manager_exceptions import ConflictError
 from manager_rest.storage import get_storage_manager
 from manager_rest.storage.models import Tenant, Agent
 
@@ -115,6 +116,11 @@ class AMQPManager(object):
         encrypted_password = resource.rabbitmq_password or \
             encrypt(new_password)
 
+        # Validate we're not overwriting the existing user
+        for existing_user in self._client.get_users():
+            if existing_user['name'] == username:
+                raise ConflictError('Cowardly refusing to overwrite the '
+                                    f'existing RabbitMQ user "{username}".')
         self._client.create_user(username, password)
         return username, encrypted_password
 

--- a/rest-service/manager_rest/rest/resources_v3_1/agents.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/agents.py
@@ -176,8 +176,13 @@ class AgentsName(SecuredResource):
             new_agent = get_storage_manager().get(models.Agent, name)
 
         if request_dict.get('create_rabbitmq_user'):
-            # Create rabbitmq user
-            self._get_amqp_manager().create_agent_user(new_agent)
+            try:
+                # Create rabbitmq user
+                self._get_amqp_manager().create_agent_user(new_agent)
+            except manager_exceptions.ConflictError:
+                # Assuming the agent user was already created
+                current_app.logger.info(f'Not creating agent user "{name}" '
+                                        'because it already exists')
         return response
 
     @rest_decorators.marshal_with(models.Agent)

--- a/rest-service/manager_rest/rest/resources_v3_1/agents.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/agents.py
@@ -181,8 +181,8 @@ class AgentsName(SecuredResource):
                 self._get_amqp_manager().create_agent_user(new_agent)
             except manager_exceptions.ConflictError:
                 # Assuming the agent user was already created
-                current_app.logger.info(f'Not creating agent user "{name}" '
-                                        'because it already exists')
+                current_app.logger.info('Not creating agent user "%s" because '
+                                        'it already exists', name)
         return response
 
     @rest_decorators.marshal_with(models.Agent)


### PR DESCRIPTION
In case `agent_create` request comes in with a `create_rabbitmq_user`
flag enabled, we attempt to create a separate RabbitMQ user for that
agent.  In case the account already existed, we would have overwritten
it thus breaking the tenant's or the manager's interaction with the
broker.  This patch prevents that from happening.