### PR TITLE
RD-3156 Add upload_execution to Blueprint.response_fields

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -135,6 +135,8 @@ class Blueprint(CreatedAtMixin, SQLResourceBase):
         fields = super(Blueprint, cls).response_fields
         fields['labels'] = flask_fields.List(
             flask_fields.Nested(Label.resource_fields))
+        fields['upload_execution'] = flask_fields.Nested(
+            Execution.resource_fields)
         return fields
 
     @classproperty


### PR DESCRIPTION
A patch for Cloudify>=6.0

copied from https://github.com/cloudify-cosmo/cloudify-manager/pull/3246