### PR TITLE
cope_with_db_failover: query via session, not via the engine

### DIFF
--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -69,7 +69,7 @@ def cope_with_db_failover():
     max_attempts = 10
     for attempt in range(1, max_attempts + 1):
         try:
-            standby = db.engine.execute(
+            standby = db.session.execute(
                 'SELECT pg_is_in_recovery()').fetchall()[0][0]
             if standby:
                 # This is a hot standby, we need to fail over

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -314,6 +314,7 @@ class BaseServerTestCase(unittest.TestCase):
                 continue
             server.db.session.execute(table.delete())
         server.db.session.commit()
+        db.engine.dispose()
 
     def _clean_tmpdir(self):
         shutil.rmtree(os.path.join(self.tmpdir, 'blueprints'),

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -24,6 +24,7 @@ import tarfile
 import unittest
 import tempfile
 import sqlalchemy.exc
+from sqlalchemy.orm.session import close_all_sessions
 
 import yaml
 import wagon
@@ -304,7 +305,7 @@ class BaseServerTestCase(unittest.TestCase):
         their contents, which is faster than dropping and recreating
         the tables.
         """
-        server.db.session.remove()
+        close_all_sessions()
         if keep_tables is None:
             keep_tables = []
         meta = server.db.metadata


### PR DESCRIPTION
using the engine directly leaks connections (in the tests).
Use the session so that we use the already-open connection.

Without this, to run tests (especially with -n5), I needed to start
the db with `max_connections=BIGNUMBER`. With this, the default is fine,
and indeed even small numbers are fine.

I'm not sure why did we use the engine directly. But if we do want
to use the engine directly, then we'd have to explicitly handle
closing the connection. Instead, let's just use the session, allowing
sqlalchemy to do the connection lifecycle automatically