### PR TITLE
Keep cffi version <1.15

### DIFF
--- a/rest-service/requirements.txt
+++ b/rest-service/requirements.txt
@@ -14,7 +14,7 @@ blinker==1.4              # via flask-mail, flask-principal
 bottle==0.12.18           # via cloudify-common
 cachetools==3.1.1         # via cloudify-rest-service (setup.py)
 certifi==2021.10.8        # via requests
-cffi==1.15.0              # via cryptography
+cffi==1.14.6              # via cloudify-rest-service (setup.py), cryptography
 chardet==4.0.0            # via aiohttp
 charset-normalizer==2.0.7  # via requests
 click==7.1.2              # via flask

--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -33,6 +33,7 @@ install_requires = [
     'python-dateutil>=2.8.1,<3',
     'voluptuous>=0.9.3,<0.10',
     'pika>=1.1.0,<1.2.0',
+    'cffi>=1.14,<1.15',
     'cryptography>=3.3,<3.4',
     'psycopg2',
     'pytz',


### PR DESCRIPTION
... because version 1.15 requires libffi 8.1.0, which is hard to come-by
in a form of RPM (that would be libffi-3.3).