### PR TITLE
RD-3689 delete deployment: fix the excluded-ids check

### DIFF
--- a/rest-service/manager_rest/storage/models.py
+++ b/rest-service/manager_rest/storage/models.py
@@ -55,6 +55,7 @@ from .resource_models import (
     TasksGraph,
     Site,
     PluginsUpdate,
+    BaseDeploymentDependencies,
     InterDeploymentDependencies,
     DeploymentLabelsDependencies,
     _PluginState,

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -2221,10 +2221,14 @@ class InterDeploymentDependencies(BaseDeploymentDependencies):
 
     def summarize(self):
         dep_creator = self.dependency_creator.split('.')
-        dep_type = dep_creator[0] \
-            if dep_creator[0] in ['component', 'sharedresource'] \
-            else 'deployment'
-        dep_node = dep_creator[1]
+        if len(dep_creator) > 1:
+            dep_type = dep_creator[0] \
+                if dep_creator[0] in ['component', 'sharedresource'] \
+                else 'deployment'
+            dep_node = dep_creator[1]
+        else:
+            dep_type = 'deployment'
+            dep_node = '<unknown node>'
         return {
             'deployment': self.source_deployment.id,
             'dependency_type': dep_type,


### PR DESCRIPTION
This seems correct! I won't bet my head on it, but I've also added
a couple tests to prove to myself that it is indeed correct :P

Add a method to check when are deployments allowed to be
uninstalled and deleted. Deployments are allowed to be
uninstalled/deleted when they have no children (that
aren't components) or dependents. You can only uninstall
components, if their main deployment is being uninstalled
as well. (then, component's uninstall + delete, is run as
part of the component node's delete operation)

Hopefully the docstring + tests make that clear to some
degree.

Also, note that I'm only checking direct dependencies here: no
need for the full tree, because if a deployment were to have
a tree of dependencies, it obviously also has some direct
dependencies as well, so that is enough.