### PR TITLE
RD-2965 + RD-3117 Refactor starting executions

### DIFF
--- a/execution-scheduler/execution_scheduler/main.py
+++ b/execution-scheduler/execution_scheduler/main.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 
 from cloudify.models_states import ExecutionState
 
-from manager_rest import config
+from manager_rest import config, workflow_executor
 from manager_rest.storage import models, get_storage_manager
 from manager_rest.flask_utils import setup_flask_app
 from manager_rest.maintenance import get_maintenance_state
@@ -132,7 +132,9 @@ def execute_workflow(schedule):
         **execution_arguments,
     )
     rm.sm.put(execution)
-    return rm.execute_workflow(execution, **start_arguments)
+    messages = rm.prepare_executions([execution], **start_arguments)
+    db.session.commit()
+    workflow_executor.execute_workflow(messages)
 
 
 def main():

--- a/mgmtworker/mgmtworker/worker.py
+++ b/mgmtworker/mgmtworker/worker.py
@@ -242,7 +242,7 @@ class MgmtworkerServiceTaskConsumer(ServiceTaskConsumer):
         shutil.rmtree(dep_dir, ignore_errors=True)
 
     def cancel_workflow_task(self, execution_id, rest_token, tenant,
-                             execution_token, rest_host):
+                             rest_host):
         logger.info('Cancelling workflow {0}'.format(execution_id))
 
         class CancelCloudifyContext(object):
@@ -252,7 +252,7 @@ class MgmtworkerServiceTaskConsumer(ServiceTaskConsumer):
                 self.rest_host = rest_host
                 self.tenant_name = tenant['name']
                 self.rest_token = rest_token
-                self.execution_token = execution_token
+                self.execution_token = None
                 # always bypass - this is a kill, as forceful as we can get
                 self.bypass_maintenance = True
 

--- a/rest-service/manager_rest/plugins_update/manager.py
+++ b/rest-service/manager_rest/plugins_update/manager.py
@@ -29,7 +29,7 @@ from dsl_parser.constants import (PLUGIN_NAME_KEY,
                                   PLUGIN_PACKAGE_NAME,
                                   PLUGIN_PACKAGE_VERSION)
 
-from manager_rest import config, utils
+from manager_rest import config, utils, workflow_executor
 from manager_rest.storage import get_storage_manager, models
 from manager_rest.resource_manager import get_resource_manager
 from manager_rest.plugins_update.constants import (STATES,

--- a/rest-service/manager_rest/plugins_update/manager.py
+++ b/rest-service/manager_rest/plugins_update/manager.py
@@ -160,12 +160,13 @@ class PluginsUpdateManager(object):
             plugins_update.state = STATES.UPDATING
             self.sm.update(plugins_update)
 
-        plugins_update.execution = \
+        plugins_update.execution, messages = \
             get_resource_manager(self.sm).update_plugins(
                 plugins_update, not changes_required, auto_correct_types,
                 reevaluate_active_statuses)
         plugins_update.state = (STATES.EXECUTING_WORKFLOW if changes_required
                                 else STATES.NO_CHANGES_REQUIRED)
+        workflow_executor.execute_workflow(messages)
         return self.sm.update(plugins_update)
 
     def finalize(self, plugins_update_id):

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -993,6 +993,7 @@ class ResourceManager(object):
         errors = []
         while executions:
             exc = executions.pop()
+            exc.ensure_defaults()
             if exc.deployment:
                 try:
                     self._check_allow_global_execution(exc.deployment)
@@ -1017,6 +1018,7 @@ class ResourceManager(object):
                 wait_after_fail=wait_after_fail,
                 bypass_maintenance=bypass_maintenance
             )
+            exc.status = ExecutionState.PENDING
             messages.append(message)
             workflow = exc.get_workflow()
             if not workflow.get('is_cascading', False):

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -271,7 +271,7 @@ class ResourceManager(object):
                 execution.deployment,
                 execution.workflow_id
             )
