### PR TITLE
Revert "Use a machine-specific docker image in integration tests"

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 import logging
-import platform
 import pytest
 import wagon
 
@@ -38,7 +37,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--image-name',
         help='Name of the Cloudify Manager AIO docker image',
-        default=f'cloudify-manager-aio-{platform.machine()}:latest'
+        default='cloudify-manager-aio:latest'
     )
     parser.addoption(
         '--keep-container',


### PR DESCRIPTION
This reverts commit cddebab74352a9f38eebb3211de7d0be83578d88.