### PR TITLE
RD-3183 Make component.create_deployment resumable

### DIFF
--- a/cloudify_types/cloudify_types/component/operations.py
+++ b/cloudify_types/cloudify_types/component/operations.py
@@ -41,7 +41,6 @@ from .constants import (
 from .utils import (
     blueprint_id_exists,
     deployment_id_exists,
-    update_runtime_properties,
     get_local_path,
     zip_files,
     should_upload_plugin,
@@ -85,12 +84,11 @@ def upload_blueprint(**kwargs):
     if 'blueprint' not in ctx.instance.runtime_properties:
         ctx.instance.runtime_properties['blueprint'] = dict()
 
-    update_runtime_properties('blueprint', 'id', blueprint_id)
-    update_runtime_properties(
-        'blueprint', 'blueprint_archive', blueprint_archive)
-    update_runtime_properties(
-        'blueprint', 'application_file_name', blueprint_file_name)
-
+    ctx.instance.runtime_properties['blueprint']['id'] = blueprint_id
+    ctx.instance.runtime_properties['blueprint']['blueprint_archive'] = \
+        blueprint_archive
+    ctx.instance.runtime_properties['blueprint']['application_file_name'] = \
+        blueprint_file_name
     blueprint_exists = blueprint_id_exists(client, blueprint_id)
 
     if blueprint.get(EXTERNAL_RESOURCE) and not blueprint_exists:
@@ -231,7 +229,7 @@ def _create_deployment_id(base_deployment_id, auto_inc_suffix):
 def _do_create_deployment(client, deployment_ids, deployment_kwargs):
     create_error = NonRecoverableError('Unknown error creating deployment')
     for deployment_id in deployment_ids:
-        update_runtime_properties('deployment', 'id', deployment_id)
+        ctx.instance.runtime_properties['deployment']['id'] = deployment_id
         try:
             client.deployments.create(
                 deployment_id=deployment_id,

--- a/cloudify_types/cloudify_types/component/operations.py
+++ b/cloudify_types/cloudify_types/component/operations.py
@@ -231,29 +231,15 @@ def _wait_for_deployment_create(client, deployment_id,
                                 deployment_log_redirect, timeout, interval,
                                 workflow_end_state):
     """Wait for deployment's create_dep_env to finish"""
-    executions = client.executions.list(
-        deployment_id=deployment_id,
-        _include=['workflow_id', 'id']
-    )
-
-    # Retrieve the ``execution_id`` associated with the current deployment
-    execution_id = [execution.get('id') for execution in executions
-                    if (execution.get('workflow_id') ==
-                        'create_deployment_environment')]
-
-    # If the ``execution_id`` cannot be found raise error
-    if not execution_id:
+    create_execution = client.deployments.get(
+        deployment_id,
+        _include=['id', 'create_execution'],
+    )['create_execution']
+    if not create_execution:
         raise NonRecoverableError(
-            'No execution Found for component "{}"'
-            ' deployment'.format(deployment_id)
-        )
-
-    # If a match was found there can only be one, so we will extract it.
-    execution_id = execution_id[0]
-    ctx.logger.info('Found execution id "%s" for deployment id "%s"',
-                    execution_id, deployment_id)
+            f'No create execution found for deployment "{deployment_id}"')
     return verify_execution_state(client,
-                                  execution_id,
+                                  create_execution,
                                   deployment_id,
                                   deployment_log_redirect,
                                   workflow_end_state,

--- a/cloudify_types/cloudify_types/component/operations.py
+++ b/cloudify_types/cloudify_types/component/operations.py
@@ -211,6 +211,10 @@ def _create_deployment_id(base_deployment_id, auto_inc_suffix):
 
 
 def _do_create_deployment(client, deployment_ids, deployment_kwargs):
+    already_created_id = ctx.instance.runtime_properties.get(
+        '_component_create_deployment_id')
+    if already_created_id:
+        return already_created_id
     create_error = NonRecoverableError('Unknown error creating deployment')
     for deployment_id in deployment_ids:
         ctx.instance.runtime_properties['deployment']['id'] = deployment_id
@@ -224,7 +228,9 @@ def _do_create_deployment(client, deployment_ids, deployment_kwargs):
             create_error = ex
     else:
         raise create_error
-
+    ctx.instance.runtime_properties['_component_create_deployment_id'] = \
+        deployment_id
+    ctx.instance.update()
     ctx.logger.info('Creating "%s" component deployment', deployment_id)
     return deployment_id
 

--- a/cloudify_types/cloudify_types/component/operations.py
+++ b/cloudify_types/cloudify_types/component/operations.py
@@ -202,22 +202,6 @@ def _upload_plugins(client, plugins):
                 os.remove(zip_path)
 
 
-def _generate_suffix_deployment_id(client, deployment_id):
-    dep_exists = True
-    suffix_index = ctx.instance.runtime_properties['deployment'].get(
-        'current_suffix_index', 0)
-
-    while dep_exists:
-        suffix_index += 1
-        inc_deployment_id = '{0}-{1}'.format(deployment_id, suffix_index)
-        dep_exists = deployment_id_exists(client, inc_deployment_id)
-
-    update_runtime_properties('deployment',
-                              'current_suffix_index',
-                              suffix_index)
-    return inc_deployment_id
-
-
 def _create_deployment_id(base_deployment_id, auto_inc_suffix):
     if not auto_inc_suffix:
         yield base_deployment_id

--- a/cloudify_types/cloudify_types/component/operations.py
+++ b/cloudify_types/cloudify_types/component/operations.py
@@ -270,11 +270,17 @@ def _wait_for_deployment_create(client, deployment_id,
 
 
 def _create_inter_deployment_dependency(client, deployment_id):
+    already_created = ctx.instance.runtime_properties.get(
+        '_component_create_idd')
+    if already_created:
+        return
     client.inter_deployment_dependencies.create(**create_deployment_dependency(
         dependency_creator_generator(COMPONENT, ctx.instance.id),
         source_deployment=ctx.deployment.id,
         target_deployment=deployment_id
     ))
+    ctx.instance.runtime_properties['_component_create_idd'] = True
+    ctx.instance.update()
 
 
 @operation(resumable=True)

--- a/cloudify_types/cloudify_types/component/operations.py
+++ b/cloudify_types/cloudify_types/component/operations.py
@@ -221,13 +221,10 @@ def _do_create_deployment(client, deployment_ids, deployment_kwargs):
                 deployment_id=deployment_id,
                 async_create=True,
                 **deployment_kwargs)
-            break
+            return deployment_id
         except CloudifyClientError as ex:
             create_error = ex
-    else:
-        raise create_error
-    ctx.logger.info('Creating "%s" component deployment', deployment_id)
-    return deployment_id
+    raise create_error
 
 
 def _wait_for_deployment_create(client, deployment_id,
@@ -308,6 +305,7 @@ def create(timeout=EXECUTIONS_TIMEOUT, interval=POLLING_INTERVAL, **kwargs):
         _create_deployment_id(deployment_id, deployment_auto_suffix),
         {'blueprint_id': blueprint_id, 'inputs': deployment_inputs},
     )
+    ctx.logger.info('Creating "%s" component deployment', deployment_id)
     _create_inter_deployment_dependency(client, deployment_id)
 
     return _wait_for_deployment_create(

--- a/cloudify_types/cloudify_types/component/operations.py
+++ b/cloudify_types/cloudify_types/component/operations.py
@@ -292,11 +292,11 @@ def _wait_for_deployment_create(client, deployment_id,
 
 
 def _create_inter_deployment_dependency(client, deployment_id):
-    _inter_deployment_dependency = create_deployment_dependency(
+    client.inter_deployment_dependencies.create(**create_deployment_dependency(
         dependency_creator_generator(COMPONENT, ctx.instance.id),
-        ctx.deployment.id)
-    _inter_deployment_dependency['target_deployment'] = deployment_id
-    client.inter_deployment_dependencies.create(**_inter_deployment_dependency)
+        source_deployment=ctx.deployment.id,
+        target_deployment=deployment_id
+    ))
 
 
 @operation(resumable=True)

--- a/cloudify_types/cloudify_types/component/tests/client_mock.py
+++ b/cloudify_types/cloudify_types/component/tests/client_mock.py
@@ -35,6 +35,11 @@ class BaseMockClient(object):
                                 })
         return response
 
+    def get(self, object_id, **kwargs):
+        for obj in self.existing_objects:
+            if obj['id'] == object_id:
+                return obj
+
     def delete(self, *_, **__):
         return None
 

--- a/cloudify_types/cloudify_types/component/tests/test_deployment.py
+++ b/cloudify_types/cloudify_types/component/tests/test_deployment.py
@@ -126,6 +126,11 @@ class TestDeployment(TestDeploymentBase):
         self._ctx.instance.runtime_properties['deployment']['id'] = 'dep_name'
 
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:
+            self.cfy_mock_client.deployments.set_existing_objects(
+                [{
+                    'id': 'dep_name',
+                    'create_execution': 'exec_id',
+                }])
             self.cfy_mock_client.executions.set_existing_objects(
                 [{
                     'id': 'exec_id',
@@ -147,6 +152,11 @@ class TestDeployment(TestDeploymentBase):
 
     def test_create_deployment_success(self):
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:
+            self.cfy_mock_client.deployments.set_existing_objects(
+                [{
+                    'id': 'test',
+                    'create_execution': 'exec_id',
+                }])
             self.cfy_mock_client.executions.set_existing_objects(
                 [{
                     'id': 'exec_id',
@@ -166,11 +176,10 @@ class TestDeployment(TestDeploymentBase):
 
     def test_create_deployment_failed(self):
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:
-            self.cfy_mock_client.executions.set_existing_objects(
+            self.cfy_mock_client.deployments.set_existing_objects(
                 [{
-                    'id': 'exec_id',
-                    'workflow_id': 'test',
-                    'deployment_id': 'dep'
+                    'id': 'test',
+                    'create_execution': None,
                 }])
             mock_client.return_value = self.cfy_mock_client
 
@@ -180,8 +189,7 @@ class TestDeployment(TestDeploymentBase):
                 poll.return_value = True
 
                 with self.assertRaisesRegex(
-                        NonRecoverableError,
-                        'No execution Found for component "test" deployment'):
+                        NonRecoverableError, 'No create execution found'):
                     create(operation='create_deployment', timeout=MOCK_TIMEOUT)
 
     def test_create_deployment_exists(self):
@@ -373,6 +381,11 @@ class TestComponentSecrets(TestDeploymentBase):
     def test_create_deployment_success_with_secrets(self):
         self._ctx.node.properties['secrets'] = {'a': 'b'}
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:
+            self.cfy_mock_client.deployments.set_existing_objects(
+                [{
+                    'id': 'test',
+                    'create_execution': 'exec_id',
+                }])
             self.cfy_mock_client.executions.set_existing_objects(
                 [{
                     'id': 'exec_id',

--- a/cloudify_types/cloudify_types/component/utils.py
+++ b/cloudify_types/cloudify_types/component/utils.py
@@ -31,10 +31,6 @@ from cloudify_types.utils import get_deployment_by_id
 from .constants import CAPABILITIES
 
 
-def update_runtime_properties(_type, _key, _value):
-    ctx.instance.runtime_properties[_type][_key] = _value
-
-
 def download_file(url, destination=None, keep_name=False):
     """
     :param url: Location of the file to download

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -533,7 +533,8 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
             dep_dict['latest_execution_finished_operations'] = \
                 self.latest_execution_finished_operations
         if 'create_execution' in include:
-            dep_dict['create_execution'] = self.create_execution.id
+            dep_dict['create_execution'] = \
+                self.create_execution.id if self.create_execution else None
         return dep_dict
 
     @staticmethod

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -499,8 +499,8 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
                 flask_fields.Integer()
             fields['latest_execution_finished_operations'] = \
                 flask_fields.Integer()
-            fields['has_sub_deployments'] = \
-                flask_fields.Boolean()
+            fields['has_sub_deployments'] = flask_fields.Boolean()
+            fields['create_execution'] = flask_fields.String()
             cls._cached_deployment_fields = fields
         return cls._cached_deployment_fields
 
@@ -532,6 +532,8 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         if 'latest_execution_finished_operations' in include:
             dep_dict['latest_execution_finished_operations'] = \
                 self.latest_execution_finished_operations
+        if 'create_execution' in include:
+            dep_dict['create_execution'] = self.create_execution.id
         return dep_dict
 
     @staticmethod

--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -157,7 +157,7 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         self.sm.put(dep)
 
         serialized_dep = dep.to_response()
-        self.assertEqual(36, len(serialized_dep))
+        self.assertEqual(37, len(serialized_dep))
         self.assertEqual(dep.id, serialized_dep['id'])
         self.assertEqual(dep.created_at, serialized_dep['created_at'])
         self.assertEqual(dep.updated_at, serialized_dep['updated_at'])
@@ -176,6 +176,7 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         serialized_dep.pop('latest_execution_total_operations')
         serialized_dep.pop('latest_execution_finished_operations')
         serialized_dep.pop('has_sub_deployments')
+        serialized_dep.pop('create_execution')
 
         # Deprecated columns, for backwards compatibility -
         # was added to the response


### PR DESCRIPTION
The main part is gating the create_deployment opreation behind
runtime properties (ie. check-and-set). This isn't 100% race-proof,
because we still can fail mid-request etc, but it makes any race
very low probability. (and in case it breaks, we'll just not create
the deployment, so it's not catastrophic, it just won't work until
the user cleans up the deployment)

Also some refactors.