-            execution.render_context()  # try this here to fail early
+            execution.get_workflow()  # try this here to fail early
         except Exception as e:
             execution.status = ExecutionState.FAILED
             execution.error = str(e)

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1019,7 +1019,8 @@ class ResourceManager(object):
 
     def prepare_executions(self, executions, *, force=False, queue=False,
                            bypass_maintenance=None, wait_after_fail=600,
-                           allow_overlapping_running_wf=False):
+                           allow_overlapping_running_wf=False,
+                           commit=True):
         executions = list(executions)
         messages = []
         while executions:
@@ -1052,7 +1053,8 @@ class ResourceManager(object):
                 continue
             component_executions = self.get_component_executions(exc)
             executions.extend(component_executions)
-        db.session.commit()
+        if commit:
+            db.session.commit()
         return messages
 
 

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -946,6 +946,7 @@ class ResourceManager(object):
                        modified_attrs=('status', 'ended_at', 'resume'))
 
         message = execution.render_message(bypass_maintenance=False)
+        db.session.commit()
         workflow_executor.execute_workflow([message])
 
         # Dealing with the inner Components' deployments
@@ -1171,6 +1172,7 @@ class ResourceManager(object):
             return execution, []
         message = execution.render_message(
             bypass_maintenance=bypass_maintenance)
+        db.session.commit()
         return execution, [message]
 
     def _retrieve_components_from_deployment(self, deployment_id_filter):

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -596,8 +596,7 @@ class ResourceManager(object):
         )
         self.sm.put(execution)
         messages = self.prepare_executions([execution])
