### PR TITLE
RD-3908 Add `resource_tags` to deployments

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/8e8314b1d848_6_2_to_6_3.py
+++ b/resources/rest-service/cloudify/migrations/versions/8e8314b1d848_6_2_to_6_3.py
@@ -76,9 +76,11 @@ def upgrade():
     _add_max_concurrent_config()
     _add_system_properties_column()
     _add_plugins_labels_and_tags_columns()
+    _add_deployment_resource_tags_column()
 
 
 def downgrade():
+    _drop_deployment_resource_tags_column()
     _drop_plugins_labels_and_tags_columns()
     _drop_system_properties_column()
     _drop_max_concurrent_config()
@@ -347,3 +349,14 @@ def _drop_plugins_labels_and_tags_columns():
     op.drop_column('plugins', 'blueprint_labels')
     op.drop_column('plugins', 'labels')
     op.drop_column('plugins', 'resource_tags')
+
+
+def _add_deployment_resource_tags_column():
+    op.add_column(
+        'deployments',
+        sa.Column('resource_tags', JSONString()),
+    )
+
+
+def _drop_deployment_resource_tags_column():
+    op.drop_column('deployments', 'resource_tags')

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -299,6 +299,7 @@ class DeploymentsId(resources_v1.DeploymentsId):
                 'description', 'workflows', 'inputs', 'policy_types',
                 'policy_triggers', 'groups', 'scaling_groups', 'outputs',
                 'capabilities', 'display_name', 'runtime_only_evaluation',
+                'resource_tags',
             }
             allow_change = {'display_name'}
             for attrib in allowed_attribs:

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -361,7 +361,7 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         v2=['scaling_groups']
     )
 
-    # This will be overriden when a workdir is being retrieved
+    # This will be overridden when a workdir is being retrieved
     workdir_zip = None
 
     description = db.Column(db.Text)
@@ -410,6 +410,7 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         db.Text, nullable=False, index=True,
         default=lambda ctx: ctx.get_current_parameters().get('id')
     )
+    resource_tags = db.Column(JSONString)
     _blueprint_fk = foreign_key(Blueprint._storage_id)
     _site_fk = foreign_key(Site._storage_id,
                            nullable=True,

--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -155,7 +155,7 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         self.sm.put(dep)
 
         serialized_dep = dep.to_response()
-        self.assertEqual(39, len(serialized_dep))
+        self.assertEqual(40, len(serialized_dep))
         self.assertEqual(dep.id, serialized_dep['id'])
         self.assertEqual(dep.created_at, serialized_dep['created_at'])
         self.assertEqual(dep.updated_at, serialized_dep['updated_at'])
@@ -163,6 +163,7 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         self.assertEqual(dep.permalink, serialized_dep['permalink'])
         self.assertEqual(dep.tenant.name, serialized_dep['tenant_name'])
         self.assertEqual(dep.description, None)
+        self.assertEqual(dep.resource_tags, None)
 
         # `blueprint_id` isn't a regular column, but a relationship
         serialized_dep.pop('blueprint_id')

--- a/workflows/cloudify_system_workflows/deployment_environment.py
+++ b/workflows/cloudify_system_workflows/deployment_environment.py
@@ -125,6 +125,7 @@ def create(ctx, labels=None, inputs=None, skip_plugins_validation=False,
         outputs=deployment_plan['outputs'],
         capabilities=deployment_plan.get('capabilities', {}),
         labels=labels_to_create,
+        resource_tags=deployment_plan.get('resource_tags'),
     )
 
     ctx.logger.info('Creating %d nodes', len(nodes))


### PR DESCRIPTION
A new column per deployment is added.  Values come from `blueprint.plan['resource_tags']`