### PR TITLE
RD-3663 Dequeue more executions

### DIFF
--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -162,7 +162,7 @@ class Config(object):
 
     # max number of threads that will be used in a `restore snapshot` wf
     snapshot_restore_threads = Setting('snapshot_restore_threads', default=15)
-
+    max_concurrent_workflows = Setting('max_concurrent_workflows', default=20)
     warnings = Setting('warnings', default=[])
 
     _logger = None

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -422,6 +422,8 @@ class ResourceManager(object):
         seen_deployments = set()
 
         for execution in queued_executions:
+            if total >= config.instance.max_concurrent_workflows:
+                break
             for group in execution.execution_groups:
                 if group._storage_id not in groups:
                     groups[group._storage_id] = [0, group.concurrency]
@@ -437,6 +439,7 @@ class ResourceManager(object):
             for g in execution.execution_groups:
                 groups[g._storage_id][0] += 1
             seen_deployments.add(execution._deployment_fk)
+            total += 1
             yield execution
 
     def _validate_execution_update(self, current_status, future_status):

--- a/rest-service/manager_rest/storage/models.py
+++ b/rest-service/manager_rest/storage/models.py
@@ -64,6 +64,7 @@ from .resource_models import (
     BlueprintsFilter,
     DeploymentGroup,
     ExecutionGroup,
+    executions_groups_executions_table,
     ExecutionSchedule,
     BlueprintLabel,
     DeploymentGroupLabel,

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1401,6 +1401,14 @@ class ExecutionGroup(CreatedAtMixin, SQLResourceBase):
             executions[:self.concurrency], force=force, queue=True)
 
 
+# re-declaring the table for the group.executions m2m, for easy access
+executions_groups_executions_table = db.table(
+    'execution_groups_executions',
+    db.Column('execution_group_id', db.Integer),
+    db.Column('execution_id', db.Integer)
+)
+
+
 class ExecutionSchedule(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'execution_schedules'
     __table_args__ = (


### PR DESCRIPTION
Make sure to check non-active exec-groups, when dequeuing executions.
Otherwise, already-at-capacity groups could be all that's returned from
our query, and we'd dequeue nothing.

This is the reason we used to always de-generate to running, like, 5
executions at a time, tops, even if there were thousands queued.

With this change, we'll dequeue up to... well, up to the new setting.
By default it's 20, which is still quite a lot, but if you know you'll be
running very simple workflows, you might as well crank it up.