-        workflow_executor.execute_workflow(messages)
-        return execution
+        return execution, messages
 
     def publish_blueprint(self,
                           application_dir,

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -983,7 +983,6 @@ class ResourceManager(object):
             component_executions.append(component_execution)
         return component_executions
 
-
     def execute_workflow(self, execution, *, force=False, queue=False,
                          bypass_maintenance=None, wait_after_fail=600,
                          allow_overlapping_running_wf=False,

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1296,12 +1296,14 @@ class ResourceManager(object):
             if execution.status not in (ExecutionState.PENDING,
                                         ExecutionState.STARTED,
                                         ExecutionState.SCHEDULED) and \
-                    (not force_execution or execution.status != ExecutionState.CANCELLING)\
+                    (not force_execution
+                     or execution.status != ExecutionState.CANCELLING)\
                     and not kill_execution:
                 raise manager_exceptions.IllegalActionError(
                     "Can't {0} cancel execution {1} because it's in status {2}"
                     .format(
-                        'kill-' if kill_execution else 'force-' if force_execution else '',
+                        'kill-' if kill_execution
+                        else 'force-' if force_execution else '',
                         execution_id,
                         execution.status))
 

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -941,7 +941,7 @@ class ResourceManager(object):
 
         execution.status = ExecutionState.STARTED
         execution.ended_at = None
-        execution.resumed = True
+        execution.resume = True
         self.sm.update(execution,
                        modified_attrs=('status', 'ended_at', 'resume'))
 

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1055,7 +1055,6 @@ class ResourceManager(object):
             db.session.commit()
         return messages
 
-
     @staticmethod
     def _verify_workflow_in_deployment(wf_id, deployment, dep_id):
         if wf_id not in deployment.workflows:
@@ -1073,7 +1072,7 @@ class ResourceManager(object):
         """
         system_exec_running = self._check_for_active_system_wide_execution(
             queue)
-        if force or not execution.deployment:
+        if force or not execution._deployment_fk:
             return system_exec_running
         else:
             execution_running = self._check_for_active_executions(

--- a/rest-service/manager_rest/rest/resources_v1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v1/executions.py
@@ -21,7 +21,7 @@ from flask_restful_swagger import swagger
 from flask_restful.inputs import boolean
 
 from cloudify.models_states import ExecutionState
-from manager_rest import manager_exceptions
+from manager_rest import manager_exceptions, workflow_executor
 from manager_rest.maintenance import is_bypass_maintenance_mode
 from manager_rest.resource_manager import (
     ResourceManager,
@@ -153,13 +153,14 @@ class Executions(SecuredResource):
                 allow_custom_parameters=allow_custom_parameters,
             )
             sm.put(execution)
-        rm.execute_workflow(
-            execution,
+        messages = rm.prepare_executions(
+            [execution],
             bypass_maintenance=is_bypass_maintenance_mode(),
             force=force,
             queue=queue,
             wait_after_fail=wait_after_fail,
         )
+        workflow_executor.execute_workflow(messages)
         return execution, 201
 
     def _parse_scheduled_time(self, scheduled_time):

--- a/rest-service/manager_rest/rest/resources_v1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v1/executions.py
@@ -153,13 +153,13 @@ class Executions(SecuredResource):
                 allow_custom_parameters=allow_custom_parameters,
             )
             sm.put(execution)
-        messages = rm.prepare_executions(
-            [execution],
-            bypass_maintenance=is_bypass_maintenance_mode(),
-            force=force,
-            queue=queue,
-            wait_after_fail=wait_after_fail,
-        )
+            messages = rm.prepare_executions(
+                [execution],
+                bypass_maintenance=is_bypass_maintenance_mode(),
+                force=force,
+                queue=queue,
+                wait_after_fail=wait_after_fail,
+            )
         workflow_executor.execute_workflow(messages)
         return execution, 201
 

--- a/rest-service/manager_rest/rest/resources_v2/snapshots.py
+++ b/rest-service/manager_rest/rest/resources_v2/snapshots.py
@@ -112,7 +112,7 @@ class SnapshotsId(SecuredResource):
             'queue',
             request_dict.get('queue', False)
         )
-        execution = get_resource_manager().create_snapshot(
+        execution, messages = get_resource_manager().create_snapshot(
             snapshot_id,
             include_credentials,
             include_logs,
@@ -120,7 +120,7 @@ class SnapshotsId(SecuredResource):
             True,
             queue
         )
-
+        workflow_executor.execute_workflow(messages)
         return execution, 201
 
     @swagger.operation(
@@ -250,7 +250,7 @@ class SnapshotsIdRestore(SecuredResource):
         default_timeout_sec = 300
         request_timeout = request_dict.get('timeout', default_timeout_sec)
         timeout = rest_utils.convert_to_int(request_timeout)
-        execution = get_resource_manager().restore_snapshot(
+        execution, messages = get_resource_manager().restore_snapshot(
             snapshot_id,
             force,
             True,
@@ -258,4 +258,5 @@ class SnapshotsIdRestore(SecuredResource):
             restore_certificates,
             no_reboot
         )
+        workflow_executor.execute_workflow(messages)
         return execution, 200

--- a/rest-service/manager_rest/rest/resources_v2/snapshots.py
+++ b/rest-service/manager_rest/rest/resources_v2/snapshots.py
@@ -21,8 +21,8 @@ from flask_restful_swagger import swagger
 
 from cloudify.models_states import SnapshotState, ExecutionState
 
+from manager_rest import config, manager_exceptions, workflow_executor
 from manager_rest.security import SecuredResource
-from manager_rest import config, manager_exceptions
 from manager_rest.security.authorization import authorize
 from manager_rest.rest import rest_decorators, rest_utils
 from manager_rest.storage import get_storage_manager, models

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -1107,7 +1107,8 @@ class DeploymentGroupsId(SecuredResource):
                 group.deployments.append(dep)
                 create_exec_group.executions.append(dep.create_execution)
                 deployment_count += 1
-        create_exec_group.start_executions(sm, rm)
+            messages = create_exec_group.start_executions(sm, rm)
+        workflow_executor.execute_workflow(messages)
 
     def _prepare_sites(self, sm, new_deployments):
         """If new-deployment specs contain a site name, fetch those sites
@@ -1294,7 +1295,8 @@ class DeploymentGroupsId(SecuredResource):
                         delete_logs=args.delete_logs
                     )
                     delete_exc_group.executions.append(delete_exc)
-            delete_exc_group.start_executions(sm, rm)
+                messages = delete_exc_group.start_executions(sm, rm)
+            workflow_executor.execute_workflow(messages)
 
         sm.delete(group)
         return None, 204

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -53,11 +53,6 @@ from manager_rest.rest import (
     rest_decorators,
     responses_v3
 )
-from manager_rest.workflow_executor import (
-    get_amqp_client,
-    workflow_sendhandler
-)
-
 from ..responses_v2 import ListResponse
 
 

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -258,16 +258,16 @@ class DeploymentsId(resources_v1.DeploymentsId):
                 labels=labels,
                 display_name=request_dict.get('display_name'),
             )
