### PR TITLE
inte-tests: selinux compat for config mounting

### DIFF
--- a/tests/integration_tests/framework/docker.py
+++ b/tests/integration_tests/framework/docker.py
@@ -152,7 +152,7 @@ service_management: {0}
     command = [
         'docker', 'run', '-d',
         '-v', '/sys/fs/cgroup:/sys/fs/cgroup:ro',
-        '-v', '{0}:/etc/cloudify/config.yaml:rw'.format(conf.name),
+        '-v', '{0}:/etc/cloudify/config.yaml:Z'.format(conf.name),
         '--tmpfs', '/run', '--tmpfs', '/run/lock',
     ]
     if resource_mapping:


### PR DESCRIPTION
This ports #3258 to 5.2.6