### PR TITLE
Mock out external auth in REST tests

### DIFF
--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -276,6 +276,7 @@ class BaseServerTestCase(unittest.TestCase):
         cls._create_temp_files_and_folders()
         cls._mock_amqp_modules()
         cls._mock_swagger()
+        cls._mock_external_auth()
 
         cls._create_config_and_reset_app()
         cls._mock_get_encryption_key()
@@ -324,6 +325,15 @@ class BaseServerTestCase(unittest.TestCase):
     def _mock_verify_role(cls):
         cls._original_verify_role = rest_utils.verify_role
         rest_utils.verify_role = MagicMock()
+
+    @classmethod
+    def _mock_external_auth(cls):
+        """No need for external auth loading; we're not gonna be using ldap!"""
+        if premium_enabled:
+            auth_path = patch(
+                'manager_rest.server.configure_auth',
+                return_value=None)
+            cls._patchers.append(auth_path)
 
     @classmethod
     def _mock_swagger(cls):

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -17,6 +17,7 @@ import os
 import json
 import time
 import uuid
+import base64
 import shutil
 import logging
 import zipfile
@@ -277,12 +278,12 @@ class BaseServerTestCase(unittest.TestCase):
         cls._mock_amqp_modules()
         cls._mock_swagger()
         cls._mock_external_auth()
+        cls._mock_get_encryption_key()
 
         for patcher in cls._patchers:
             patcher.start()
 
         cls._create_config_and_reset_app()
-        cls._mock_get_encryption_key()
         cls._handle_flask_app_and_db()
         cls.client = cls.create_client()
         cls.sm = get_storage_manager()
@@ -366,7 +367,7 @@ class BaseServerTestCase(unittest.TestCase):
         """ Mock the _get_encryption_key_patcher function for all unittests """
         get_encryption_key_patcher = patch(
             'cloudify.cryptography_utils._get_encryption_key',
-            MagicMock(return_value=config.instance.security_encryption_key)
+            MagicMock(return_value=base64.b64encode(os.urandom(64)))
         )
         cls._patchers.append(get_encryption_key_patcher)
 

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -278,6 +278,9 @@ class BaseServerTestCase(unittest.TestCase):
         cls._mock_swagger()
         cls._mock_external_auth()
 
+        for patcher in cls._patchers:
+            patcher.start()
+
         cls._create_config_and_reset_app()
         cls._mock_get_encryption_key()
         cls._handle_flask_app_and_db()
@@ -285,9 +288,6 @@ class BaseServerTestCase(unittest.TestCase):
         cls.sm = get_storage_manager()
         cls.rm = get_resource_manager()
         cls._mock_verify_role()
-
-        for patcher in cls._patchers:
-            patcher.start()
 
     def setUp(self):
         self._handle_default_db_config()

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -34,7 +34,7 @@ import requests
 import traceback
 
 from flask_migrate import Migrate, upgrade
-from mock import MagicMock, patch
+from mock import Mock, patch
 from flask.testing import FlaskClient
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
@@ -325,7 +325,7 @@ class BaseServerTestCase(unittest.TestCase):
     @classmethod
     def _mock_verify_role(cls):
         cls._original_verify_role = rest_utils.verify_role
-        rest_utils.verify_role = MagicMock()
+        rest_utils.verify_role = Mock()
 
     @classmethod
     def _mock_external_auth(cls):
@@ -367,7 +367,7 @@ class BaseServerTestCase(unittest.TestCase):
         """ Mock the _get_encryption_key_patcher function for all unittests """
         get_encryption_key_patcher = patch(
             'cloudify.cryptography_utils._get_encryption_key',
-            MagicMock(return_value=base64.b64encode(os.urandom(64)))
+            Mock(return_value=base64.b64encode(os.urandom(64)))
         )
         cls._patchers.append(get_encryption_key_patcher)
 
@@ -455,7 +455,7 @@ class BaseServerTestCase(unittest.TestCase):
         default_tenant = create_default_user_tenant_and_roles(
             admin_username=admin_user['username'],
             admin_password=admin_user['password'],
-            amqp_manager=MagicMock()
+            amqp_manager=Mock()
         )
         default_tenant.rabbitmq_username = \
             'rabbitmq_username_default_tenant'
@@ -499,7 +499,7 @@ class BaseServerTestCase(unittest.TestCase):
         """
         admin_user = set_admin_current_user(server.app)
         login_manager = server.app.extensions['security'].login_manager
-        login_manager.anonymous_user = MagicMock(return_value=admin_user)
+        login_manager.anonymous_user = Mock(return_value=admin_user)
 
     @classmethod
     def tearDownClass(cls):
@@ -809,7 +809,7 @@ class BaseServerTestCase(unittest.TestCase):
     def create_deployment_environment(self, deployment, client=None):
         from cloudify_system_workflows.deployment_environment import create
         client = client or self.client
-        m = MagicMock()
+        m = Mock()
         deployment = self.sm.get(models.Deployment, deployment.id)
         blueprint = client.blueprints.get(deployment.blueprint_id)
         m.deployment = client.deployments.get(deployment.id)
@@ -998,7 +998,7 @@ class BaseServerTestCase(unittest.TestCase):
             raise Exception(f'No `upload_blueprint` execution was found for '
                             f'the blueprint {blueprint_id}')
 
-        m = MagicMock()
+        m = Mock()
         with patch('cloudify_system_workflows.blueprint.get_rest_client',
                    return_value=client):
             try:

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -52,7 +52,6 @@ from cloudify.cluster_status import (
 )
 
 from manager_rest import server
-from manager_rest.rest import rest_utils
 from manager_rest.storage.models_base import db
 from manager_rest.rest.filters_utils import FilterRule
 from manager_rest.resource_manager import get_resource_manager

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -279,6 +279,7 @@ class BaseServerTestCase(unittest.TestCase):
         cls._mock_swagger()
         cls._mock_external_auth()
         cls._mock_get_encryption_key()
+        cls._mock_verify_role()
 
         for patcher in cls._patchers:
             patcher.start()
@@ -288,7 +289,6 @@ class BaseServerTestCase(unittest.TestCase):
         cls.client = cls.create_client()
         cls.sm = get_storage_manager()
         cls.rm = get_resource_manager()
-        cls._mock_verify_role()
 
     def setUp(self):
         self._handle_default_db_config()
@@ -324,8 +324,8 @@ class BaseServerTestCase(unittest.TestCase):
 
     @classmethod
     def _mock_verify_role(cls):
-        cls._original_verify_role = rest_utils.verify_role
-        rest_utils.verify_role = Mock()
+        mock_verify_role = patch('manager_rest.rest.rest_utils.verify_role')
+        cls._patchers.append(mock_verify_role)
 
     @classmethod
     def _mock_external_auth(cls):


### PR DESCRIPTION
We don't really want to set up external auth, even if premium
is installed, in these tests.