### PR TITLE
RD-3904 dep-update: keep non-plan IDDs

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2395,7 +2395,8 @@ class ResourceManager(object):
                         ExecutionState.QUEUED
                     ]),
                     models.Execution.workflow_id.in_([
-                        'stop', 'uninstall', 'update'
+                        'stop', 'uninstall', 'update',
+                        'csys_new_deployment_update'
                     ])
                 )
                 .exists()
@@ -2405,7 +2406,9 @@ class ResourceManager(object):
         return children.all() + component_creators.all()
 
     def _verify_dependencies_not_affected(self, execution, force):
-        if execution.workflow_id not in ['stop', 'uninstall', 'update']:
+        if execution.workflow_id not in [
+            'stop', 'uninstall', 'update', 'csys_new_deployment_update'
+        ]:
             return
         # if we're in the middle of an execution initiated by the component
         # creator, we'd like to drop the component dependency from the list
@@ -2425,7 +2428,7 @@ class ResourceManager(object):
                 formatted_dependencies)
             return
         # If part of a deployment update - mark the update as failed
-        if execution.workflow_id == 'update':
+        if execution.workflow_id in ('update', 'csys_new_deployment_update'):
             dep_update = self.sm.get(
                 models.DeploymentUpdate,
                 None,

--- a/tests/integration_tests/resources/dsl/deployment_update/modify_idd/base/modify_idd_base.yaml
+++ b/tests/integration_tests/resources/dsl/deployment_update/modify_idd/base/modify_idd_base.yaml
@@ -1,0 +1,16 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - cloudify/types/types.yaml
+
+node_templates:
+  resource_node1:
+    type: cloudify.nodes.SharedResource
+    properties:
+      resource_config:
+        deployment:
+          id: shared1
+
+outputs:
+  out1:
+    value: {get_capability: [shared1, cap1]}

--- a/tests/integration_tests/resources/dsl/deployment_update/modify_idd/modification/modify_idd_modification.yaml
+++ b/tests/integration_tests/resources/dsl/deployment_update/modify_idd/modification/modify_idd_modification.yaml
@@ -1,0 +1,16 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - cloudify/types/types.yaml
+
+node_templates:
+  resource_node1:
+    type: cloudify.nodes.SharedResource
+    properties:
+      resource_config:
+        deployment:
+          id: shared2
+
+outputs:
+  out1:
+    value: {get_capability: [shared2, cap1]}

--- a/tests/integration_tests/resources/dsl/deployment_update/modify_idd/shared.yaml
+++ b/tests/integration_tests/resources/dsl/deployment_update/modify_idd/shared.yaml
@@ -1,0 +1,8 @@
+tosca_definitions_version: 'cloudify_dsl_1_3'
+
+imports:
+  - cloudify/types/types.yaml
+
+node_templates:
+  node1:
+    type: cloudify.nodes.Root


### PR DESCRIPTION
Let's not lose component/sharedresource IDDs in a dep-update.

Those aren't in the plan, so that means we can't just blindly
overwrite all the IDDs of a deployment with just the ones from
the new plan, we need to keep some as well.

This isn't perfect just yet, but RD-3903 will make it better, someday.