### PR TITLE
RD-3077 dep-update inte-tests: cope with no-op executions

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_removal.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_removal.py
@@ -174,15 +174,12 @@ class TestDeploymentUpdateRemoval(DeploymentUpdateBase):
                 workflow_id='execute_operation',
                 parameters={'operation': operation_id}
         )
-        self.assertRaises(
-            RuntimeError,
-            self.wait_for_execution_to_end, execution
-        )
-        execution = self.client.executions.get(execution.id)
+        self.wait_for_execution_to_end(execution)
 
-        self.assertIn('{0} operation of node instance {1} does not exist'
-                      .format(operation_id, modified_node_instance.id),
-                      execution.error)
+        # the operation doesnt exist anymore - the execution was a no-op, so
+        # runtime-properties haven't changed
+        ni = self.client.node_instances.get(modified_node_instance['id'])
+        self.assertEqual(ni['runtime_properties']['source_ops_counter'], '1')
 
     def test_remove_relationship(self):
         deployment, modified_bp_path = \
@@ -301,16 +298,14 @@ class TestDeploymentUpdateRemoval(DeploymentUpdateBase):
                 'custom_workflow',
                 parameters={'node_id': 'site2'}
         )
-        self.assertRaises(
-            RuntimeError,
-            self.wait_for_execution_to_end, execution
-        )
-        execution = self.client.executions.get(execution.id)
-        self.assertEqual(execution.status, 'failed')
-        self.assertIn('{0} operation of node instance {1} does not exist'
-                      .format(operation_id,
-                              base_node_instances['source'][0]['id']),
-                      execution.error)
+        self.wait_for_execution_to_end(execution)
+
+        # the operation doesnt exist anymore - the execution was a no-op, so
+        # the runtime-property was not inserted
+        ni = self.client.node_instances.list(
+            deployment_id=deployment.id, node_id='site2'
+        )[0]
+        self.assertNotIn('source_ops_counter', ni['runtime_properties'])
 
         modified_nodes, modified_node_instances = \
             self._map_node_and_node_instances(deployment.id, node_mapping)


### PR DESCRIPTION
This ports #3230 to 6.2.0

Those tests used to assert that nonexistent (removed) operations throw
an error, however now it's a no-op instead. So those tests must now
assert that nothing has changed instead (in this case:
runtime-properties, which would have been changed by those operations,
if they still existed)