### PR TITLE
RD-3573 Retrieve all data needed to recalc a tree

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -2157,6 +2157,99 @@ class BaseDeploymentDependencies(CreatedAtMixin, SQLResourceBase):
             query = query.with_for_update()
         return query.all()
 
+    @classmethod
+    def _get_update_tree(cls, deployment_ids):
+        """Fetch just enough data to recalculate statuses for a subtree.
+
+        To recalculate the status/sub_counts of each ancestor, we must
+        select all the ancestors in the tree, and all of their direct
+        children: for each ancestor, we must know how many sub-deployments
+        it has, and what are their statuses.
+
+        Eg. when computing the update-tree of a deployment, we fetch that
+        deployment's parent, and ALL of the children of that parent, ie.
+        all of the target deployment's siblings.
+
+        This method is very closely tied to its usage: we only select the
+        columns that are necessarily required; it's only useful for
+        recalculating the status of a subtree of deployments, PLEASE
+        do not use this for anything else.
+
+        Returns a a list of rows that contain:
+            - several columns from each deployment
+            - the edges, ie. source_id/target_id
+            - if the deployment is an environment
+            - the latest execution status for each deployment
+        """
+        select_cols = db.session.query(
+            cls._storage_id,
+            cls._source_deployment,
+            cls._target_deployment,
+        )
+
+        base = select_cols.filter(db.or_(
+            # starting at both source AND target: we want the parents
+            # of the given deployments, but also their _direct_ (only direct)
+            # children
+            cls._target_deployment.in_(deployment_ids),
+            cls._source_deployment.in_(deployment_ids)
+        )).cte(name='dependents', recursive=True)
+
+        recursive = select_cols.join(
+            # recurse up the tree - fetch ancestors
+            base, cls._source_deployment == base.c._target_deployment)
+        cte = base.union(recursive)
+
+        depends = (
+            db.session.query(cte)
+            .union(
+                # for each ancestor, ALSO fetch all of its direct children
+                select_cols
+                .filter(cls._target_deployment == cte.c._target_deployment)
+            )
+            .subquery()
+        )
+
+        return (
+            db.session.query(
+                # these columns just happen to be enough to recalculate
+                # the statuses and counts; we avoid selecting anything
+                # that isn't necessarily required
+                Deployment._storage_id,
+                Deployment.deployment_status,
+                Deployment.installation_status,
+                Deployment.sub_services_count,
+                Deployment.sub_environments_count,
+                Deployment.sub_services_status,
+                Deployment.sub_environments_status,
+                depends.c.dependents__target_deployment.label(
+                    '_target_deployment'),
+                depends.c.dependents__source_deployment.label(
+                    '_source_deployment'),
+                db.session.query(DeploymentLabel.id)
+                    .filter_by(_labeled_model_fk=Deployment._storage_id)
+                    .filter_by(key='csys-obj-type')
+                    .filter_by(value='environment')
+                    .exists()
+                    .label('is_env'),
+                Execution.status.label('latest_execution_status'),
+            )
+            .select_from(Deployment)
+            .join(depends, db.or_(
+                # we want deployment details for the parents and the children
+                Deployment._storage_id ==
+                     depends.c.dependents__target_deployment,
+                Deployment._storage_id ==
+                    depends.c.dependents__source_deployment
+            ))
+            .outerjoin(
+                Execution,
+                Deployment._latest_execution_fk == Execution._storage_id
+            )
+            .with_for_update(of=Deployment)
+            .all()
+        )
+
 
 class InterDeploymentDependencies(BaseDeploymentDependencies):
     __tablename__ = 'inter_deployment_dependencies'

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -2227,20 +2227,20 @@ class BaseDeploymentDependencies(CreatedAtMixin, SQLResourceBase):
                 depends.c.dependents__source_deployment.label(
                     '_source_deployment'),
                 db.session.query(DeploymentLabel.id)
