### PR TITLE
RD-3235 Plugins update: don't delete deployments on timeout

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -203,7 +203,15 @@ class ResourceManager(object):
                 plugin_update.state = PluginsUpdateStates.FAILED
                 self.sm.update(plugin_update)
                 # Delete a temporary blueprint
-                self.sm.delete(plugin_update.temp_blueprint)
+                for dep_id in plugin_update.deployments_to_update:
+                    dep = self.sm.get(models.Deployment, dep_id)
+                    dep.blueprint = plugin_update.blueprint  # original bp
+                    self.sm.update(dep)
+                if not plugin_update.temp_blueprint.deployments:
+                    self.sm.delete(plugin_update.temp_blueprint)
+                else:
+                    plugin_update.temp_blueprint.is_hidden = False
+                    self.sm.update(plugin_update.temp_blueprint)
 
         if workflow_id == 'delete_deployment_environment' and \
                 status == ExecutionState.TERMINATED:

--- a/workflows/cloudify_system_workflows/plugins.py
+++ b/workflows/cloudify_system_workflows/plugins.py
@@ -105,7 +105,8 @@ def update(ctx, update_id, temp_blueprint_id, deployments_to_update, force,
                      'status',
                      lambda x: x in ExecutionState.END_STATES,
                      RuntimeError,
-                     get_wait_for_execution_message(execution_id))
+                     get_wait_for_execution_message(execution_id),
+                     timeout=3600)
             execution_status = client.executions.get(execution_id).status
 
         msg = f'Deployment update of deployment {dep} {execution_status}. ' \


### PR DESCRIPTION
When the dep-upd inside of plug-upd times out, we'll continue on
to setting the plug-upd execution's state to FAILED, and we can't
just delete the temp blueprint! If the dep-upd started, deployments
might be using it!

First, set all deployments to use the original blueprint, instead.
If (by race) some deployments still use the temp one, then don't
delete it anyway, just un-hide it so that the user has a chance to
clean up.