### PR TITLE
Keep cffi version <1.15

### DIFF
--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -33,6 +33,7 @@ install_requires = [
     'python-dateutil==2.5.3',
     'voluptuous==0.9.3',
     'pika==1.1.0',
+    'cffi>=1.14,<1.15',
     'cryptography==3.3.2',
     'psycopg2==2.7.4',
     'pytz==2018.4',


### PR DESCRIPTION
... because version 1.15 requires libffi 8.1.0, which is hard to come-by
in a form of RPM (that would be libffi-3.3).