-                    .filter_by(_labeled_model_fk=Deployment._storage_id)
-                    .filter_by(key='csys-obj-type')
-                    .filter_by(value='environment')
-                    .exists()
-                    .label('is_env'),
+                .filter_by(_labeled_model_fk=Deployment._storage_id)
+                .filter_by(key='csys-obj-type')
+                .filter_by(value='environment')
+                .exists()
+                .label('is_env'),
                 Execution.status.label('latest_execution_status'),
             )
             .select_from(Deployment)
             .join(depends, db.or_(
                 # we want deployment details for the parents and the children
                 Deployment._storage_id ==
-                     depends.c.dependents__target_deployment,
+                depends.c.dependents__target_deployment,
                 Deployment._storage_id ==
-                    depends.c.dependents__source_deployment
+                depends.c.dependents__source_deployment
             ))
             .outerjoin(
                 Execution,

--- a/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
@@ -26,7 +26,7 @@ from manager_rest.rest.rest_utils import RecursiveDeploymentDependencies
 from manager_rest.test.base_test import BaseServerTestCase
 
 
-class _DependencyTestUtils(BaseServerTestCase):
+class _DependencyTestUtils(object):
     def setUp(self):
         super().setUp()
         self.tenant = models.Tenant()

--- a/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
@@ -62,6 +62,168 @@ class ModelDependenciesTest(BaseServerTestCase):
             creator=self.user
         ))
 
+    def _label(self, dep, k, v):
+        db.session.add(models.DeploymentLabel(
+            deployment=dep,
+            creator=self.user,
+            key=k,
+            value=v
+        ))
+
+
+class UpdateTreeTest(_DependencyTestUtils, BaseServerTestCase):
+    def test_empty(self):
+        d1 = self._deployment(id='d1')
+        db.session.flush()
+
+        update_tree = models.DeploymentLabelsDependencies._get_update_tree(
+            [d1._storage_id])
+        assert not update_tree
+
+    def test_direct_dependency(self):
+        d1 = self._deployment(id='d1')
+        d2 = self._deployment(id='d2')
+        self._deployment(id='unrelated')
+        self._label_dependency(d1, d2)
+        db.session.flush()
+        update_tree = models.DeploymentLabelsDependencies._get_update_tree(
+            [d1._storage_id])
+        assert len(update_tree) == 2
+        assert {r._storage_id for r in update_tree} == \
+            {d1._storage_id, d2._storage_id}
+        assert {
+            (r._source_deployment, r._target_deployment) for r in update_tree
+        } == {(d1._storage_id, d2._storage_id)}
+
+    def test_multi_level(self):
+        d1 = self._deployment(id='d1')
+        d2 = self._deployment(id='d2')
+        d3 = self._deployment(id='d3')
+        self._deployment(id='unrelated')
+        self._label_dependency(d1, d2)
+        self._label_dependency(d2, d3)
+        db.session.flush()
+        update_tree = models.DeploymentLabelsDependencies._get_update_tree(
+            [d1._storage_id])
+        assert len(update_tree) == 4
+        assert {r._storage_id for r in update_tree} == \
+            {d1._storage_id, d2._storage_id, d3._storage_id}
+        assert {
+            (r._source_deployment, r._target_deployment) for r in update_tree
+        } == {
+            (d1._storage_id, d2._storage_id),
+            (d2._storage_id, d3._storage_id)
+        }
+
+    def test_siblings(self):
+        d1 = self._deployment(id='d1')
+        d2 = self._deployment(id='d2')
+        d3 = self._deployment(id='d3')
+        self._deployment(id='unrelated')
+        self._label_dependency(d1, d2)
+        self._label_dependency(d3, d2)
+        db.session.flush()
+        update_tree = models.DeploymentLabelsDependencies._get_update_tree(
+            [d1._storage_id])
+        assert {r._storage_id for r in update_tree} == \
+            {d1._storage_id, d2._storage_id, d3._storage_id}
+        assert {
+            (r._source_deployment, r._target_deployment) for r in update_tree
+        } == {
+            (d1._storage_id, d2._storage_id),
+            (d3._storage_id, d2._storage_id)
+        }
+
+    def test_tree(self):
+        # with a tree like:
+        # E1__
+        # |   \
+        # E2   E3
+        # | \    \
+        # E4 S2   S3
+        # | \
+        # S1 S4
+        # ...select the tree rooted at S1: we expect to get back all the
+        # ancestors, and all the siblings of ancestors:
+        # S1, S4, E4, S2, E2, E1, E3
+        # ...but not S3
+        deps = {
+            dep_id: self._deployment(id=dep_id)
+            for dep_id in ['s1', 's2', 's3', 's4', 'e1', 'e2', 'e3', 'e4',
+                           'unrelated']
+        }
+        dependencies = [
+            ('s1', 'e4'),
+            ('s4', 'e4'),
+            ('e4', 'e2'),
+            ('s2', 'e2'),
+            ('e2', 'e1'),
+            ('e3', 'e1'),
+            ('s3', 'e3'),
+        ]
+        for source, target in dependencies:
+            self._label_dependency(deps[source], deps[target])
+        db.session.flush()
+
+        update_tree = models.DeploymentLabelsDependencies._get_update_tree(
+            [deps['s1']._storage_id])
+
+        assert {r._storage_id for r in update_tree} == \
+            {
+                deps[dep_id]._storage_id for dep_id in
+                ['s1', 's4', 'e4', 's2', 'e2', 'e1', 'e3']
+            }
+
+        expected_edges = {
+            (deps[source]._storage_id, deps[target]._storage_id)
+            for source, target in dependencies
+            # we dont want s3 here, it's not an ancestor of s1, nor a direct
+            # child of an ancestor
+            if source != 's3'
+        }
+        assert {
+            (r._source_deployment, r._target_deployment) for r in update_tree
+        } == expected_edges
+
+    def test_is_env(self):
+        d1 = self._deployment(id='d1')
+        d2 = self._deployment(id='d2')
+        self._label(d1, 'csys-obj-type', 'environment')
+        self._label(d2, 'csys-obj-type', 'service')
+        self._label_dependency(d1, d2)
+        db.session.flush()
+        update_tree = models.DeploymentLabelsDependencies._get_update_tree(
+            [d1._storage_id])
+        assert {(r._storage_id, r.is_env) for r in update_tree} == \
+            {(d1._storage_id, True), (d2._storage_id, False)}
+
+    def test_latest_status(self):
+        d1 = self._deployment(id='d1')
+        d2 = self._deployment(id='d2')
+        d1.latest_execution = models.Execution(
+            status='pending',
+            workflow_id='',
+            tenant=self.tenant,
+            creator=self.user,
+        )
+        d2.latest_execution = models.Execution(
+            status='terminated',
+            workflow_id='',
+            tenant=self.tenant,
+            creator=self.user,
+        )
+        self._label_dependency(d1, d2)
+        db.session.flush()
+        update_tree = models.DeploymentLabelsDependencies._get_update_tree(
+            [d1._storage_id])
+        assert {
+            (r._storage_id, r.latest_execution_status)
+            for r in update_tree
+        } == {(d1._storage_id, 'pending'), (d2._storage_id, 'terminated')}
+
+
+
+class ModelDependenciesTest(_DependencyTestUtils, BaseServerTestCase):
     def test_empty(self):
         d1 = self._deployment(id='d1')
         db.session.flush()

