### PR TITLE
RD-2996 Drop manager_rest dependency in integration tests (#3295)

### DIFF
--- a/tests/integration_tests/framework/utils.py
+++ b/tests/integration_tests/framework/utils.py
@@ -5,6 +5,8 @@ import json
 import shutil
 import zipfile
 import tempfile
+from base64 import b64encode
+
 import requests
 
 from functools import wraps
@@ -13,7 +15,6 @@ from contextlib import contextmanager
 
 from cloudify.utils import setup_logger
 from cloudify_rest_client import CloudifyClient
-from manager_rest.utils import create_auth_header
 
 from cloudify_cli import env as cli_env
 from cloudify_cli.constants import CLOUDIFY_BASE_DIRECTORY_NAME
@@ -22,6 +23,26 @@ from . import docker
 
 
 logger = setup_logger('testenv.utils')
+
+
+def create_auth_header(username=None, password=None, token=None, tenant=None):
+    """Create a valid authentication header either from username/password or
+    a token if any were provided; return an empty dict otherwise
+    """
+    headers = {}
+    if username and password:
+        credentials = b64encode(
+            '{0}:{1}'.format(username, password).encode('utf-8')
+        ).decode('ascii')
+        headers = {
+            'Authorization':
+            'Basic ' + credentials
+        }
+    elif token:
+        headers = {'Authentication-Token': token}
+    if tenant:
+        headers['Tenant'] = tenant
+    return headers
 
 
 def _write(stream, s):

--- a/tests/integration_tests/tests/agent_tests/test_list_agents.py
+++ b/tests/integration_tests/tests/agent_tests/test_list_agents.py
@@ -13,10 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from importlib.util import find_spec
+
 import pytest
-from manager_rest import premium_enabled
+
 from integration_tests import AgentTestCase
 from integration_tests.tests.utils import get_resource as resource
+
+premium_enabled = find_spec('cloudify_premium') is not None
 
 pytestmark = pytest.mark.group_agents
 

--- a/tests/integration_tests/tests/agent_tests/test_plugin_update.py
+++ b/tests/integration_tests/tests/agent_tests/test_plugin_update.py
@@ -21,7 +21,6 @@ import pytest
 from functools import wraps
 
 import integration_tests_plugins
-from manager_rest.plugins_update.constants import STATES
 
 from integration_tests import AgentTestWithPlugins
 from integration_tests.tests.utils import (
@@ -167,14 +166,14 @@ class TestPluginUpdate(AgentTestWithPlugins):
         self._assert_host_values(self.versions[0])
 
         plugins_update = self._perform_plugins_update()
-        self.assertEqual(plugins_update.state, STATES.SUCCESSFUL)
+        self.assertEqual(plugins_update.state, 'successful')
 
         # Execute mod (V 2.0) workflows
         self._execute_workflows()
         self._assert_host_values(self.versions[1])
 
         plugins_update = self._perform_plugins_update()
-        self.assertEqual(plugins_update.state, STATES.NO_CHANGES_REQUIRED)
+        self.assertEqual(plugins_update.state, 'no_changes_required')
 
         # Execute mod (V 2.0) workflows
         self._execute_workflows()
@@ -209,7 +208,7 @@ class TestPluginUpdate(AgentTestWithPlugins):
             self._assert_host_values(self.versions[0])
 
         plugins_update = self._perform_plugins_update()
-        self.assertEqual(plugins_update.state, STATES.SUCCESSFUL)
+        self.assertEqual(plugins_update.state, 'successful')
 
         # Execute mod (V 2.0) workflows
         for dep_id in self.setup_deployment_ids:
@@ -236,21 +235,21 @@ class TestPluginUpdate(AgentTestWithPlugins):
 
         # Update a different (non-existent) plugin - nothing should change
         plugins_update = self._perform_plugins_update(plugin_names=['asd'])
-        self.assertEqual(plugins_update.state, STATES.NO_CHANGES_REQUIRED)
+        self.assertEqual(plugins_update.state, 'no_changes_required')
         self._execute_workflows()
         self._assert_host_values(self.versions[0])
 
         # Update only minor version - nothing should change
         plugins_update = self._perform_plugins_update(all_to_minor=True,
                                                       all_to_latest=False)
-        self.assertEqual(plugins_update.state, STATES.NO_CHANGES_REQUIRED)
+        self.assertEqual(plugins_update.state, 'no_changes_required')
         self._execute_workflows()
         self._assert_host_values(self.versions[0])
 
         # This should do the update
         plugins_update = self._perform_plugins_update(
             to_latest=[self.plugin_name])
-        self.assertEqual(plugins_update.state, STATES.SUCCESSFUL)
+        self.assertEqual(plugins_update.state, 'successful')
         self._execute_workflows()
         self._assert_host_values(self.versions[1])
 

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/__init__.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/__init__.py
@@ -14,8 +14,6 @@
 
 import os
 
-from manager_rest.deployment_update.constants import STATES
-
 from integration_tests import AgentlessTestCase
 from integration_tests.tests.utils import get_resource as resource
 
@@ -43,7 +41,7 @@ class DeploymentUpdateBase(AgentlessTestCase):
             self.client.executions.get(dep_update.execution_id))
         self.assertEqual(
             self.client.deployment_updates.get(dep_update.id).state,
-            STATES.SUCCESSFUL
+            'successful'
         )
 
     def _assert_relationship(self,

--- a/tests/integration_tests/tests/agentless_tests/multi_tenancy/test_list_tenant_filter.py
+++ b/tests/integration_tests/tests/agentless_tests/multi_tenancy/test_list_tenant_filter.py
@@ -4,8 +4,6 @@ from integration_tests import AgentlessTestCase
 from integration_tests.tests.constants import USER_ROLE
 from integration_tests.tests.utils import get_resource as resource
 
-from manager_rest.constants import DEFAULT_TENANT_NAME, DEFAULT_TENANT_ROLE
-
 from cloudify_rest_client.exceptions import CloudifyClientError
 
 pytestmark = pytest.mark.group_premium
@@ -20,21 +18,21 @@ class ListResourcesTest(AgentlessTestCase):
 
         # Alice belongs to both tenants
         self.client.tenants.add_user('alice',
-                                     DEFAULT_TENANT_NAME,
-                                     DEFAULT_TENANT_ROLE)
+                                     'default_tenant',
+                                     'user')
         self.client.tenants.add_user('alice',
                                      'TEST_TENANT',
-                                     DEFAULT_TENANT_ROLE)
+                                     'user')
         # Fred only belongs to 'TEST_TENANT'
         self.client.tenants.add_user('fred',
                                      'TEST_TENANT',
-                                     DEFAULT_TENANT_ROLE)
+                                     'user')
 
         # Create clients for each user
         self.alice_client = self.create_rest_client(
             username='alice',
             password='alice_password',
-            tenant=DEFAULT_TENANT_NAME,
+            tenant='default_tenant',
         )
         self.fred_client = self.create_rest_client(
             username='fred',
@@ -57,7 +55,7 @@ class ListResourcesTest(AgentlessTestCase):
         self.assertEqual(len(result), 1)
 
         with self.client_using_tenant(self.alice_client,
-                                      tenant_name=DEFAULT_TENANT_NAME):
+                                      tenant_name='default_tenant'):
             result = self.alice_client.blueprints.list()
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].id, 'alice_bp')
@@ -70,7 +68,7 @@ class ListResourcesTest(AgentlessTestCase):
 
     def test_list_blueprints_not_authorized(self):
         error_msg = '403.*blueprint_list.*default_tenant'
