### PR TITLE
Alembic version without PEP-484 type annotations

### DIFF
--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -43,6 +43,7 @@ install_requires = [
     'email-validator>1.0.0,<2.0.0',
     'werkzeug>1,<2',
     'itsdangerous>1,<2',
+    'alembic<1.7.0',
 ]
 
 


### PR DESCRIPTION
... because these are incompatible with Python 3.6.0 we use to run
integration tests in Jenkins