### PR TITLE
RD-3235 plugin-update: handle no .temp_blueprint

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -202,11 +202,13 @@ class ResourceManager(object):
             if plugin_update:
                 plugin_update.state = PluginsUpdateStates.FAILED
                 self.sm.update(plugin_update)
-                # Delete a temporary blueprint
+            if plugin_update.blueprint:
                 for dep_id in plugin_update.deployments_to_update:
                     dep = self.sm.get(models.Deployment, dep_id)
                     dep.blueprint = plugin_update.blueprint  # original bp
                     self.sm.update(dep)
+            if plugin_update.temp_blueprint:
+                # Delete the temporary blueprint
                 if not plugin_update.temp_blueprint.deployments:
                     self.sm.delete(plugin_update.temp_blueprint)
                 else:


### PR DESCRIPTION
The temporary blueprint might well be missing, primarily in case
there were no changes to be made. In that case, let's not 500, but just
do nothingi nstead.