### PR TITLE
Events list: make the timestamp range end-exclusive

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -203,7 +203,7 @@ class Events(SecuredResource):
         if 'from' in range_filter:
             query = query.filter(getattr(model, field) >= range_filter['from'])
         if 'to' in range_filter:
-            query = query.filter(getattr(model, field) <= range_filter['to'])
+            query = query.filter(getattr(model, field) < range_filter['to'])
         return query
 
     @staticmethod

--- a/tests/integration_tests/resources/scripts/follow_events.py
+++ b/tests/integration_tests/resources/scripts/follow_events.py
@@ -11,7 +11,7 @@ from manager_rest import config
 def print_event(event):
     try:
         timestamp = datetime.strptime(
-            event['timestamp'], '%Y-%m-%dT%H:%M:%S.%f')
+            event['timestamp'][:19], '%Y-%m-%dT%H:%M:%S')
         # skip events coming from old snapshots, only display current logs
         if (datetime.now() - timestamp) < timedelta(days=1):
             print(f"\t{event['timestamp']:<26}\t{event['message']}")


### PR DESCRIPTION
I'm not sure why was it working before, but now we see fails in the
test_timestamp_range test, because the test does expect exclusive
at the upper end. Were we dropping the milliseconds bit from timestamps
before?

Anyway, the range is now going to be explicitly lower-inclusive,
upper-exclusive, same as eg. python's range() function.