### PR TITLE
Pin cffi version to be lower than 1.15

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {
           steps {
             container('rpmbuild'){
               sh """
-                cd && mkdir rpmbuild && cd rpmbuild
+                cd ~/rpmbuild
                 git clone --single-branch --branch ${env.BRANCH} https://github.com/cloudify-cosmo/cloudify-manager.git SOURCES && cd SOURCES
               """
 

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -9,7 +9,7 @@ spec:
         cpu: 0.5
         memory: 256Mi
   - name: python
-    image: circleci/python:3.6
+    image: 263721492972.dkr.ecr.eu-west-1.amazonaws.com/cloudify-python3.6
     resources:
       requests:
         cpu: 2

--- a/jenkins/rpm-pod.yaml
+++ b/jenkins/rpm-pod.yaml
@@ -9,7 +9,7 @@ spec:
         cpu: 0.3
         memory: 256Mi
   - name: rpmbuild
-    image: rpmbuild/centos7
+    image: 263721492972.dkr.ecr.eu-west-1.amazonaws.com/cloudify-rpmbuild
     command:
     - cat
     tty: true

--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -33,6 +33,7 @@ install_requires = [
     'python-dateutil==2.8.1',
     'voluptuous==0.9.3',
     'pika==1.1.0',
+    'cffi>=1.14,<1.15',
     'cryptography==3.3.2',
     'psycopg2==2.9.1',
     'pytz==2021.1',


### PR DESCRIPTION
... because higher versions require libffi which is not available in our
CentOS builders