### PR TITLE
6.3 migration: drop the trigger before dropping the function

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/8e8314b1d848_6_2_to_6_3.py
+++ b/resources/rest-service/cloudify/migrations/versions/8e8314b1d848_6_2_to_6_3.py
@@ -280,5 +280,5 @@ def _add_audit_log_notify():
 
 
 def _drop_audit_log_notify():
-    op.execute("""DROP FUNCTION notify_new_audit_log();""")
     op.execute("""DROP TRIGGER audit_log_inserted ON audit_log;""")
+    op.execute("""DROP FUNCTION notify_new_audit_log();""")


### PR DESCRIPTION
I mean, the trigger depends on the function. Trying to drop the
function first just throws an error.