### PR TITLE
RD-3890 Various fixes to consumer-id labels

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1683,7 +1683,9 @@ class ResourceManager(object):
                 # Add deployment to parent's consumers
                 existing_consumer_label = self.sm.list(
                     models.DeploymentLabel,
-                    filters={'key': 'csys-consumer-id', 'value': dep.id}
+                    filters={'key': 'csys-consumer-id',
+                             'value': dep.id,
+                             'deployment': parent}
                 )
                 if not existing_consumer_label:
                     new_label = {'key': 'csys-consumer-id',


### PR DESCRIPTION
1. A component should be the consumer of its creator deployment (by parent label) but not vice-versa! - i.e. a "component.*" type IDD shouldn't register a consumer.
2. Fixed skipping on existing consumer label to only skip if the existing label is for the same source AND target
3. Fixed shared resources not adding a consumer label by themselves (as opposed to by a "get_capability" IDD which may not necessarily exist)