### PR TITLE
RD-3040 Run inte-tests with the new deployment-update workflow

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_addition.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_addition.py
@@ -517,10 +517,10 @@ class TestDeploymentUpdateAddition(DeploymentUpdateBase):
             self._deploy_and_get_modified_bp_path('add_workflow')
         self.client.blueprints.upload(modified_bp_path, BLUEPRINT_ID)
         wait_for_blueprint_upload(BLUEPRINT_ID, self.client)
-        dep_update = self._do_update(deployment.id, BLUEPRINT_ID)
+        self._do_update(deployment.id, BLUEPRINT_ID)
 
         execution = self.client.executions.start(
-            dep_update.deployment_id,
+            deployment.id,
             workflow_id='my_custom_workflow',
             parameters={
                 'node_id': 'site1',
@@ -530,11 +530,11 @@ class TestDeploymentUpdateAddition(DeploymentUpdateBase):
         self.wait_for_execution_to_end(execution)
 
         affected_node = self.client.node_instances.list(
-            deployment_id=dep_update.deployment_id,
+            deployment_id=deployment.id,
             node_id='site1'
         )
         self.assertEqual(len(affected_node), 3)
-        deployment = self.client.deployments.get(dep_update.deployment_id)
+        deployment = self.client.deployments.get(deployment.id)
         self.assertIn('my_custom_workflow',
                       [w['name'] for w in deployment.workflows])
 
@@ -543,8 +543,8 @@ class TestDeploymentUpdateAddition(DeploymentUpdateBase):
             self._deploy_and_get_modified_bp_path('add_output')
         self.client.blueprints.upload(modified_bp_path, BLUEPRINT_ID)
         wait_for_blueprint_upload(BLUEPRINT_ID, self.client)
-        dep_update = self._do_update(deployment.id, BLUEPRINT_ID)
-        deployment = self.client.deployments.get(dep_update.deployment_id)
+        self._do_update(deployment.id, BLUEPRINT_ID)
+        deployment = self.client.deployments.get(deployment.id)
         self._assertDictContainsSubset({'custom_output': {'value': 0}},
                                        deployment.outputs)
 
@@ -555,7 +555,7 @@ class TestDeploymentUpdateAddition(DeploymentUpdateBase):
 
         self.client.blueprints.upload(modified_bp_path, BLUEPRINT_ID)
         wait_for_blueprint_upload(BLUEPRINT_ID, self.client)
-        dep_update = self._do_update(deployment.id, BLUEPRINT_ID)
+        self._do_update(deployment.id, BLUEPRINT_ID)
 
-        deployment = self.client.deployments.get(dep_update.deployment_id)
+        deployment = self.client.deployments.get(deployment.id)
         self.assertRegexpMatches(deployment['description'], 'new description')

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_addition.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_addition.py
@@ -559,3 +559,16 @@ class TestDeploymentUpdateAddition(DeploymentUpdateBase):
 
         deployment = self.client.deployments.get(deployment.id)
         self.assertRegexpMatches(deployment['description'], 'new description')
+
+
+class NewTestDeploymentUpdateAddition(TestDeploymentUpdateAddition):
+    def _do_update(self, deployment_id, blueprint_id=None,
+                   preview=False, **kwargs):
+        params = {
+            'blueprint_id': blueprint_id,
+        }
+        if preview:
+            params['preview'] = preview
+        exc = self.client.executions.start(
+            deployment_id, 'csys_new_deployment_update', parameters=params)
+        self.wait_for_execution_to_end(exc)


### PR DESCRIPTION
Same testcases (inherited), but a different implementation!