### PR TITLE
RD-3077 dep-update inte-tests: cope with no-op executions

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_removal.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_removal.py
@@ -178,8 +178,7 @@ class TestDeploymentUpdateRemoval(DeploymentUpdateBase):
 
         # the operation doesnt exist anymore - the execution was a no-op, so
         # runtime-properties haven't changed
-        ni = self.client.node_instances.get(
-            modified_node_instances['modified'][0]['id'])
+        ni = self.client.node_instances.get(modified_node_instance['id'])
         self.assertEqual(ni['runtime_properties']['source_ops_counter'], '1')
 
     def test_remove_relationship(self):


### PR DESCRIPTION
Those tests used to assert that nonexistent (removed) operations throw
an error, however now it's a no-op instead. So those tests must now
assert that nothing has changed instead (in this case:
runtime-properties, which would have been changed by those operations,
if they still existed)