### PR TITLE
Speed up: rewrite several infrastructure/ tests

### DIFF
--- a/rest-service/manager_rest/test/infrastructure/base_list_test.py
+++ b/rest-service/manager_rest/test/infrastructure/base_list_test.py
@@ -12,71 +12,97 @@
 #  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
-import tempfile
-import os
-import shutil
-
+from datetime import datetime
+from cloudify.models_states import DeploymentModificationState, ExecutionState
+from manager_rest.storage import models
 from manager_rest.test.base_test import BaseServerTestCase
-
-import wagon
 
 
 class BaseListTest(BaseServerTestCase):
 
-    def _put_deployment_modification(self, deployment_id,
+    def _node(self, node_id, **kwargs):
+        node_params = {
+            'id': node_id,
+            'type': 'type1',
+            'number_of_instances': 1,
+            'deploy_number_of_instances': 1,
+            'max_number_of_instances': 1,
+            'min_number_of_instances': 1,
+            'planned_number_of_instances': 1,
+            'creator': self.user,
+            'tenant': self.tenant,
+        }
+        node_params.update(kwargs)
+        return models.Node(**node_params)
+
+    def _instance(self, instance_id, **kwargs):
+        instance_params = {
+            'id': instance_id,
+            'state': 'uninitialized',
+            'index': 1,
+            'creator': self.user,
+            'tenant': self.tenant,
+        }
+        instance_params.update(kwargs)
+        return models.NodeInstance(**instance_params)
+
+    def _put_deployment_modification(self, deployment,
                                      modified_nodes=None,
                                      node_instances=None,
                                      nodes=None):
-        resource_path = '/deployment-modifications'
-        data = {'deployment_id': deployment_id,
-                'modified_nodes': modified_nodes or {},
-                'node_instances': node_instances or {},
-                'nodes': nodes or {}}
-        return self.post(resource_path, data).json
-
-    def _mark_deployment_modification_finished(self, modification_id=None):
-        resource_path = '/deployment-modifications/{0}/finish'.format(
-            modification_id)
-        data = {'modification_id': modification_id}
-        return self.post(resource_path, data).json
-
-    def _put_n_deployment_modifications(self, id_prefix,
-                                        number_of_modifications,
-                                        skip_creation=None):
-        self._put_n_deployments(id_prefix,
-                                number_of_modifications,
-                                skip_creation=skip_creation,
-                                add_modification=True)
+        models.DeploymentModification(
+            modified_nodes=modified_nodes or {},
+            node_instances=node_instances or {},
+            status=DeploymentModificationState.FINISHED,
+            deployment=deployment,
+            creator=self.user,
+            tenant=self.tenant,
+        )
 
     def _put_n_plugins(self, number_of_plugins):
-        for i in range(0, number_of_plugins):
-            tmpdir = tempfile.mkdtemp(prefix='test-pagination-')
-            with open(os.path.join(tmpdir, 'setup.py'), 'w') as f:
-                f.write('from setuptools import setup\n')
-                f.write('setup(name="cloudify-script-plugin", version={0})'
-                        .format(i))
-            plugin_path = wagon.create(tmpdir, archive_destination_dir=tmpdir)
-            yaml_path = self.get_full_path('mock_blueprint/plugin.yaml')
-            zip_path = self.zip_files([plugin_path, yaml_path])
-            self.post_file('/plugins', zip_path)
-            shutil.rmtree(tmpdir)
+        for i in range(number_of_plugins):
+            models.Plugin(
+                id=f'plugin{i}',
+                archive_name='',
+                package_name='cloudify-script-plugin',
+                wheels=[],
+                uploaded_at=datetime.now(),
+                creator=self.user,
+                tenant=self.tenant,
+            )
 
-    def _put_n_deployments(self, id_prefix,
-                           number_of_deployments,
-                           skip_creation=None,
-                           add_modification=None):
-        for i in range(0, number_of_deployments):
-            deployment_id = "{0}{1}_{2}".format(id_prefix, str(i),
-                                                'deployment')
-            blueprint_id = "{0}{1}_{2}".format(id_prefix, str(i), 'blueprint')
-            if not skip_creation:
-                self.put_deployment(deployment_id=deployment_id,
-                                    blueprint_id=blueprint_id)
-            if add_modification:
-                response = self._put_deployment_modification(
-                    deployment_id=deployment_id)
-                self._mark_deployment_modification_finished(
-                    modification_id=response['id'])
+    def _put_n_deployments(self, id_prefix, number_of_deployments):
+        deployments = []
+        for i in range(number_of_deployments):
+            blueprint_id = f"{id_prefix}{i}_blueprint"
+            bp = models.Blueprint(
+                id=blueprint_id,
+                creator=self.user,
+                tenant=self.tenant,
+            )
+            bp.upload_execution = models.Execution(
+                workflow_id='upload_blueprint',
+                status=ExecutionState.TERMINATED,
+                creator=self.user,
+                tenant=self.tenant,
+            )
+            deployment_id = f"{id_prefix}{i}_deployment"
+
+            deployment = models.Deployment(
+                id=deployment_id,
+                blueprint=bp,
+                scaling_groups={},
+                creator=self.user,
+                tenant=self.tenant,
+            )
+            exc = deployment.make_create_environment_execution()
+            exc.status = ExecutionState.TERMINATED
+            node1 = self._node('vm', deployment=deployment)
+            node2 = self._node('http_web_server', deployment=deployment)
+            self._instance('vm_1', node=node1)
+            self._instance('http_web_server_1', node=node2)
+            deployments.append(deployment)
+        return deployments
 
     def _put_n_snapshots(self, number_of_snapshots, prefix=None, suffix=None):
         prefix = prefix or 'oh-snap'

--- a/rest-service/manager_rest/test/infrastructure/test_list_pagination.py
+++ b/rest-service/manager_rest/test/infrastructure/test_list_pagination.py
@@ -62,12 +62,10 @@ class ResourceListTestCase(BaseListTest):
                               sort_keys=['id', 'deployment_id'])
 
     def test_deployment_modifications_list_paginated(self):
-        self._put_n_deployments(id_prefix='test', number_of_deployments=2)
-        response = self._put_deployment_modification(
-            deployment_id='test0_deployment')
-        self._mark_deployment_modification_finished(
-            modification_id=response['id'])
-        self._put_deployment_modification(deployment_id='test1_deployment')
+        deployments = self._put_n_deployments(
+            id_prefix='test', number_of_deployments=2)
+        for dep in deployments:
+            self._put_deployment_modification(dep)
         self._test_pagination(self.client.deployment_modifications.list, 2,
                               sort_keys=['id', 'deployment_id'])
 


### PR DESCRIPTION
This speeds them up MASSIVELY, the whole directory used to be on the
order of 4 minutes, but it's on the order of 1 minute now.

The idea is, instead of creating actual real plugins etc, just to
test listing and filtering, only create the models directly.