### PR TITLE
New dep-update inte-test: factor out a mixin

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/deployment_update/__init__.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/__init__.py
@@ -168,3 +168,17 @@ class DeploymentUpdateBase(AgentlessTestCase):
     @staticmethod
     def _assertDictContainsSubset(subset, containing_dict):
         assert subset.items() <= containing_dict.items()
+
+
+class NewDeploymentUpdateMixin(object):
+    _group_update_workflow = 'csys_new_deployment_update'
+    _workflow_name = 'csys_new_deployment_update'
+
+    def _do_update(self, deployment_id, blueprint_id=None, **kwargs):
+        params = {
+            'blueprint_id': blueprint_id,
+        }
+        params.update(kwargs)
+        exc = self.client.executions.start(
+            deployment_id, 'csys_new_deployment_update', parameters=params)
+        self.wait_for_execution_to_end(exc)

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_addition.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_addition.py
@@ -21,7 +21,7 @@ from pytest import mark
 
 from integration_tests.tests.utils import (tar_blueprint,
                                            wait_for_blueprint_upload)
-from . import DeploymentUpdateBase, BLUEPRINT_ID
+from . import DeploymentUpdateBase, BLUEPRINT_ID, NewDeploymentUpdateMixin
 
 
 pytestmark = pytest.mark.group_deployments
@@ -561,14 +561,8 @@ class TestDeploymentUpdateAddition(DeploymentUpdateBase):
         self.assertRegexpMatches(deployment['description'], 'new description')
 
 
-class NewTestDeploymentUpdateAddition(TestDeploymentUpdateAddition):
-    def _do_update(self, deployment_id, blueprint_id=None,
-                   preview=False, **kwargs):
-        params = {
-            'blueprint_id': blueprint_id,
-        }
-        if preview:
-            params['preview'] = preview
-        exc = self.client.executions.start(
-            deployment_id, 'csys_new_deployment_update', parameters=params)
-        self.wait_for_execution_to_end(exc)
+class NewTestDeploymentUpdateAddition(
+    NewDeploymentUpdateMixin,
+    TestDeploymentUpdateAddition
+):
+    pass

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_misc.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_misc.py
@@ -20,7 +20,7 @@ from integration_tests.tests.utils import (
     wait_for_blueprint_upload,
     wait_for_deployment_deletion_to_complete
 )
-from . import DeploymentUpdateBase, BLUEPRINT_ID
+from . import DeploymentUpdateBase, BLUEPRINT_ID, NewDeploymentUpdateMixin
 
 pytestmark = pytest.mark.group_deployments
 
@@ -533,14 +533,8 @@ class TestDeploymentUpdateMisc(DeploymentUpdateBase):
             self.assertIn('description', dep.description)
 
 
-class NewTestDeploymentUpdateMisc(TestDeploymentUpdateMisc):
-    _group_update_workflow = 'csys_new_deployment_update'
-
-    def _do_update(self, deployment_id, blueprint_id=None, **kwargs):
-        params = {
-            'blueprint_id': blueprint_id,
-        }
-        params.update(kwargs)
-        exc = self.client.executions.start(
-            deployment_id, 'csys_new_deployment_update', parameters=params)
-        self.wait_for_execution_to_end(exc)
+class NewTestDeploymentUpdateMisc(
+    NewDeploymentUpdateMixin,
+    TestDeploymentUpdateMisc
+):
+    pass

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_mixed_operations.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_mixed_operations.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from . import DeploymentUpdateBase, BLUEPRINT_ID
+from . import DeploymentUpdateBase, BLUEPRINT_ID, NewDeploymentUpdateMixin
 
 from integration_tests.tests.utils import wait_for_blueprint_upload
 
@@ -256,3 +256,10 @@ class TestDeploymentUpdateMixedOperations(DeploymentUpdateBase):
             self._assertDictContainsSubset(
                     {'target_ops_counter': str(1)},
                     node_instances[node]['runtime_properties'])
+
+
+class NewTestDeploymentUpdateMixedOperations(
+        NewDeploymentUpdateMixin,
+        TestDeploymentUpdateMixedOperations
+):
+    pass

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_modification.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_modification.py
@@ -15,7 +15,7 @@
 import re
 import pytest
 
-from . import DeploymentUpdateBase, BLUEPRINT_ID
+from . import DeploymentUpdateBase, BLUEPRINT_ID, NewDeploymentUpdateMixin
 from integration_tests.tests.utils import wait_for_blueprint_upload
 
 pytestmark = pytest.mark.group_deployments
@@ -401,20 +401,8 @@ class TestDeploymentUpdateModification(DeploymentUpdateBase):
                         event_messages.index(u'Node instance started'))
 
 
-class NewTestDeploymentUpdateModification(TestDeploymentUpdateModification):
-    _workflow_name = 'csys_new_deployment_update'
-
-    def _do_update(self, deployment_id, blueprint_id=None,
-                   preview=False, inputs=None, skip_reinstall=False, **kwargs):
-        params = {
-            'blueprint_id': blueprint_id,
-        }
-        if preview:
-            params['preview'] = preview
-        if inputs:
-            params['inputs'] = inputs
-        if skip_reinstall:
-            params['skip_reinstall'] = skip_reinstall
-        exc = self.client.executions.start(
-            deployment_id, 'csys_new_deployment_update', parameters=params)
-        self.wait_for_execution_to_end(exc)
+class NewTestDeploymentUpdateModification(
+    NewDeploymentUpdateMixin,
+    TestDeploymentUpdateModification
+):
+    pass

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_removal.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_removal.py
@@ -15,7 +15,7 @@ from pytest import mark
 
 from cloudify_rest_client.exceptions import CloudifyClientError
 
-from . import DeploymentUpdateBase, BLUEPRINT_ID
+from . import DeploymentUpdateBase, BLUEPRINT_ID, NewDeploymentUpdateMixin
 from integration_tests.tests.utils import wait_for_blueprint_upload
 
 pytestmark = mark.group_deployments
@@ -406,14 +406,8 @@ class TestDeploymentUpdateRemoval(DeploymentUpdateBase):
         self.assertFalse(deployment.get('description'))
 
 
-class NewTestDeploymentUpdateRemoval(TestDeploymentUpdateRemoval):
-    def _do_update(self, deployment_id, blueprint_id=None,
-                   preview=False, **kwargs):
-        params = {
-            'blueprint_id': blueprint_id,
-        }
-        if preview:
-            params['preview'] = preview
-        exc = self.client.executions.start(
-            deployment_id, 'csys_new_deployment_update', parameters=params)
-        self.wait_for_execution_to_end(exc)
+class NewTestDeploymentUpdateRemoval(
+    NewDeploymentUpdateMixin,
+    TestDeploymentUpdateRemoval
+):
+    pass


### PR DESCRIPTION
Put the _do_update in a single place, and have all of the test
classes import it.
Also, this adds tests for the mixed_operations one.