### PR TITLE
RD-3674 Declare the check_status operation

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -38,6 +38,7 @@ node_types:
       cloudify.interfaces.monitoring:
         start: {}
         stop: {}
+        check_status: {}
 
   # A host (physical / virtual or LXC) in a topology
   cloudify.nodes.Compute:


### PR DESCRIPTION
Under the cloudify.interfaces.monitoring interface. This seems to be
the most fitting interface.