### PR TITLE
RD-3573 Recursive query for dependency retrieval

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -796,6 +796,7 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
             self.get_descendants(*args, **kwargs)
         )
 
+
 class DeploymentGroup(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'deployment_groups'
     description = db.Column(db.Text)
@@ -2112,9 +2113,11 @@ class BaseDeploymentDependencies(CreatedAtMixin, SQLResourceBase):
         )
 
         if dependents:
-            base = select_cols.filter(cls._target_deployment.in_(deployment_ids))
+            base = select_cols.filter(
+                cls._target_deployment.in_(deployment_ids))
         else:
-            base = select_cols.filter(cls._source_deployment.in_(deployment_ids))
+            base = select_cols.filter(
+                cls._source_deployment.in_(deployment_ids))
         base = base.cte(name='dependents', recursive=True)
 
         if dependents:
@@ -2138,9 +2141,10 @@ class BaseDeploymentDependencies(CreatedAtMixin, SQLResourceBase):
 
     @classmethod
     def get_dependencies(cls, deployments, dependents=True, locking=False,
-                          fetch_deployments=True):
+                         fetch_deployments=True):
         deployment_ids = [d._storage_id for d in deployments]
-        dependencies = cls._dependencies_adjacency(deployment_ids, dependents=dependents)
+        dependencies = cls._dependencies_adjacency(
+            deployment_ids, dependents=dependents)
         if fetch_deployments:
             query = cls._join_deployments(dependencies, dependents)
         else:
@@ -2150,6 +2154,7 @@ class BaseDeploymentDependencies(CreatedAtMixin, SQLResourceBase):
         if locking:
             query = query.with_for_update()
         return query.all()
+
 
 class InterDeploymentDependencies(BaseDeploymentDependencies):
     __tablename__ = 'inter_deployment_dependencies'

--- a/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
@@ -19,10 +19,151 @@ from mock import patch
 from cloudify_rest_client.exceptions import CloudifyClientError
 from cloudify.deployment_dependencies import create_deployment_dependency
 
+from manager_rest.storage import db, models
 from manager_rest.manager_exceptions import NotFoundError, ConflictError
 from manager_rest.rest.rest_utils import RecursiveDeploymentDependencies
 
 from manager_rest.test.base_test import BaseServerTestCase
+
+
+class ModelDependenciesTest(BaseServerTestCase):
+    def setUp(self):
+        super().setUp()
+        self.tenant = models.Tenant()
+        self.user = models.User()
+        self.bp1 = models.Blueprint(tenant=self.tenant, creator=self.user)
+
+    def _deployment(self, **kwargs):
+        dep_params = {
+            'blueprint': self.bp1,
+            'display_name': 'a',
+            'creator': self.user,
+            'tenant': self.tenant
+        }
+        dep_params.update(kwargs)
+        dep = models.Deployment(**dep_params)
+        db.session.add(dep)
+        return dep
+
+    def _dependency(self, source, target):
+        db.session.add(models.InterDeploymentDependencies(
+            source_deployment=source,
+            target_deployment=target,
+            tenant=self.tenant,
+            dependency_creator='',
+            creator=self.user
+        ))
+
+    def _label_dependency(self, source, target):
+        db.session.add(models.DeploymentLabelsDependencies(
+            source_deployment=source,
+            target_deployment=target,
+            tenant=self.tenant,
+            creator=self.user
+        ))
+
+    def test_empty(self):
+        d1 = self._deployment(id='d1')
+        db.session.flush()
+        assert d1.get_dependencies() == []
+        assert d1.get_dependents() == []
+        assert d1.get_ancestors() == []
+        assert d1.get_descendants() == []
+
+    def test_direct_dependency(self):
+        d1 = self._deployment(id='d1')
+        d2 = self._deployment(id='d2')
+        unrelated = self._deployment(id='unrelated')
+        self._dependency(d1, d2)
+        db.session.flush()
+        assert d1.get_dependencies() == [d2]
+        assert d2.get_dependents() == [d1]
+
+    def test_multiple_dependencies(self):
+        d1 = self._deployment(id='d1')
+        d2 = self._deployment(id='d2')
+        d3 = self._deployment(id='d3')
+        self._dependency(d1, d2)
+        self._dependency(d3, d2)
+        db.session.flush()
+        assert d1.get_dependencies() == d3.get_dependencies() == [d2]
+        assert set(d2.get_dependents()) == {d1, d3}
+
+    def test_multi_level(self):
+        d1 = self._deployment(id='d1')
+        d2 = self._deployment(id='d2')
+        d3 = self._deployment(id='d3')
+        self._dependency(d1, d2)
+        self._dependency(d2, d3)
+        db.session.flush()
+        assert set(d1.get_dependencies()) == {d2, d3}
+        assert set(d3.get_dependents()) == {d1, d2}
+
+        assert set(d2.get_dependents()) == {d1}
+        assert set(d2.get_dependencies()) == {d3}
+
+    def test_dependency_objects(self):
+        d1 = self._deployment(id='d1')
+        d2 = self._deployment(id='d2')
+        unrelated = self._deployment(id='unrelated')
+        self._dependency(d1, d2)
+        db.session.flush()
+        deps = d1.get_dependencies(fetch_deployments=False)
+        deps2 = d2.get_dependents(fetch_deployments=False)
+        assert deps == deps2
+        assert len(deps) == 1
+        dep = deps[0]
+        assert isinstance(dep, models.InterDeploymentDependencies)
+        assert dep.source_deployment == d1
+        assert dep.target_deployment == d2
+
+    def test_label_dependencies(self):
+        d1 = self._deployment(id='d1')
+        d2 = self._deployment(id='d2')
+        unrelated = self._deployment(id='unrelated')
+        self._label_dependency(d1, d2)
+        db.session.flush()
+        assert d1.get_dependencies() == []
+        assert d2.get_dependents() == []
+        assert d1.get_ancestors() == [d2]
+        assert d2.get_descendants() == [d1]
+
+
+    def test_label_dependencies_objects(self):
+        d1 = self._deployment(id='d1')
+        d2 = self._deployment(id='d2')
+        self._label_dependency(d1, d2)
+        db.session.flush()
+        deps = d1.get_ancestors(fetch_deployments=False)
+        deps2 = d2.get_descendants(fetch_deployments=False)
+        assert deps == deps2
+        assert len(deps) == 1
+        dep = deps[0]
+        assert isinstance(dep, models.DeploymentLabelsDependencies)
+        assert dep.source_deployment == d1
+        assert dep.target_deployment == d2
+
+    def test_get_all(self):
+        d1 = self._deployment(id='d1')
+        d2 = self._deployment(id='d2')
+        d3 = self._deployment(id='d3')
+        d4 = self._deployment(id='d4')
+        unrelated = self._deployment(id='unrelated')
+        self._dependency(d1, d2)
+        self._label_dependency(d3, d2)
+        self._dependency(d3, d4)
+        db.session.flush()
+        assert d1.get_all_dependents() == set()
+        assert d3.get_all_dependents() == set()
+
+        assert d2.get_all_dependencies() == set()
+        assert d4.get_all_dependencies() == set()
+
+        assert d1.get_all_dependencies() == {d2}
+        assert d3.get_all_dependencies() == {d2, d4}
+
+        assert d2.get_all_dependents() == {d1, d3}
+        assert d4.get_all_dependents() == {d3}
 
 
 class InterDeploymentDependenciesTest(BaseServerTestCase):