-        with self.client_using_tenant(self.fred_client, DEFAULT_TENANT_NAME):
+        with self.client_using_tenant(self.fred_client, 'default_tenant'):
             self.assertRaisesRegex(CloudifyClientError, error_msg,
                                    self.fred_client.blueprints.list)
 

--- a/tests/integration_tests/tests/agentless_tests/multi_tenancy/test_users.py
+++ b/tests/integration_tests/tests/agentless_tests/multi_tenancy/test_users.py
@@ -1,7 +1,6 @@
 import pytest
 
 from cloudify_rest_client.exceptions import CloudifyClientError
-from manager_rest.constants import DEFAULT_TENANT_NAME
 
 from integration_tests import AgentlessTestCase
 from integration_tests.tests.constants import ADMIN_ROLE, USER_ROLE
@@ -68,7 +67,7 @@ class UsersTest(AgentlessTestCase):
             self._get_user_dict(
                 'admin',
                 role=ADMIN_ROLE,
-                tenants=[DEFAULT_TENANT_NAME]
+                tenants=['default_tenant']
             ),
             users[0]
         )

--- a/tests/integration_tests/tests/agentless_tests/security/test_file_server_access.py
+++ b/tests/integration_tests/tests/agentless_tests/security/test_file_server_access.py
@@ -2,7 +2,6 @@ import pytest
 import requests
 
 from cloudify_cli.env import get_auth_header
-from manager_rest.constants import DEFAULT_TENANT_ROLE
 
 from integration_tests import AgentlessTestCase
 from integration_tests.tests.constants import USER_ROLE
@@ -22,7 +21,7 @@ class ResourcesAvailableTest(AgentlessTestCase):
         self.client.tenants.create(tenant_name='t')
         self.client.tenants.add_user(username='u',
                                      tenant_name='t',
-                                     role=DEFAULT_TENANT_ROLE)
+                                     role='user')
         tenant_t_client = self.create_rest_client(tenant='t')
         tenant_t_client.blueprints.upload(resource('dsl/empty_blueprint.yaml'),
                                           entity_id='blu')

--- a/tests/integration_tests/tests/agentless_tests/test_deployment_resource.py
+++ b/tests/integration_tests/tests/agentless_tests/test_deployment_resource.py
@@ -26,8 +26,6 @@ from integration_tests.tests.utils import (
     wait_for_deployment_deletion_to_complete
 )
 
-from manager_rest.constants import DEFAULT_TENANT_NAME
-
 pytestmark = pytest.mark.group_deployments
 RESOURCE_PATH = 'resources/resource.txt'
 RESOURCE_CONTENT = 'this is a deployment resource'
