### PR TITLE
RD-2871 Support setting state on new execution

### DIFF
--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -15,6 +15,8 @@ from manager_rest.storage import get_storage_manager, models
 
 
 def execute_workflow(messages):
+    if not messages:
+        return
     client = get_amqp_client()
     handler = workflow_sendhandler()
     client.add_handler(handler)


### PR DESCRIPTION
This will not run the execution. It will be used for snapshot restores.