### PR TITLE
RD-3887 Synchronous dep-update preview

### DIFF
--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -35,7 +35,11 @@ from manager_rest.utils import create_filter_params_list_description
 
 from manager_rest.resource_manager import get_resource_manager
 from .. import rest_decorators
-from ..rest_utils import verify_and_convert_bool, get_json_and_verify_params
+from ..rest_utils import (
+    verify_and_convert_bool,
+    get_json_and_verify_params,
+    wait_for_execution
+)
 
 
 class DeploymentUpdate(SecuredResource):
@@ -124,6 +128,9 @@ class DeploymentUpdate(SecuredResource):
                     exec_group.executions.append(update_exec)
                 db.session.commit()
         workflow_executor.execute_workflow(messages)
+        if preview:
+            wait_for_execution(sm, dep_up.execution.id)
+            sm.refresh(dep_up)
         return dep_up
 
     @staticmethod

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/__init__.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/__init__.py
@@ -32,7 +32,8 @@ class DeploymentUpdateBase(AgentlessTestCase):
         dep_update = \
             self.client.deployment_updates.update_with_existing_blueprint(
                 deployment_id, blueprint_id, preview=preview, **kwargs)
-        self._wait_for_update(dep_update)
+        if not preview:
+            self._wait_for_update(dep_update)
         return dep_update
 
     def _wait_for_update(self, dep_update):


### PR DESCRIPTION
It used to be synchronous before, let's keep it this way for now.
This also allows me to revert the test to the previous state, in which
it didn't wait for previews.