-        try:
-            messages = rm.prepare_executions(
-                [create_execution],
-                bypass_maintenance=bypass_maintenance
-            )
-            workflow_executor.execute_workflow(messages)
-        except manager_exceptions.ExistingRunningExecutionError:
-            rm.delete_deployment(deployment)
-            raise
-
+            try:
+                messages = rm.prepare_executions(
+                    [create_execution],
+                    bypass_maintenance=bypass_maintenance,
+                    commit=False
+                )
+            except manager_exceptions.ExistingRunningExecutionError:
+                rm.delete_deployment(deployment)
+                raise
+        workflow_executor.execute_workflow(messages)
         if not args.async_create:
             rest_utils.wait_for_execution(sm, deployment.create_execution.id)
             if deployment.create_execution.status != ExecutionState.TERMINATED:

--- a/rest-service/manager_rest/rest/resources_v3_1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/executions.py
@@ -219,11 +219,7 @@ class ExecutionGroups(SecuredResource):
                     executions.append(execution)
                     group.executions.append(execution)
 
-        amqp_client = get_amqp_client()
-        handler = workflow_sendhandler()
-        amqp_client.add_handler(handler)
-        with amqp_client:
-            group.start_executions(sm, rm, handler, force=force)
+        group.start_executions(sm, rm, force=force)
         return group
 
 
@@ -292,12 +288,7 @@ class ExecutionGroupsId(SecuredResource):
                 exc.ended_at = None
                 exc.resumed = True
                 sm.update(exc, modified_attrs=('status', 'ended_at', 'resume'))
-
-        amqp_client = get_amqp_client()
-        handler = workflow_sendhandler()
-        amqp_client.add_handler(handler)
-        with amqp_client:
-            group.start_executions(sm, rm, handler)
+        group.start_executions(sm, rm)
 
     @authorize('execution_group_update')
     @rest_decorators.marshal_with(models.ExecutionGroup)

--- a/rest-service/manager_rest/rest/resources_v3_1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/executions.py
@@ -20,8 +20,9 @@ from flask import request
 from sqlalchemy.dialects.postgresql import insert
 
 from cloudify.models_states import ExecutionState
-from manager_rest.rest.responses_v3 import ItemsCount
 
+from manager_rest import workflow_executor
+from manager_rest.rest.responses_v3 import ItemsCount
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
 from manager_rest.rest import resources_v2, rest_decorators
@@ -34,10 +35,6 @@ from manager_rest.rest.rest_utils import (
     parse_datetime_multiple_formats
 )
 from manager_rest.storage import models, db, get_storage_manager, ListResult
-from manager_rest.workflow_executor import (
-    get_amqp_client,
-    workflow_sendhandler
-)
 
 
 class Executions(resources_v2.Executions):

--- a/rest-service/manager_rest/rest/resources_v3_1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/executions.py
@@ -218,8 +218,8 @@ class ExecutionGroups(SecuredResource):
                     sm.put(execution)
                     executions.append(execution)
                     group.executions.append(execution)
-
-        group.start_executions(sm, rm, force=force)
+            messages = group.start_executions(sm, rm, force=force)
+        workflow_executor.execute_workflow(messages)
         return group
 
 
@@ -288,7 +288,8 @@ class ExecutionGroupsId(SecuredResource):
                 exc.ended_at = None
                 exc.resumed = True
                 sm.update(exc, modified_attrs=('status', 'ended_at', 'resume'))
-        group.start_executions(sm, rm)
+            messages = group.start_executions(sm, rm)
+        workflow_executor.execute_workflow(messages)
 
     @authorize('execution_group_update')
     @rest_decorators.marshal_with(models.ExecutionGroup)

--- a/rest-service/manager_rest/storage/models_base.py
+++ b/rest-service/manager_rest/storage/models_base.py
@@ -169,6 +169,24 @@ class SQLModelBase(db.Model):
         'Float': flask_fields.Float
     }
 
