### PR TITLE
RD-3039 Make new nodes in the dep-update workflow

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -190,9 +190,8 @@ class ResourceManager(object):
                 status in [ExecutionState.FAILED, ExecutionState.CANCELLED]:
             dep_update = self.sm.get(models.DeploymentUpdate, None,
                                      filters={'execution_id': execution_id})
-            if dep_update:
-                dep_update.state = UpdateStates.FAILED
-                self.sm.update(dep_update)
+            dep_update.state = UpdateStates.FAILED
+            self.sm.update(dep_update)
 
         # Similarly for a plugin update
         if workflow_id == 'update_plugin' and \

--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -237,7 +237,8 @@ class DeploymentUpdateId(SecuredResource):
         params = get_json_and_verify_params({
             'deployment_id': {'type': text_type, 'required': True},
             'state': {'optional': True},
-            'inputs': {'optional': True}
+            'inputs': {'optional': True},
+            'blueprint_id': {'optional': True}
         })
         sm = get_storage_manager()
         if not current_execution:
@@ -255,6 +256,9 @@ class DeploymentUpdateId(SecuredResource):
                 )
             dep_upd.state = params.get('state') or STATES.UPDATING
             dep_upd.new_inputs = params.get('inputs')
+            if params.get('blueprint_id'):
+                dep_upd.new_blueprint = sm.get(
+                    models.Blueprint, params['blueprint_id'])
             dep_upd.set_deployment(dep)
             return dep_upd
 

--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -270,6 +270,7 @@ class DeploymentUpdateId(SecuredResource):
             'plan': {'optional': True},
             'steps': {'optional': True},
             'nodes': {'optional': True},
+            'node_instances': {'optional': True},
         })
         sm = get_storage_manager()
         with sm.transaction():
@@ -287,6 +288,9 @@ class DeploymentUpdateId(SecuredResource):
                     step.set_deployment_update(dep_upd)
             if params.get('nodes'):
                 dep_upd.deployment_update_nodes = params['nodes']
+            if params.get('node_instances'):
+                dep_upd.deployment_update_node_instances = \
+                    params['node_instances']
             return dep_upd
 
 

--- a/workflows/cloudify_system_workflows/deployment_update/workflow.py
+++ b/workflows/cloudify_system_workflows/deployment_update/workflow.py
@@ -103,6 +103,11 @@ def _prepare_update_graph(
         inputs=None,
         blueprint_id=None,
         **kwargs):
