### PR TITLE
inte-tests: selinux compat for config mounting

### DIFF
--- a/tests/integration_tests/framework/docker.py
+++ b/tests/integration_tests/framework/docker.py
@@ -24,7 +24,7 @@ service_management: {0}
     command = [
         'docker', 'run', '-d',
         '-v', '/sys/fs/cgroup:/sys/fs/cgroup:ro',
-        '-v', '{0}:/etc/cloudify/config.yaml:rw'.format(conf.name),
+        '-v', '{0}:/etc/cloudify/config.yaml:Z'.format(conf.name),
         '--tmpfs', '/run', '--tmpfs', '/run/lock',
     ]
     if resource_mapping:


### PR DESCRIPTION
`:rw` doesn't cut it, if the file is selinux-protected.
Seems to work fine without selinux as well.