+    def ensure_defaults(self):
+        """Synchronously set the defaults for this model's properties.
+
+        Normally the python-side defaults are only applied when the
+        model is committed, but if you need them to be applied _right now_,
+        call this.
+
+        This will only apply scalar and callable defaults, of course it
+        cannot apply defaults that are db-side (eg. a selectable).
+        """
+        for col_name, col in self.__table__.c.items():
+            if getattr(self, col_name, None) is None and col.default:
+                if col.default.is_scalar:
+                    value = col.default.arg
+                elif col.default.is_callable:
+                    value = col.default.arg(self)
+                setattr(self, col_name, value)
+
     def to_dict(self, suppress_error=False):
         """Return a dict representation of the model
 

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1334,15 +1334,12 @@ class ExecutionGroup(CreatedAtMixin, SQLResourceBase):
             exc for exc in self.executions
             if exc.status == ExecutionState.PENDING
         ]
-        with sm.transaction():
-            for execution in executions[self.concurrency:]:
-                execution.status = ExecutionState.QUEUED
-                sm.update(execution, modified_attrs=('status', ))
+        for execution in executions[self.concurrency:]:
+            execution.status = ExecutionState.QUEUED
+            sm.update(execution, modified_attrs=('status', ))
 
-        messages = rm.prepare_executions(
+        return rm.prepare_executions(
             executions[:self.concurrency], force=force, queue=True)
-        from manager_rest import workflow_executor
-        workflow_executor.execute_workflow(messages)
 
 
 class ExecutionSchedule(CreatedAtMixin, SQLResourceBase):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1149,6 +1149,7 @@ class Execution(CreatedAtMixin, SQLResourceBase):
             return param
 
     def render_message(self, wait_after_fail=600, bypass_maintenance=None):
+        self.ensure_defaults()
         workflow = self.get_workflow()
         session = db.session.object_session(self)
 

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -67,7 +67,6 @@ from .relationships import (
 if typing.TYPE_CHECKING:
     from manager_rest.resource_manager import ResourceManager
     from manager_rest.storage.storage_manager import SQLStorageManager
-    from cloudify.amqp_client import SendHandler
 
 
 RELATIONSHIP = 'relationship'

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1063,12 +1063,16 @@ class Execution(CreatedAtMixin, SQLResourceBase):
         if system_task_name:
             self.allow_custom_parameters = True
             return {'operation': system_task_name}
-        raise manager_exceptions.NonexistentWorkflowError(
-            f'Workflow {workflow_id} does not exist in the '
-            f'deployment {deployment.id}')
+        if deployment:
+            raise manager_exceptions.NonexistentWorkflowError(
+                f'Workflow {workflow_id} does not exist in the '
+                f'deployment {deployment.id}')
+        else:
+            raise manager_exceptions.NonexistentWorkflowError(
+                f'Builtin workflow {workflow_id} does not exist')
 
     def merge_workflow_parameters(self, parameters, deployment, workflow_id):
-        if not deployment.workflows:
+        if not deployment or not deployment.workflows:
             return
         workflow = self.get_workflow(deployment, workflow_id)
         workflow_parameters = workflow.get('parameters', {})

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -296,21 +296,15 @@ class SQLStorageManager(object):
             if all_tenants_authorization():
                 return query
             # Filter by all the tenants the user is allowed to list in
-            tenant_ids = [
-                tenant.id for tenant in current_user.all_tenants
+            tenants = [
+                tenant for tenant in current_user.all_tenants
                 if utils.tenant_specific_authorization(tenant,
                                                        model_class.__name__)
             ]
         else:
             # Specific tenant only
-            tenant_ids = [current_tenant.id] if current_tenant else []
-
-        # Match any of the applicable tenant ids or if it's a global resource
-        tenant_filter = sql_or(
-            model_class.visibility == VisibilityState.GLOBAL,
-            model_class._tenant_id.in_(tenant_ids)
-        )
-        return query.filter(tenant_filter)
+            tenants = [current_tenant] if current_tenant else []
+        return query.tenant(*tenants)
 
     def _add_permissions_filter(self, query, model_class):
         """Filter by the users present in either the `viewers` or `owners`

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -345,7 +345,8 @@ class BaseServerTestCase(unittest.TestCase):
             patch('manager_rest.workflow_executor._send_mgmtworker_task',
                   mock_send_mgmtworker_task),
             patch('manager_rest.workflow_executor._broadcast_mgmtworker_task'),
