### PR TITLE
CYBL-1248 Handle invalid blueprint syntax

### DIFF
--- a/packaging/cloudify-mgmtworker.spec
+++ b/packaging/cloudify-mgmtworker.spec
@@ -24,7 +24,7 @@ Cloudify's Management worker
 
 %build
 python3 -m venv /opt/mgmtworker/env
-%{PIP_INSTALL} --upgrade pip"<20.0" setuptools
+%{PIP_INSTALL} --upgrade pip"<20.0" setuptools"<58.0"
 %{PIP_INSTALL} -r "${RPM_SOURCE_DIR}/packaging/mgmtworker/requirements.txt"
 %{PIP_INSTALL} --upgrade "${RPM_SOURCE_DIR}/mgmtworker"
 %{PIP_INSTALL} --upgrade "${RPM_SOURCE_DIR}/workflows"

--- a/packaging/cloudify-rest-service.spec
+++ b/packaging/cloudify-rest-service.spec
@@ -34,7 +34,7 @@ Cloudify's REST Service.
 
 python3 -m venv %_manager_env
 
-%_manager_env/bin/pip install --upgrade pip"<20.0" setuptools
+%_manager_env/bin/pip install --upgrade pip"<20.0" setuptools"<58.0"
 %_manager_env/bin/pip install -r "${RPM_SOURCE_DIR}/rest-service/dev-requirements.txt"
 %_manager_env/bin/pip install "${RPM_SOURCE_DIR}/rest-service"[dbus]
 %_manager_env/bin/pip install "${RPM_SOURCE_DIR}/amqp-postgres"

--- a/rest-service/manager_rest/shell/substitute_import_lines.py
+++ b/rest-service/manager_rest/shell/substitute_import_lines.py
@@ -108,6 +108,9 @@ def correct_blueprint(blueprint: models.Blueprint,
         raise common.UpdateException(
             'Cannot load blueprint from {0}: {1}'.format(file_name, ex))
 
+    if start_at >= end_at:
+        raise common.UpdateException('Invalid syntax: {0}'.format(file_name))
+
     try:
         common.update_blueprint(file_name, new_file_name, start_at, end_at,
                                 mapping.replacement(separator))


### PR DESCRIPTION
... in case we're unable to determine `imports:` line position when
parsing a blueprint in substitute-import-lines scripts.

copied from https://github.com/cloudify-cosmo/cloudify-manager/pull/3241