### PR TITLE
RD-3121 delete_blueprint: handle blueprints w/o imports

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -693,7 +693,7 @@ class ResourceManager(object):
                 if b.state not in BlueprintUploadState.FAILED_STATES \
                         and b.plan \
                         and blueprint_id in \
-                            b.plan.get(constants.IMPORTED_BLUEPRINTS):
+                            b.plan.get(constants.IMPORTED_BLUEPRINTS, []):
                     raise manager_exceptions.BlueprintInUseError(
                         'Blueprint {} is currently in use. You can "force" '
                         'blueprint removal.'.format(blueprint_id))


### PR DESCRIPTION
Old blueprints, like from a 4.5 snapshot, don't have this field
at all, and then the .get() returns None, and a None is not a good
target for a `x in None` check. Needs to default to something
that can be a container.

This fixes `integration_tests/tests/agentless_tests/test_snapshot.py::TestSnapshot::test_v_4_5_restore_snapshot_without_imported_blueprints`