### PR TITLE
RD-3572 Lock deployments up-front

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -53,7 +53,8 @@ from manager_rest.plugins_update.constants import STATES as PluginsUpdateStates
 from manager_rest.storage import (db,
                                   get_storage_manager,
                                   models,
-                                  get_node)
+                                  get_node,
+                                  storage_utils)
 
 from . import utils
 from . import config
@@ -124,6 +125,7 @@ class ResourceManager(object):
 
     def update_execution_status(self, execution_id, status, error):
         with self.sm.transaction():
+            storage_utils.deployments_lock()
             execution = self.sm.get(models.Execution, execution_id,
                                     locking=True)
             if execution._deployment_fk:

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -214,6 +214,7 @@ class ResourceManager(object):
         to_run = []
         while True:
             with self.sm.transaction():
+                storage_utils.deployments_lock()
                 dequeued = self._get_queued_executions(deployment_storage_id)
                 all_started = True
                 for execution in dequeued:

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -262,7 +262,8 @@ class ResourceManager(object):
 
     def _prepare_execution_or_log(self, execution: models.Execution) -> list:
         try:
-            return self.prepare_executions([execution], queue=True)
+            return self.prepare_executions(
+                [execution], queue=True, commit=False)
         except Exception as e:
             current_app.logger.warning(
                 'Could not dequeue execution %s: %s',

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -805,6 +805,7 @@ class DeploymentGroupsId(SecuredResource):
         sm = get_storage_manager()
         graph = rest_utils.RecursiveDeploymentLabelsDependencies(sm)
         with sm.transaction():
+            storage_utils.deployments_lock()
             try:
                 group = sm.get(models.DeploymentGroup, group_id)
             except manager_exceptions.NotFoundError:

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -20,7 +20,7 @@ from manager_rest import utils, manager_exceptions, workflow_executor
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import (authorize,
                                                  check_user_action_allowed)
-from manager_rest.storage import db, models, get_storage_manager
+from manager_rest.storage import db, models, get_storage_manager, storage_utils
 from manager_rest.manager_exceptions import (
     DeploymentEnvironmentCreationInProgressError,
     DeploymentCreationError,
@@ -267,6 +267,7 @@ class DeploymentsId(resources_v1.DeploymentsId):
         sm = get_storage_manager()
         rm = get_resource_manager()
         with sm.transaction():
+            storage_utils.deployments_lock()
             deployment = sm.get(models.Deployment, deployment_id, locking=True)
             allowed_attribs = {
                 'description', 'workflows', 'inputs', 'policy_types',

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -846,6 +846,7 @@ class DeploymentGroupsId(SecuredResource):
         })
         sm = get_storage_manager()
         with sm.transaction():
+            storage_utils.deployments_lock()
             group = sm.get(models.DeploymentGroup, group_id)
             if request_dict.get('add'):
                 self._add_group_deployments(

--- a/rest-service/manager_rest/storage/storage_utils.py
+++ b/rest-service/manager_rest/storage/storage_utils.py
@@ -124,6 +124,22 @@ def _create_default_tenant():
     return default_tenant
 
 
+def deployments_lock():
+    """Lock multi-deployments update.
+
+    This lock is to be used around operations that possibly access multiple
+    deployments, their dependencies, and their executions.
+
+    This is not strictly based on deployments themselves, but to be used
+    co-operatively by functions, to avoid deadlocks in case multiple locks
+    on the deployments table are going to be acquired.
+    """
+    # the number doesn't mean anything, just needs to be globally unique,
+    # ie. not used by any other kind of lock across all of Cloudify
+    lock = 5
+    db.session.execute('SELECT pg_advisory_xact_lock(:lock)', {'lock': lock})
+
+
 def try_acquire_lock_on_table(lock_number):
     # make sure a flask app exists before calling this function
     results = db.session.execute('SELECT pg_try_advisory_lock(:lock_number)',


### PR DESCRIPTION
Before touching multiple deployments as part of some update call
(most importantly, `update_execution_status), acquire a super-global
lock (super-global, ie. ALL restservice instances, on all nodes - it's
a db advisory lock).

This is a bit unfortunate and of course lowers throughput a bit (not
all that much, because well, those aren't the most-frequently-used
endpoints), but it's the nuclear option to make sure that deadlocks
don't happen. We can't lock deployments in different orders, if we
just lock the whole thing, right.

RD-3573 is going to implement smarter queries for dep-label-deps,
which is going to hopefully make this unnecessary, restoring our
throughput.