--- a/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
@@ -73,7 +73,7 @@ class ModelDependenciesTest(BaseServerTestCase):
     def test_direct_dependency(self):
         d1 = self._deployment(id='d1')
         d2 = self._deployment(id='d2')
-        unrelated = self._deployment(id='unrelated')
+        self._deployment(id='unrelated')
         self._dependency(d1, d2)
         db.session.flush()
         assert d1.get_dependencies() == [d2]
@@ -105,7 +105,7 @@ class ModelDependenciesTest(BaseServerTestCase):
     def test_dependency_objects(self):
         d1 = self._deployment(id='d1')
         d2 = self._deployment(id='d2')
-        unrelated = self._deployment(id='unrelated')
+        self._deployment(id='unrelated')
         self._dependency(d1, d2)
         db.session.flush()
         deps = d1.get_dependencies(fetch_deployments=False)
@@ -120,14 +120,13 @@ class ModelDependenciesTest(BaseServerTestCase):
     def test_label_dependencies(self):
         d1 = self._deployment(id='d1')
         d2 = self._deployment(id='d2')
-        unrelated = self._deployment(id='unrelated')
+        self._deployment(id='unrelated')
         self._label_dependency(d1, d2)
         db.session.flush()
         assert d1.get_dependencies() == []
         assert d2.get_dependents() == []
         assert d1.get_ancestors() == [d2]
         assert d2.get_descendants() == [d1]
-
 
     def test_label_dependencies_objects(self):
         d1 = self._deployment(id='d1')
@@ -148,7 +147,7 @@ class ModelDependenciesTest(BaseServerTestCase):
         d2 = self._deployment(id='d2')
         d3 = self._deployment(id='d3')
         d4 = self._deployment(id='d4')
-        unrelated = self._deployment(id='unrelated')
+        self._deployment(id='unrelated')
         self._dependency(d1, d2)
         self._label_dependency(d3, d2)
         self._dependency(d3, d4)


### PR DESCRIPTION
Note: this just implements the query, doesn't actually use it
yet - that'll come in the next PRs.

This is a way to retrieve a whole sub-tree of dependent
deployments, as opposed to the current approach, which
selects ALL THE DEPENDENCIES EVER and then formats them
into a tree.

There's a generic query on the InterDepDeps class itself,
and then a bunch of frontend interface methods on the
Deployment model.