### PR TITLE
RD-3086 Allow updating relationships for node-instances

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v1/nodes.py
@@ -27,6 +27,7 @@ from manager_rest.rest.rest_utils import (
     get_args_and_verify_arguments,
     get_json_and_verify_params,
     verify_and_convert_bool,
+    is_deployment_update
 )
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
@@ -227,6 +228,7 @@ class NodeInstancesId(SecuredResource):
             if 'state' in request_dict:
                 instance.state = request_dict['state']
         if 'relationships' in request_dict:
-
+            if not is_deployment_update():
+                raise manager_exceptions.OnlyDeploymentUpdate()
             instance.relationships = request_dict['relationships']
         return get_storage_manager().update(instance)

--- a/rest-service/manager_rest/rest/resources_v1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v1/nodes.py
@@ -224,7 +224,8 @@ class NodeInstancesId(SecuredResource):
                     'update version={1}]'.format(instance.version, version)
                 )
             if 'runtime_properties' in request_dict:
-                instance.runtime_properties = request_dict['runtime_properties']
+                instance.runtime_properties = \
+                    request_dict['runtime_properties']
             if 'state' in request_dict:
                 instance.state = request_dict['state']
         if 'relationships' in request_dict:

--- a/rest-service/manager_rest/rest/resources_v1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v1/nodes.py
@@ -198,12 +198,17 @@ class NodeInstancesId(SecuredResource):
     def patch(self, node_instance_id, **kwargs):
         """Update node instance by id."""
         request_dict = get_json_and_verify_params(
-            {'version': {'optional': True}}
+            {'version': {'type': int}}
         )
 
         if not isinstance(request.json, collections.Mapping):
             raise manager_exceptions.BadParametersError(
                 'Request body needs to be a mapping')
+        version = request_dict['version'] or 1
+        force = verify_and_convert_bool(
+            'force',
+            request.args.get('force', False)
+        )
 
         instance = get_storage_manager().get(
             models.NodeInstance,
@@ -213,11 +218,6 @@ class NodeInstancesId(SecuredResource):
         if 'runtime_properties' in request_dict or 'state' in request_dict:
             # Added for backwards compatibility with older client versions that
             # had version=0 by default
-            version = request_dict['version'] or 1
-            force = verify_and_convert_bool(
-                'force',
-                request.args.get('force', False)
-            )
             if not force and instance.version > version:
                 raise manager_exceptions.ConflictError(
                     'Node instance update conflict [current version={0}, '

--- a/rest-service/manager_rest/rest/resources_v1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v1/nodes.py
@@ -227,6 +227,6 @@ class NodeInstancesId(SecuredResource):
             if 'state' in request_dict:
                 instance.state = request_dict['state']
         if 'relationships' in request_dict:
-            instance.relationships = instance.relationships + \
-                request_dict['relationships']
+
+            instance.relationships = request_dict['relationships']
         return get_storage_manager().update(instance)

--- a/rest-service/manager_rest/test/endpoints/test_nodes.py
+++ b/rest-service/manager_rest/test/endpoints/test_nodes.py
@@ -76,9 +76,8 @@ class NodesTest(base_test.BaseServerTestCase):
         response = self.patch('/node-instances/1234', 'not a dictionary')
         self.assertEqual(400, response.status_code)
         response = self.patch('/node-instances/1234', {
-            'a dict': 'without '
-                      'state_version'
-                      ' key'})
+            'a dict': 'without a version key'
+        })
         self.assertEqual(400, response.status_code)
         response = self.patch('/node-instances/1234', {
             'runtime_properties': {},


### PR DESCRIPTION
Other than changing node-instance runtime-props, we can now also change
relationships too.