+    """Make a tasks-graph that prepares the deployment-update.
+
+    Those operations only plan the update and prepare the
+    things-to-be-changed. They're safe to be rerun any number of times.
+    """
     graph = ctx.graph_mode()
     seq = graph.sequence()
     seq.add(
@@ -158,6 +163,11 @@ def create_new_instances(*, update_id):
 
 
 def _perform_update_graph(ctx, update_id, **kwargs):
+    """Make a tasks-graph that performs the deployment-update.
+
+    This is for the destructive operations that actually change the
+    deployment.
+    """
     graph = ctx.graph_mode()
     seq = graph.sequence()
     seq.add(

--- a/workflows/cloudify_system_workflows/deployment_update/workflow.py
+++ b/workflows/cloudify_system_workflows/deployment_update/workflow.py
@@ -68,6 +68,34 @@ def create_steps(*, update_id):
     )
 
 
+def prepare_update_nodes(*, update_id):
+    client = get_rest_client()
+    dep_up = client.deployment_updates.get(update_id)
+    deployment = client.deployments.get(dep_up.deployment_id)
+    old_nodes = client.nodes.list(deployment_id=dep_up.deployment_id)
+    new_nodes = dep_up.deployment_plan['nodes'].copy()
+    old_instances = client.node_instances.list(
+        deployment_id=dep_up.deployment_id)
+    changed_instances = tasks.modify_deployment(
+        nodes=new_nodes,
+        previous_nodes=old_nodes,
+        previous_node_instances=old_instances,
+        scaling_groups=deployment.scaling_groups,
+        modified_nodes=()
+    )
+    workflow_ctx.logger.info('changed_instances %s', changed_instances)
+    update_nodes = {}
+    for step in dep_up.steps:
+        if step['entity_type'] != 'node':
+            continue
+        update_nodes.setdefault(step['action'], []).append(step['entity_id'])
+    client.deployment_updates.set_attributes(
+        update_id,
+        nodes=update_nodes,
+        node_instances=changed_instances
+    )
+
+
 def _prepare_update_graph(
         ctx,
         update_id,
@@ -89,16 +117,77 @@ def _prepare_update_graph(
         ctx.local_task(create_steps, kwargs={
             'update_id': update_id,
         }, total_retries=0),
+        ctx.local_task(prepare_update_nodes, kwargs={
+            'update_id': update_id,
+        }, total_retries=0),
     )
     return graph
 
 
+def create_new_nodes(*, update_id):
+    client = get_rest_client()
+    dep_up = client.deployment_updates.get(update_id)
+    update_nodes = dep_up['deployment_update_nodes'] or {}
+    plan_nodes = dep_up.deployment_plan['nodes']
+    create_nodes = []
+    for node_path in update_nodes.get('add', []):
+        node_name = node_path.split(':')[-1]
+        for plan_node in plan_nodes:
+            if plan_node['name'] == node_name:
+                create_nodes.append(plan_node)
+                new_node = plan_node
+                break
+        else:
+            raise RuntimeError(f'New node {node_name} not found in the plan')
+    client.nodes.create_many(
+        dep_up.deployment_id,
+        create_nodes
+    )
+
+
+def create_new_instances(*, update_id):
+    client = get_rest_client()
+    dep_up = client.deployment_updates.get(update_id)
+
+    update_instances = dep_up['deployment_update_node_instances']
+    if update_instances.get('added_and_related'):
+        client.node_instances.create_many(
+            dep_up.deployment_id,
+            update_instances['added_and_related']
+        )
+
+
+def _perform_update_graph(ctx, update_id, **kwargs):
+    graph = ctx.graph_mode()
+    seq = graph.sequence()
+    seq.add(
+        ctx.local_task(create_new_nodes, kwargs={
+            'update_id': update_id,
+        }, total_retries=0),
+        ctx.local_task(create_new_instances, kwargs={
+            'update_id': update_id,
+        }, total_retries=0),
+    )
+    return graph
+
+
+def _clear_graph(graph):
+    for task in graph.tasks:
+        graph.remove_task(task)
+
+
 @workflow
-def update_deployment(ctx, **kwargs):
+def update_deployment(ctx, *, preview=False, **kwargs):
     client = get_rest_client()
     update_id = '{0}_{1}'.format(ctx.deployment.id, ctx.execution_id)
     graph = _prepare_update_graph(ctx, update_id, **kwargs)
     graph.execute()
+
+
+    if not preview:
+        _clear_graph(graph)
+        graph = _perform_update_graph(ctx, update_id)
+        graph.execute()
 
     client.deployment_updates.set_attributes(
         update_id,

--- a/workflows/cloudify_system_workflows/deployment_update/workflow.py
+++ b/workflows/cloudify_system_workflows/deployment_update/workflow.py
@@ -140,7 +140,6 @@ def create_new_nodes(*, update_id):
         for plan_node in plan_nodes:
             if plan_node['name'] == node_name:
                 create_nodes.append(plan_node)
-                new_node = plan_node
                 break
         else:
             raise RuntimeError(f'New node {node_name} not found in the plan')
@@ -192,7 +191,6 @@ def update_deployment(ctx, *, preview=False, **kwargs):
     update_id = '{0}_{1}'.format(ctx.deployment.id, ctx.execution_id)
     graph = _prepare_update_graph(ctx, update_id, **kwargs)
     graph.execute()
-
 
     if not preview:
         _clear_graph(graph)


### PR DESCRIPTION
Make a separate graph for the destructive operations, and in it,
create new nodes and node-instances.

For now, only adding nodes is implemented. Removing and modifications
will come later.