### PR TITLE
RD-3699 Only lowercase csys-obj-type, not other labels

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2419,10 +2419,10 @@ class ResourceManager(object):
         """
         if not labels_list:
             return
-
+        lowercase_labels = {'csys-obj-type'}
         current_time = datetime.utcnow()
         for key, value in labels_list:
-            if key.startswith('csys-'):
+            if key.lower() in lowercase_labels:
                 key = key.lower()
                 value = value.lower()
             new_label = {'key': key,


### PR DESCRIPTION
Other csys- labels can contain things that SHOULD be mixed-case,
eg deployment ids :)