### PR TITLE
TestConcurrentUpdate: wait for both executions

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_concurrent_node_instance_update.py
+++ b/tests/integration_tests/tests/agentless_tests/test_concurrent_node_instance_update.py
@@ -52,7 +52,7 @@ class TestConcurrentUpdate(AgentlessTestCase):
     def _assert_operation_retried(self, *executions):
         found = False
         for execution in executions:
-            events, _ = self.client.events.get(
+            events = self.client.events.list(
                 execution_id=execution.id,
                 include_logs=True
             )


### PR DESCRIPTION
It doesn't make sense to start 2 executions, but only wait for
one, and do the asserts while the other is still running.
Wait for both!