### PR TITLE
RD-3006 Create a dep-update object in the workflow

### DIFF
--- a/workflows/cloudify_system_workflows/deployment_update/workflow.py
+++ b/workflows/cloudify_system_workflows/deployment_update/workflow.py
@@ -1,6 +1,47 @@
 from cloudify.decorators import workflow
+from cloudify.state import workflow_ctx
+from cloudify.manager import get_rest_client
+
+
+def create_update(*, update_id, new_inputs):
+    client = get_rest_client()
+    dep = client.deployments.get(workflow_ctx.deployment.id)
+
+    inputs = dep.inputs.copy()
+    inputs.update(new_inputs)
+
+    client.deployment_updates.create(
+        update_id,
+        workflow_ctx.deployment.id,
+        inputs=inputs
+    )
+
+
+def _prepare_update_graph(
+        ctx,
+        update_id,
+        *,
+        inputs=None,
+        **kwargs):
+    graph = ctx.graph_mode()
+    seq = graph.sequence()
+    seq.add(
+        ctx.local_task(create_update, kwargs={
+            'update_id': update_id,
+            'new_inputs': inputs or {},
+        }, total_retries=0),
+    )
+    return graph
 
 
 @workflow
 def update_deployment(ctx, **kwargs):
-    pass
+    client = get_rest_client()
+    update_id = '{0}_{1}'.format(ctx.deployment.id, ctx.execution_id)
+    graph = _prepare_update_graph(ctx, update_id, **kwargs)
+    graph.execute()
+
+    client.deployment_updates.set_attributes(
+        update_id,
+        state='successful'
+    )


### PR DESCRIPTION
Just adding to the skeleton.

I'm going to organize this workflow in a graph, so that all the
potentially-expensive computations can be stored and resumed if
cancelled, and in the future also replaced by remote tasks,
so that they can be split between nodes.

After this, there's going to be a second graph as well, for all the
installation.