### PR TITLE
RD-3909 dep-up: drop removed inputs

### DIFF
--- a/tests/integration_tests/resources/dsl/deployment_update/modify_inputs/base/modify_inputs_base.yaml
+++ b/tests/integration_tests/resources/dsl/deployment_update/modify_inputs/base/modify_inputs_base.yaml
@@ -4,6 +4,8 @@ imports:
   - https://cloudify.co/spec/cloudify/5.0.5/types.yaml
 
 inputs:
+  test_string_toremove:
+    default: "xxx"
   test_list:
     default: "initial_input"
 

--- a/tests/integration_tests/resources/dsl/deployment_update/modify_inputs/modification/modify_inputs_modification.yaml
+++ b/tests/integration_tests/resources/dsl/deployment_update/modify_inputs/modification/modify_inputs_modification.yaml
@@ -4,9 +4,12 @@ imports:
   - https://cloudify.co/spec/cloudify/5.0.5/types.yaml
 
 inputs:
+  test_string_new:
+    default: "xxx"
   test_list:
-    - update_input1
-    - update_input2
+    default:
+      - update_input1
+      - update_input2
 
 node_types:
 

--- a/workflows/cloudify_system_workflows/deployment_update/workflow.py
+++ b/workflows/cloudify_system_workflows/deployment_update/workflow.py
@@ -389,10 +389,9 @@ def set_deployment_attributes(*, update_id):
         'outputs': dep_up.deployment_plan['outputs'],
         'description': dep_up.deployment_plan['description'],
         'capabilities': dep_up.deployment_plan['capabilities'],
+        'inputs': dep_up.deployment_plan['inputs'],
         'runtime_only_evaluation': dep_up.runtime_only_evaluation,
     }
-    if dep_up.new_inputs:
-        new_attributes['inputs'] = dep_up.new_inputs
     if dep_up.new_blueprint_id:
         new_attributes['blueprint_id'] = dep_up.new_blueprint_id
         # in the currently-running execution, update the current context as

--- a/workflows/cloudify_system_workflows/deployment_update/workflow.py
+++ b/workflows/cloudify_system_workflows/deployment_update/workflow.py
@@ -27,10 +27,13 @@ def prepare_plan(*, update_id):
         dep = client.deployments.get(dep_up.deployment_id)
         bp = client.blueprints.get(dep.blueprint_id)
 
+    new_inputs = {
+        k: v for k, v in dep_up.new_inputs.items() if k in bp.plan['inputs']
+    }
     deployment_plan = tasks.prepare_deployment_plan(
         bp.plan,
         client.secrets.get,
-        dep_up.new_inputs,
+        new_inputs,
         runtime_only_evaluation=dep_up.runtime_only_evaluation
     )
     client.deployment_updates.set_attributes(update_id, plan=deployment_plan)

--- a/workflows/cloudify_system_workflows/deployment_update/workflow.py
+++ b/workflows/cloudify_system_workflows/deployment_update/workflow.py
@@ -28,7 +28,8 @@ def prepare_plan(*, update_id):
         bp = client.blueprints.get(dep.blueprint_id)
 
     new_inputs = {
-        k: v for k, v in dep_up.new_inputs.items() if k in bp.plan['inputs']
+        k: v for k, v in dep_up.new_inputs.items()
+        if k in bp.plan.get('inputs', {})
     }
     deployment_plan = tasks.prepare_deployment_plan(
         bp.plan,


### PR DESCRIPTION
Make sure to keep new deployment.inputs correct: drop ones that
were removed, and add new ones (even if the old blueprint didnt
declare any)