### PR TITLE
RD-3703 Dequeue create-dep-env before other workflows

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -65,8 +65,6 @@ class ResourceManager(object):
 
     def __init__(self, sm=None):
         self.sm = sm or get_storage_manager()
-        self._cached_executions_query = None
-        self._cached_executions_query_with_deployment = None
 
     def list_executions(self, include=None, is_include_system_workflows=False,
                         filters=None, pagination=None, sort=None,
@@ -275,65 +273,58 @@ class ResourceManager(object):
             return []
 
     def _queued_executions_query(self, with_deployment_id):
-        if (
-            self._cached_executions_query is None or
-            self._cached_executions_query_with_deployment is None
-        ):
-            executions = aliased(models.Execution)
+        executions = aliased(models.Execution)
 
-            queued_non_system_filter = db.and_(
-                executions.status == ExecutionState.QUEUED,
-                executions.is_system_workflow.is_(False)
+        queued_non_system_filter = db.and_(
+            executions.status == ExecutionState.QUEUED,
+            executions.is_system_workflow.is_(False)
+        )
+
+        # fetch only execution that:
+        # - are either create-dep-env (priority!)
+        # - belong to deployments that have none of:
+        #   - active executions
+        #   - queued create-dep-env executions
+        other_execs_in_deployment_filter = db.or_(
+            executions.workflow_id == 'create_deployment_environment',
+            ~models.Execution.query
+            .filter(
+                models.Execution._deployment_fk ==
+                executions._deployment_fk,
             )
-
-            # fetch only execution that:
-            # - are either create-dep-env (priority!)
-            # - belong to deployments that have none of:
-            #   - active executions
-            #   - queued create-dep-env executions
-            other_execs_in_deployment_filter = db.or_(
-                executions.workflow_id == 'create_deployment_environment',
-                ~models.Execution.query
-                .filter(
-                    models.Execution._deployment_fk ==
-                    executions._deployment_fk,
-                )
-                .filter(
-                    db.or_(
-                        models.Execution.status.in_(
-                            ExecutionState.ACTIVE_STATES),
-                        db.and_(
-                            models.Execution.status == ExecutionState.QUEUED,
-                            models.Execution.workflow_id ==
-                            'create_deployment_environment'
-                        )
+            .filter(
+                db.or_(
+                    models.Execution.status.in_(
+                        ExecutionState.ACTIVE_STATES),
+                    db.and_(
+                        models.Execution.status == ExecutionState.QUEUED,
+                        models.Execution.workflow_id ==
+                        'create_deployment_environment'
                     )
                 )
-                .exists()
             )
+            .exists()
+        )
 
-            queued_query = (
-                db.session.query(executions)
-                .filter(queued_non_system_filter)
-                .filter(other_execs_in_deployment_filter)
-                .outerjoin(executions.execution_groups)
-                .with_for_update(of=executions)
-            )
+        queued_query = (
+            db.session.query(executions)
+            .filter(queued_non_system_filter)
+            .filter(other_execs_in_deployment_filter)
+            .outerjoin(executions.execution_groups)
+            .with_for_update(of=executions)
+        )
 
-            self._cached_executions_query = (
-                queued_query
-                .order_by(executions.created_at.asc())
-            )
-            self._cached_executions_query_with_deployment = (
+        if with_deployment_id:
+            return (
                 queued_query
                 .order_by(executions._deployment_fk != db.bindparam('dep_id'))
                 .order_by(executions.created_at.asc())
-
             )
-        if with_deployment_id:
-            return self._cached_executions_query_with_deployment
         else:
-            return self._cached_executions_query
+            return (
+                queued_query
+                .order_by(executions.created_at.asc())
+            )
 
     def _get_queued_executions(self, deployment_storage_id):
         sort_by = {'created_at': 'asc'}

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -16,7 +16,6 @@
 import mock
 import uuid
 import hashlib
-import pytest
 import unittest
 from itertools import dropwhile
 from datetime import datetime, timedelta
@@ -1118,7 +1117,6 @@ class ExecutionQueueingTests(BaseServerTestCase):
         assert sm_exc2.status in (
             ExecutionState.PENDING, ExecutionState.TERMINATED)
 
-    @pytest.mark.xfail
     def test_install_before_create(self):
         # make a create_dep_env execution, and an install execution; the
         # create_dep_env for the new deployment cannot run, because it's in
@@ -1167,7 +1165,7 @@ class ExecutionQueueingTests(BaseServerTestCase):
         new_dep.create_execution = create_exc
         new_dep.latest_execution = create_exc
         create_group.executions.append(create_exc)
-        install_exc = models.Execution(
+        models.Execution(
             id=f'install_{new_dep.id}',
             workflow_id='install',
             deployment=new_dep,

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -16,6 +16,7 @@
 import mock
 import uuid
 import hashlib
+import pytest
 import unittest
 from itertools import dropwhile
 from datetime import datetime, timedelta
@@ -960,6 +961,7 @@ class ExecutionQueueingTests(BaseServerTestCase):
                 status=ExecutionState.TERMINATED,
             )
             self.sm.put(self.execution1)
+            self.bp = bp
 
     def _get_queued(self):
         return list(
@@ -1115,3 +1117,63 @@ class ExecutionQueueingTests(BaseServerTestCase):
         assert 'nonexistent' in sm_exc.error
         assert sm_exc2.status in (
             ExecutionState.PENDING, ExecutionState.TERMINATED)
+
+    @pytest.mark.xfail
+    def test_install_before_create(self):
+        # make a create_dep_env execution, and an install execution; the
+        # create_dep_env for the new deployment cannot run, because it's in
+        # an exec-group that is already full. The install for the new dep
+        # could run, but we check that it MUST NOT run, because create-dep-env
+        # hasn't finished yet (or even started)
+        create_group = models.ExecutionGroup(
+            id='create_group',
+            workflow_id='create_deployment_environment',
+            concurrency=1,
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        old_dep = models.Deployment(
+            id='old_dep',
+            blueprint=self.bp,
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        create_exc = models.Execution(
+            id=f'create_{old_dep.id}',
+            workflow_id='create_deployment_environment',
+            deployment=old_dep,
+            status=ExecutionState.STARTED,
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        old_dep.create_execution = create_exc
+        old_dep.latest_execution = create_exc
+        create_group.executions.append(create_exc)
+
+        new_dep = models.Deployment(
+            id='new_dep',
+            blueprint=self.bp,
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        create_exc = models.Execution(
+            id=f'create_{new_dep.id}',
+            workflow_id='create_deployment_environment',
+            deployment=new_dep,
+            status=ExecutionState.QUEUED,
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        new_dep.create_execution = create_exc
+        new_dep.latest_execution = create_exc
+        create_group.executions.append(create_exc)
+        install_exc = models.Execution(
+            id=f'install_{new_dep.id}',
+            workflow_id='install',
+            deployment=new_dep,
+            status=ExecutionState.QUEUED,
+            creator=self.user,
+            tenant=self.tenant,
+        )
+
+        assert self._get_queued() == []


### PR DESCRIPTION
Make sure that create-dep-env is dequeued before executions of
any other workflows that use that deployment.

The "only dequeue executions that belong to deployments who
have no active executions" check is just not enough.
Instead, only dequeue executions, who:
- are either create-dep-env (so their deployment will NOT possibly 
  have any other executions running)
- belong to deployments that have:
  - no other executions _running_
  - no create-dep-env _queued_

That is to say, if a create-dep-env is even queued, then no other
executions for that deployment can possibly run.
Trying to run them would result in just an error, and indeed we
used to just throw an error.