### PR TITLE
RD-3681 sm.list: return empty, for empty filter lists

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -917,11 +917,14 @@ class DeploymentGroupsId(SecuredResource):
         target_deployments = set()
         created_labels = set()
         for key, value in labels_to_create:
-            existing_labels = sm.list(models.DeploymentLabel, filters={
-                'key': key,
-                'value': value,
-                '_labeled_model_fk': deployment_ids
-            }, get_all_results=True)
+            if not deployment_ids:
+                existing_labels = []
+            else:
+                existing_labels = sm.list(models.DeploymentLabel, filters={
+                    'key': key,
+                    'value': value,
+                    '_labeled_model_fk': deployment_ids
+                }, get_all_results=True)
             skip_deployments = {
                 label._labeled_model_fk for label in existing_labels
             }

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -220,7 +220,7 @@ class SQLStorageManager(object):
             if callable(value):
                 query = query.filter(value(column))
             elif isinstance(value, (list, tuple)):
-                if all(callable(item) for item in value):
+                if value and all(callable(item) for item in value):
                     operations_filter = (operation(column)
                                          for operation in value)
                     query = query.filter(*operations_filter)

--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -216,7 +216,6 @@ class StorageManagerTests(base_test.BaseServerTestCase):
                 'config.instance.default_page_size',
                 10)
     def test_all_results_query(self):
-        now = utils.get_formatted_timestamp()
         for i in range(20):
             secret = models.Secret(id='secret_{}'.format(i),
                                    value='value',

--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -220,10 +220,10 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         for i in range(20):
             secret = models.Secret(id='secret_{}'.format(i),
                                    value='value',
-                                   created_at=now,
-                                   updated_at=now,
+                                   tenant=self.tenant,
+                                   creator=self.user,
                                    visibility=VisibilityState.TENANT)
-            self.sm.put(secret)
+            db.session.add(secret)
 
         secret_list = self.sm.list(
             models.Secret,

--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -255,6 +255,16 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         self.assertEqual({secret.id for secret in secrets_list},
                          {'secret_0', 'secret_2'})
 
+    def test_list_with_empty_filter(self):
+        secret = models.Secret(id='secret',
+                               value='value',
+                               tenant=self.tenant,
+                               creator=self.user,
+                               visibility=VisibilityState.TENANT)
+        db.session.add(secret)
+        retrieved = self.sm.list(models.Secret, filters={'_storage_id': []})
+        assert len(retrieved) == 0
+
 
 class TestTransactions(base_test.BaseServerTestCase):
     def _make_secret(self, id, value):


### PR DESCRIPTION
`sm.list(models.X, filters={'id': []})` should return no results,
because the filter-by list is empty.
However, currently it instead returns all entries, because
it takes it to mean "apply no filters".
Well that's silly. Let's fix it to mean the former.