@@ -43,12 +41,12 @@ class DeploymentResourceTest(AgentlessTestCase):
         base_dep_dir = '/opt/manager/resources/deployments'
         dep_resources_dir = join(
             base_dep_dir,
-            DEFAULT_TENANT_NAME,
+            'default_tenant',
             deployment_id,
             'resources'
         )
         full_resource_path = join(base_dep_dir,
-                                  DEFAULT_TENANT_NAME,
+                                  'default_tenant',
                                   deployment_id,
                                   RESOURCE_PATH)
         self.execute_on_manager('mkdir -p {0}'.format(dep_resources_dir))

--- a/tests/integration_tests/tests/agentless_tests/test_script_mapping.py
+++ b/tests/integration_tests/tests/agentless_tests/test_script_mapping.py
@@ -21,8 +21,6 @@ import tempfile
 from integration_tests import AgentlessTestCase
 from integration_tests.tests.utils import get_resource as resource
 
-from manager_rest.constants import DEFAULT_TENANT_NAME
-
 pytestmark = pytest.mark.group_dsl
 
 
@@ -53,7 +51,7 @@ class TestScriptMapping(AgentlessTestCase):
 
         deployment_folder = os.path.join(
             base_dep_dir,
-            DEFAULT_TENANT_NAME,
+            'default_tenant',
             deployment.id
         )
         workflow_folder = os.path.join(deployment_folder, 'scripts/workflows')

--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -29,8 +29,6 @@ from integration_tests import AgentlessTestCase
 from cloudify.snapshots import STATES
 from cloudify.models_states import AgentState
 
-from manager_rest.constants import DEFAULT_TENANT_NAME
-
 from cloudify_rest_client.executions import Execution
 from cloudify_rest_client.exceptions import CloudifyClientError
 
@@ -319,7 +317,7 @@ class TestSnapshot(AgentlessTestCase):
 
     def _assert_4_4_0_plugins_restored_bad_plugin(
             self,
-            tenant_name=DEFAULT_TENANT_NAME,
+            tenant_name='default_tenant',
             number_of_deployments=0):
         with self.client_using_tenant(self.client, tenant_name):
             plugins = self.client.plugins.list()
@@ -376,7 +374,7 @@ class TestSnapshot(AgentlessTestCase):
     def _upload_and_restore_snapshot(
             self,
             snapshot_path,
-            tenant_name=DEFAULT_TENANT_NAME,
+            tenant_name='default_tenant',
             snapshot_id=None,
             desired_execution_status=Execution.TERMINATED,
             error_execution_status=Execution.FAILED,

--- a/tests/integration_tests/tests/agentless_tests/test_workflow.py
+++ b/tests/integration_tests/tests/agentless_tests/test_workflow.py
@@ -35,8 +35,6 @@ from integration_tests.framework.utils import create_zip
 from integration_tests.tests.utils import (get_resource,
                                            wait_for_blueprint_upload)
 
-from manager_rest.constants import DEFAULT_TENANT_NAME
-
 pytestmark = pytest.mark.group_workflows
 
 
@@ -434,7 +432,7 @@ class BasicWorkflowsTest(AgentlessTestCase):
     def _get_deployment_folder(deployment):
         return os.path.join(
             '/opt/manager/resources/deployments',
-            DEFAULT_TENANT_NAME,
+            'default_tenant',
             deployment.id
         )
 
@@ -442,7 +440,7 @@ class BasicWorkflowsTest(AgentlessTestCase):
     def _get_plugin_path(deployment):
         return os.path.join(
             '/opt/mgmtworker/env/source_plugins/',
-            DEFAULT_TENANT_NAME,
+            'default_tenant',
             deployment.id,
             'mock-plugin', '0.1',
             'lib/python3.6/site-packages/',

--- a/tests/integration_tests/tests/test_cases.py
+++ b/tests/integration_tests/tests/test_cases.py
@@ -33,8 +33,6 @@ from requests.exceptions import ConnectionError
 import cloudify.utils
 from cloudify.snapshots import STATES, SNAPSHOT_RESTORE_FLAG_FILE
 
-from manager_rest.constants import CLOUDIFY_TENANT_HEADER
-
 from integration_tests.framework import utils, docker
 from integration_tests.tests import utils as test_utils
 from integration_tests.tests.utils import (
@@ -391,12 +389,12 @@ class BaseTestCase(unittest.TestCase):
 
     @contextmanager
     def client_using_tenant(self, client, tenant_name):
-        curr_tenant = client._client.headers.get(CLOUDIFY_TENANT_HEADER)
+        curr_tenant = client._client.headers.get('Tenant')
         try:
-            client._client.headers[CLOUDIFY_TENANT_HEADER] = tenant_name
+            client._client.headers['Tenant'] = tenant_name
             yield
         finally:
-            client._client.headers[CLOUDIFY_TENANT_HEADER] = curr_tenant
+            client._client.headers['Tenant'] = curr_tenant
 
     def make_file_with_name(self, content, filename, base_dir=None):
         base_dir = (os.path.join(self._temp_dir, base_dir)


### PR DESCRIPTION
This ports #3295 to 6.2.1, dropping rest-service dependency in the
inte-tests.