--- a/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
@@ -26,7 +26,7 @@ from manager_rest.rest.rest_utils import RecursiveDeploymentDependencies
 from manager_rest.test.base_test import BaseServerTestCase
 
 
-class ModelDependenciesTest(BaseServerTestCase):
+class _DependencyTestUtils(BaseServerTestCase):
     def setUp(self):
         super().setUp()
         self.tenant = models.Tenant()
@@ -220,7 +220,6 @@ class UpdateTreeTest(_DependencyTestUtils, BaseServerTestCase):
             (r._storage_id, r.latest_execution_status)
             for r in update_tree
         } == {(d1._storage_id, 'pending'), (d2._storage_id, 'terminated')}
-
 
 
 class ModelDependenciesTest(_DependencyTestUtils, BaseServerTestCase):


### PR DESCRIPTION
This isn't used yet, but it will be (in the next PR, or one of them).

This adds a query that fetches all the data needed to recompute
a subtree: ie. given a deployment storage id, it will fetch details
required to compute that deployment's status(es), and those of
its parents, and those parents' parents, etc.

I'm keeping this query semi-private, because of how specific it
is, and not very useful for anything else than the one call site
(that it is yet to have).

It is a bit unfortunate that this writes the whole query from
scratch, rather than using the other methods, but I've tried,
and I haven't been able to do it in a way that made anything
cleaner.