### PR TITLE
RD-3009 Update audit_log_creator_or_user_not_null constraint

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/03ad040e6f78_6_1_to_6.2.py
+++ b/resources/rest-service/cloudify/migrations/versions/03ad040e6f78_6_1_to_6.2.py
@@ -51,7 +51,7 @@ def _create_audit_log_table():
             'created_at', UTCDateTime(),
             nullable=False),
         sa.CheckConstraint(
-            '(creator_name IS NULL) != (execution_id IS NULL)',
+            'creator_name IS NOT NULL OR execution_id IS NOT NULL',
             name='audit_log_creator_or_user_not_null'),
         sa.PrimaryKeyConstraint(
             '_storage_id',


### PR DESCRIPTION
`creator_name` and `execution_id` can be set at the same time.