### PR TITLE
RD-3573 Recalculate all ancestors sub-counts&statuses 

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2702,8 +2702,7 @@ class ResourceManager(object):
     def _reset_sub_deployments(self, deployment_ids):
         """Set sub-counts to 0 and sub-statuses to None, for deployment_ids.
 
-        We know that deployment_ids have no children, so we can clear their
-        sub-counts and statuses.
+        Only call this on deployments who we know have no children.
         This however requires re-evaluation of the deployment status as well.
         """
         deployments_to_update = (

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -91,10 +91,10 @@ class _SubDepSummary(object):
 
     def __add__(self, other):
         return self.__class__(
-            sub_services_count=
-            self.sub_services_count + other.sub_services_count,
-            sub_environments_count=
-            self.sub_environments_count + other.sub_environments_count,
+            sub_services_count=self.sub_services_count +
+            other.sub_services_count,
+            sub_environments_count=self.sub_environments_count +
+            other.sub_environments_count,
             sub_services_status=models.Deployment.compare_statuses(
                 self.sub_services_status, other.sub_services_status
             ),
@@ -2834,6 +2834,7 @@ class ResourceManager(object):
                     sub_environments_status=dep_summary.sub_environments_status
                 )
             )
+
 
 # What we need to access this manager in Flask
 def get_resource_manager(sm=None):

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -91,13 +91,13 @@ class DeploymentsId(resources_v1.DeploymentsId):
                 exclude_sub_deployments=True)
             if _dep.is_environment:
                 sub_environments_count += 1
-                sub_environments_status = _dep.compare_between_statuses(
+                sub_environments_status = _dep.compare_statuses(
                     sub_environments_status,
                     _dep_status
                 )
             else:
                 sub_services_count += 1
-                sub_services_status = _dep.compare_between_statuses(
+                sub_services_status = _dep.compare_statuses(
                     sub_services_status,
                     _dep_status
                 )

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -806,10 +806,10 @@ class RecursiveDeploymentLabelsDependencies(BaseDeploymentDependencies):
                         total_srv_status = DeploymentState.REQUIRE_ATTENTION
                         break
 
-                    total_env_status = _source.compare_between_statuses(
+                    total_env_status = _source.compare_statuses(
                         total_env_status, _sub_env_status
                     )
-                    total_srv_status = _source.compare_between_statuses(
+                    total_srv_status = _source.compare_statuses(
                         total_srv_status, _sub_srv_status
                     )
             _update_deployment_status(v, total_srv_status, total_env_status)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -572,6 +572,8 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         }
         return max(statuses, key=lambda st: importance.get(st, 0))
 
+    compare_statuses = compare_between_statuses
+
     def evaluate_sub_deployments_statuses(self):
         """
         Evaluate the deployment statuses per deployment using the following

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -608,35 +608,46 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         and latest execution object
         :return: deployment_status: Overall deployment status
         """
+        deployment_status = self.decide_deployment_status(
+            self.latest_execution_status,
+            self.installation_status,
+            self.sub_services_status,
+            self.sub_environments_status
+        )
+        self.deployment_status = deployment_status
+        return deployment_status
+
+    @classmethod
+    def decide_deployment_status(
+        cls,
+        latest_execution_status,
+        installation_status,
+        sub_services_status,
+        sub_environments_status,
+    ):
         latest_status = DeploymentState.EXECUTION_STATES_SUMMARY.get(
-            self.latest_execution_status)
+            latest_execution_status)
         if latest_status == DeploymentState.IN_PROGRESS:
             deployment_status = DeploymentState.IN_PROGRESS
         elif latest_status == DeploymentState.FAILED \
-                or self.installation_status == DeploymentState.INACTIVE:
+                or installation_status == DeploymentState.INACTIVE:
             deployment_status = DeploymentState.REQUIRE_ATTENTION
         else:
             deployment_status = DeploymentState.GOOD
 
-        has_sub_sts = self.sub_services_status or self.sub_environments_status
-        if not has_sub_sts or exclude_sub_deployments:
-            return deployment_status
-
         # Check whether or not deployment has services or environments
         # attached to it, so that we can consider that while evaluating the
         # deployment status
-        if self.sub_services_status:
-            deployment_status = \
-                self.compare_between_statuses(
-                    self.sub_services_status,
-                    deployment_status
-                )
-        if self.sub_environments_status:
-            deployment_status = \
-                self.compare_between_statuses(
-                    self.sub_environments_status,
-                    deployment_status
-                )
+        if sub_services_status:
+            deployment_status = cls.compare_between_statuses(
+                sub_services_status,
+                deployment_status
+            )
+        if sub_environments_status:
+            deployment_status = cls.compare_between_statuses(
+                sub_environments_status,
+                deployment_status
+            )
         return deployment_status
 
     @property

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -554,7 +554,7 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
                 for wf_name, wf in deployment_workflows.items()]
 
     @classmethod
-    def compare_between_statuses(
+    def compare_statuses(
                 cls, *statuses: typing.Optional[str]
             ) -> typing.Optional[str]:
         """Unify multiple DeploymentStates into a single state.
@@ -571,8 +571,6 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
             DeploymentState.REQUIRE_ATTENTION: 3
         }
         return max(statuses, key=lambda st: importance.get(st, 0))
-
-    compare_statuses = compare_between_statuses
 
     def evaluate_sub_deployments_statuses(self):
         """
@@ -591,14 +589,14 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         _sub_services_status = self.sub_services_status
         if self.is_environment:
             _sub_environments_status = \
-                self.compare_between_statuses(
+                self.compare_statuses(
                     self.sub_environments_status,
                     self.deployment_status
                 )
 
         else:
             _sub_services_status = \
-                self.compare_between_statuses(
+                self.compare_statuses(
                     self.sub_services_status,
                     self.deployment_status
                 )
@@ -641,12 +639,12 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         # attached to it, so that we can consider that while evaluating the
         # deployment status
         if sub_services_status:
-            deployment_status = cls.compare_between_statuses(
+            deployment_status = cls.compare_statuses(
                 sub_services_status,
                 deployment_status
             )
         if sub_environments_status:
-            deployment_status = cls.compare_between_statuses(
+            deployment_status = cls.compare_statuses(
                 sub_environments_status,
                 deployment_status
             )


### PR DESCRIPTION
A single tree-traversing function to recalculate all statuses & counts
for parents of the given deployments.

This uses the `_get_update_tree` query from before, and it is not
yet used itself, but it will be!