### PR TITLE
RD-3757 Refresh the deployment before starting an execution

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1069,6 +1069,14 @@ class ResourceManager(object):
                 self._workflow_queued(exc)
                 continue
 
+            if exc.deployment \
+                    and exc.workflow_id != 'create_deployment_environment':
+                # refresh in case create-dep-env JUST finished, between the
+                # time we fetched the deployment, and checked that we don't
+                # need to queue. No need for create-dep-env, because the
+                # deployment is not persistent yet in that case
+                self.sm.refresh(exc.deployment)
+
             message = exc.render_message(
                 wait_after_fail=wait_after_fail,
                 bypass_maintenance=bypass_maintenance


### PR DESCRIPTION
In case create-dep-env finished between:

  - the time we checked for if we need to queue (and decided that we
    don't, because create-dep-env finished)
  - and the time we fetched the deployment (where it didn't have
    workflows populated yet, because create-dep-env didnt finish yet)

then the execution would attempt to run, but won't be able to, because
we have an old version of the deployment fetched in memory.
Refresh it to get the workflows.