### PR TITLE
restservice log_request: omit form data

### DIFF
--- a/rest-service/manager_rest/app_logging.py
+++ b/rest-service/manager_rest/app_logging.py
@@ -36,27 +36,19 @@ def setup_logger(logger):
 
 
 def log_request():
-    # form and args parameters are "multidicts", i.e. values are not
-    # flattened and will appear in a list (even if single value)
-    form_data = request.form.to_dict(False)
     # args is the parsed query string data
     args_data = request.args.to_dict(False)
-    # json data; other data (e.g. binary) is available via request.data,
-    #  but is not logged
 
     # content-type and content-length are already included in headers
-
     current_app.logger.debug(
         '\nRequest (%s):\n'
         '\tpath: %s\n'
         '\thttp method: %s\n'
-        '\tquery string data: %s\n'
-        '\tform data: %s',
+        '\tquery string data: %s',
         id(request),
         request.path,  # includes "path parameters"
         request.method,
         args_data,
-        form_data
     )
 
 


### PR DESCRIPTION
We don't keep anything interesting in the form data anyway, we almost
always use json instead. (which is request.json() rather
than request.form)

However, accessing request.form (which we did for
_every single request_) breaks one important usecase: the fileserver
(and cloudify-api) auth endpoint.

For auth_request, nginx sends through all the headers, but not the
request body (because the internal auth request is a GET request).

That means the auth request gets a non-zero content-length but an
empty request body, and so accessing `request.form` waits forever
for the body. If content-type was application/json, then accessing
request.form would not wait, because in that case flask always just
returns empty for .form