### PR TITLE
RD-3435 More deployment details in context

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1163,6 +1163,8 @@ class Execution(CreatedAtMixin, SQLResourceBase):
         }
         if self.deployment is not None:
             context['deployment_id'] = self.deployment.id
+            context['deployment_display_name'] = self.deployment.display_name
+            context['deployment_creator'] = self.deployment.creator.username
             context['blueprint_id'] = self.blueprint_id
             context['runtime_only_evaluation'] = \
                 self.deployment.runtime_only_evaluation


### PR DESCRIPTION
Add `deployment.display_name` and `deployment.creator.username` to the
message sent over to mgmtworker as the execution's context.  These
values are going to be available as `ctx.deployment.display_name` and
`ctx.deployment.creator`.