### PR TITLE
Events/logs: allow passing in timestamp

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3/events.py
+++ b/rest-service/manager_rest/rest/resources_v3/events.py
@@ -42,7 +42,7 @@ class Events(v2_Events):
         raw_events = request_dict.get('events') or []
         raw_logs = request_dict.get('logs') or []
         if any(
-            item.get('timestamp') or item.get('reported_timestamp')
+            item.get('reported_timestamp')
             for item in itertools.chain(raw_events, raw_logs)
         ):
             check_user_action_allowed('set_timestamp')


### PR DESCRIPTION
`timestamp` is actually passed in normally by the client.
`reported_timestamp` is the time of inserting into the db.
Is it named the wrong way around? Perhaps.