-            patch('manager_rest.workflow_executor.get_client'),
+            patch('manager_rest.workflow_executor.execute_workflow',
+                mock_send_mgmtworker_task),
             patch('manager_rest.resource_manager.send_event'),
         ]
         cls._patchers.extend(amqp_patches)

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -346,7 +346,7 @@ class BaseServerTestCase(unittest.TestCase):
                   mock_send_mgmtworker_task),
             patch('manager_rest.workflow_executor._broadcast_mgmtworker_task'),
             patch('manager_rest.workflow_executor.execute_workflow',
-                mock_send_mgmtworker_task),
+                  mock_send_mgmtworker_task),
             patch('manager_rest.resource_manager.send_event'),
         ]
         cls._patchers.extend(amqp_patches)

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -1064,9 +1064,9 @@ class ExecutionQueueingTests(BaseServerTestCase):
         exc2 = self._make_execution(status=ExecutionState.PENDING)
         with self.assertRaises(
                 manager_exceptions.ExistingRunningExecutionError):
-            self.rm.execute_workflow(exc2)
+            self.rm.prepare_executions([exc2])
 
-        self.rm.execute_workflow(exc2, queue=True)
+        self.rm.prepare_executions([exc2], queue=True)
         assert exc2.status == ExecutionState.QUEUED
 
     @mock.patch('manager_rest.resource_manager.send_event', mock.Mock())
@@ -1080,9 +1080,9 @@ class ExecutionQueueingTests(BaseServerTestCase):
         exc2 = self._make_execution(status=ExecutionState.PENDING)
         with self.assertRaises(
                 manager_exceptions.ExistingRunningExecutionError):
-            self.rm.execute_workflow(exc2)
+            self.rm.prepare_executions([exc2])
 
-        self.rm.execute_workflow(exc2, queue=True)
+        self.rm.prepare_executions([exc2], queue=True)
         assert exc2.status == ExecutionState.QUEUED
 
     @mock.patch('manager_rest.resource_manager.send_event', mock.Mock())

--- a/rest-service/manager_rest/test/mocks.py
+++ b/rest-service/manager_rest/test/mocks.py
@@ -195,14 +195,15 @@ def task_state():
     return Execution.TERMINATED
 
 
