### PR TITLE
RD-3087 Allow setting new attributes in deployment-update

### DIFF
--- a/rest-service/manager_rest/manager_exceptions.py
+++ b/rest-service/manager_rest/manager_exceptions.py
@@ -138,6 +138,11 @@ class ForbiddenWhileCancelling(ForbiddenError):
     error_code = 'forbidden_while_cancelling'
 
 
+class OnlyDeploymentUpdate(ForbiddenError):
+    """This request is only allowed from a deployment-update workflow."""
+    error_code = 'only_deployment_update'
+
+
 class UnsupportedContentTypeError(ManagerException):
     error_code = 'unsupported_content_type_error'
     status_code = 415

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -34,6 +34,7 @@ from cloudify.models_states import (
 )
 
 from manager_rest.storage import db, models
+from manager_rest.execution_token import current_execution
 from manager_rest.constants import RESERVED_LABELS, RESERVED_PREFIX
 from manager_rest.dsl_functions import (get_secret_method,
                                         evaluate_intrinsic_functions)
@@ -1110,3 +1111,9 @@ def deployment_group_id_filter():
 
 def normalize_value(value):
     return unicodedata.normalize('NFKC', value)
+
+
+def is_deployment_update():
+    """Is the current request within a deployment-update execution?"""
+    return current_execution and current_execution.workflow_id in (
+        'update', 'csys_new_deployment_update')


### PR DESCRIPTION
Allow changing deployment attributes, but only from a deployment-update.

The decorator will be useful for some other endpoint (nodes/node-instances patch)