### PR TITLE
cope_with_db_failover: rollback afterwards

### DIFF
--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -88,6 +88,8 @@ def cope_with_db_failover():
                 'Attempt number %s/%s. Error was: %s',
                 attempt, max_attempts, err,
             )
+        finally:
+            db.session.rollback()
 
 
 def query_service_settings():

--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -88,7 +88,6 @@ def cope_with_db_failover():
                 'Attempt number %s/%s. Error was: %s',
                 attempt, max_attempts, err,
             )
-        finally:
             db.session.rollback()
 
 


### PR DESCRIPTION
Now that we're using session management here, rollback after
running the query;  otherwise, if the first "pg_is_in_recovery()"
call failed (because a reconnection has occured), the next one might
fail as well due to an already-errored-out session. After the
query, roll it back, and start fresh.