### PR TITLE
Component: clean the new runtime-props on delete

### DIFF
--- a/cloudify_types/cloudify_types/component/operations.py
+++ b/cloudify_types/cloudify_types/component/operations.py
@@ -334,7 +334,10 @@ def _delete_secrets(client, secrets):
 
 
 def _delete_runtime_properties():
-    for property_name in ['deployment', 'blueprint', 'plugins']:
+    for property_name in [
+        'deployment', 'blueprint', 'plugins', '_component_create_idd',
+        '_component_create_deployment_id',
+    ]:
         if property_name in ctx.instance.runtime_properties:
             del ctx.instance.runtime_properties[property_name]
 


### PR DESCRIPTION
When the thing is deleted, we need to clean up, otherwise
they'll already be there on a reinstall :)