### PR TITLE
RD-3221 execution resume: only set pending, not started

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -930,12 +930,9 @@ class ResourceManager(object):
                 'Cannot resume execution: `{0}` in state: `{1}`'
                 .format(execution.id, execution.status))
 
-        execution.status = ExecutionState.STARTED
+        execution.status = ExecutionState.PENDING
         execution.ended_at = None
         execution.resume = True
-        self.sm.update(execution,
-                       modified_attrs=('status', 'ended_at', 'resume'))
-
         message = execution.render_message(bypass_maintenance=False)
         db.session.commit()
         workflow_executor.execute_workflow([message])


### PR DESCRIPTION
It's not quite started yet - it'll be started once it gets picked
up by the mgmtworker.

Also drop the additional .update(), it's not needed, because we commit
anyway - and it's not even all the attrs that changed (anymore)
(because now .render_message is what sets the new token)