### PR TITLE
RD-3761 check_deployment_delete: handle external source

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -2237,8 +2237,13 @@ class InterDeploymentDependencies(BaseDeploymentDependencies):
         else:
             dep_type = 'deployment'
             dep_node = '<unknown node>'
+        deployment = '<unknown deployment>'
+        if self.source_deployment:
+            deployment = self.source_deployment.id
+        elif self.external_source:
+            deployment = f'EXTERNAL:{self.external_source}'
         return {
-            'deployment': self.source_deployment.id,
+            'deployment': deployment,
             'dependency_type': dep_type,
             'dependent_node': dep_node,
             'tenant': self.tenant_name
@@ -2252,8 +2257,9 @@ class InterDeploymentDependencies(BaseDeploymentDependencies):
             'deployment': 'uses capabilities of'
         }[summary['dependency_type']]
         dep_node = summary['dependent_node']
+        deployment = summary['deployment']
         return (
-            f'Deployment `{self.source_deployment.id}` {type_message} '
+            f'Deployment `{deployment}` {type_message} '
             f'the current deployment in its node `{dep_node}`'
         )
 

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -237,6 +237,29 @@ class TestCheckDeploymentDelete(base_test.BaseServerTestCase):
         )
         self.rm.check_deployment_delete(dep1)  # doesnt throw
 
+    def test_external_dependency_source(self):
+        dep1 = self._deployment(id='dep1')
+        models.InterDeploymentDependencies(
+            target_deployment=dep1,
+            dependency_creator='',
+            external_source='external-source',
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        with self.assertRaises(manager_exceptions.DependentExistsError):
+            self.rm.check_deployment_delete(dep1)
+
+    def test_external_dependency_target(self):
+        dep1 = self._deployment(id='dep1')
+        models.InterDeploymentDependencies(
+            source_deployment=dep1,
+            dependency_creator='',
+            external_target='external-target',
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        self.rm.check_deployment_delete(dep1)  # doesnt throw
+
 
 class TestValidateExecutionDependencies(base_test.BaseServerTestCase):
     def setUp(self):
@@ -381,6 +404,43 @@ class TestValidateExecutionDependencies(base_test.BaseServerTestCase):
             id='exc1',
             workflow_id='uninstall',
             deployment=dep2,
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        self.rm._verify_dependencies_not_affected(exc, False)  # doesnt throw
+
+    def test_external_dependency_source(self):
+        dep1 = self._deployment(id='dep1')
+        models.InterDeploymentDependencies(
+            target_deployment=dep1,
+            dependency_creator='',
+            external_source='external-source',
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        exc = models.Execution(
+            id='exc1',
+            workflow_id='uninstall',
+            deployment=dep1,
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        with self.assertRaises(manager_exceptions.DependentExistsError):
+            self.rm._verify_dependencies_not_affected(exc, False)
+
+    def test_external_dependency_target(self):
+        dep1 = self._deployment(id='dep1')
+        models.InterDeploymentDependencies(
+            source_deployment=dep1,
+            dependency_creator='',
+            external_target='external-target',
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        exc = models.Execution(
+            id='exc1',
+            workflow_id='uninstall',
+            deployment=dep1,
             creator=self.user,
             tenant=self.tenant,
         )


### PR DESCRIPTION
If external_source is set, there won't be a `self.deployment`,
so attempting to access `self.deployment.id` is futile.
In that case, format the message a bit differently.