### PR TITLE
RD-3009 Set audit.execution_id parameter when installing

### DIFF
--- a/packaging/rest-service/files/opt/manager/scripts/create_system_filters.py
+++ b/packaging/rest-service/files/opt/manager/scripts/create_system_filters.py
@@ -11,6 +11,8 @@ from manager_rest.flask_utils import setup_flask_app
 
 def create_system_filters():
     with setup_flask_app().app_context():
+        db.session.execute("SET SESSION audit.execution_id = :id",
+                           params={'id': 'create_system_filters'})
         current_deployment_filters = db.session.query(models.DeploymentsFilter)
         curr_dep_filters_ids = {dep_filter.id for dep_filter
                                 in current_deployment_filters}

--- a/packaging/rest-service/files/opt/manager/scripts/load_permissions.py
+++ b/packaging/rest-service/files/opt/manager/scripts/load_permissions.py
@@ -17,6 +17,8 @@ def load_permissions(authorization_file_path, debug=False):
         auth_data = yaml.safe_load(f)
 
     with setup_flask_app().app_context():
+        db.session.execute("SET SESSION audit.execution_id = :id",
+                           params={'id': 'load_permissions'})
         existing_roles = db.session.query(models.Role)
         existing_role_names = [
             role.name for role in existing_roles


### PR DESCRIPTION
... because otherwise `audit_log`'s `audit_log_creator_or_user_not_null`
constraint is not met.