### PR TITLE
Use a machine-specific docker image in integration tests

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import logging
+import platform
 import pytest
 import wagon
 
@@ -37,7 +38,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--image-name',
         help='Name of the Cloudify Manager AIO docker image',
-        default='cloudify-manager-aio:latest'
+        default=f'cloudify-manager-aio-{platform.machine()}:latest'
     )
     parser.addoption(
         '--keep-container',


### PR DESCRIPTION
Because now generate Docker images with names containing a machine
information, e.g. `cloudify-manager-aio-x86_64`.