-def mock_send_mgmtworker_task(message, **_):
-    execution_id = message['id']
-    sm = get_storage_manager()
-    execution = sm.get(models.Execution, execution_id)
-    execution.status = task_state()
-    execution.ended_at = utils.get_formatted_timestamp()
-    execution.error = ''
-    sm.update(execution)
+def mock_send_mgmtworker_task(messages, **_):
+    for message in messages:
+        execution_id = message['id']
+        sm = get_storage_manager()
+        execution = sm.get(models.Execution, execution_id)
+        execution.status = task_state()
+        execution.ended_at = utils.get_formatted_timestamp()
+        execution.error = ''
+        sm.update(execution)
 
 
 def put_node_instance(storage_manager,

--- a/rest-service/manager_rest/upload_manager.py
+++ b/rest-service/manager_rest/upload_manager.py
@@ -39,7 +39,7 @@ from manager_rest.constants import (FILE_SERVER_PLUGINS_FOLDER,
                                     FILE_SERVER_BLUEPRINTS_FOLDER)
 from manager_rest.archiving import get_archive_type
 from manager_rest.storage.models import Blueprint, Plugin
-from manager_rest import config, chunked, manager_exceptions
+from manager_rest import config, chunked, manager_exceptions, workflow_executor
 from manager_rest.utils import (mkdirs,
                                 get_formatted_timestamp,
                                 current_tenant,

--- a/rest-service/manager_rest/upload_manager.py
+++ b/rest-service/manager_rest/upload_manager.py
@@ -399,7 +399,7 @@ class UploadedBlueprintsManager(UploadedDataManager):
             self.upload_archive_to_file_server(data_id)
 
         try:
-            new_blueprint.upload_execution = rm.upload_blueprint(
+            new_blueprint.upload_execution, messages = rm.upload_blueprint(
                 data_id,
                 application_file_name,
                 blueprint_url,
@@ -407,6 +407,7 @@ class UploadedBlueprintsManager(UploadedDataManager):
                 labels=labels
             )
             rm.sm.update(new_blueprint)
+            workflow_executor.execute_workflow(messages)
         except manager_exceptions.ExistingRunningExecutionError as e:
             new_blueprint.state = BlueprintUploadState.FAILED_UPLOADING
             new_blueprint.error = str(e)
@@ -582,13 +583,14 @@ class UploadedBlueprintsValidator(UploadedBlueprintsManager):
             self.upload_archive_to_file_server(data_id)
 
         try:
-            temp_blueprint.upload_execution = rm.upload_blueprint(
+            temp_blueprint.upload_execution, messages = rm.upload_blueprint(
                 data_id,
                 application_file_name,
                 blueprint_url,
                 config.instance.file_server_root,   # for the import resolver
                 validate_only=True,
             )
+            workflow_executor.execute_workflow(messages)
         except manager_exceptions.ExistingRunningExecutionError:
             rm.sm.delete(temp_blueprint)
             self.cleanup_blueprint_archive_from_file_server(

--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -98,7 +98,6 @@ def cancel_execution(execution):
                 'execution_id': execution.id,
                 'rest_token': current_user.get_auth_token(),
                 'tenant': _get_tenant_dict(),
-                'execution_token': generate_execution_token(execution)
             }
         }
     }

--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -18,19 +18,11 @@ def execute_workflow(execution,
                      bypass_maintenance=None,
                      wait_after_fail=600,
                      handler: SendHandler = None,):
-    context = execution.render_context(
+    message = execution.render_message(
         wait_after_fail=wait_after_fail,
         bypass_maintenance=bypass_maintenance,
     )
     db.session.commit()
-    execution_parameters = execution.parameters.copy()
-    execution_parameters['__cloudify_context'] = context
-    message = {
-        'cloudify_task': {'kwargs': execution_parameters},
-        'id': execution.id,
-        'execution_creator': execution.creator.id
-    }
-
     if handler is not None:
         handler.publish(message)
     else:

--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -11,7 +11,7 @@ from cloudify.constants import (
 )
 
 from manager_rest import config, utils
-from manager_rest.storage import get_storage_manager, models, db
+from manager_rest.storage import get_storage_manager, models
 
 
 def execute_workflow(messages):

--- a/tests/integration_tests/tests/agentless_tests/component/test_component_cascading.py
+++ b/tests/integration_tests/tests/agentless_tests/component/test_component_cascading.py
@@ -58,12 +58,12 @@ class ComponentCascadingCancelAndResume(AgentlessTestCase):
             deployment_id=deployment_id)[0].id
         for retry in range(30):
             if self.client.node_instances.get(
-                    node_instance_id).state == 'creating':
+                    node_instance_id).state != 'uninitialized':
                 break
             time.sleep(1)
         else:
-            raise RuntimeError("sleep node instance was expected to go"
-                               " into 'creating' status")
+            raise RuntimeError("sleep node instance was expected to start "
+                               "being created")
 
     def _verify_cancel_install_execution(self,
                                          execution,
@@ -725,7 +725,6 @@ workflows:
         main_blueprint_path = self.make_yaml_file(main_blueprint)
         self.deploy_application(main_blueprint_path,
                                 deployment_id=deployment_id)
-
         self.execute_workflow('nothing_workflow', deployment_id)
         self.client.executions.start(deployment_id,
                                      'nothing_workflow',


### PR DESCRIPTION
Make it cleaner what parts of starting an execution are under a
transaction, and what must not be.

This should do away with the deadlocks when starting/dequeueing
(note: I haven't touched update-dep-status just yet).

This is done by splitting rendering an execution, from actually sending
it. Rendering can be done on any execution, in a transaction, even if the
execution is not committed yet. Sending is sending.

Commit messages go into more depth on that.