### PR TITLE
RD-3116 Skip audit-logs in snap-res

### DIFF
--- a/workflows/cloudify_system_workflows/snapshots/postgres.py
+++ b/workflows/cloudify_system_workflows/snapshots/postgres.py
@@ -47,7 +47,7 @@ class Postgres(object):
     _CONFIG_TABLES = ['config', 'rabbitmq_brokers', 'db_nodes',
                       'maintenance_mode', 'usage_collector', 'plugins_states']
     _TABLES_TO_EXCLUDE_ON_DUMP = _TABLES_TO_KEEP + \
-        ['audit_log__storage_id_seq', 'snapshots'] + \
+        ['audit_log', 'audit_log__storage_id_seq', 'snapshots'] + \
         _CONFIG_TABLES
     _TABLES_TO_RESTORE = ['users', 'tenants']
     _STAGE_TABLES_TO_EXCLUDE = ['"SequelizeMeta"']


### PR DESCRIPTION
During snap-restore, don't insert new audit-logs, and also don't
have audit-logs in the snapshot either.
This avoids conflicts on already-existing audit-log storage ids.

See both commit messages for each part.