### PR TITLE
RD-3727 Dequeue executions after exiting maint-mode

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -31,6 +31,7 @@ from cloudify_rest_client.client import CloudifyClient
 from dsl_parser import constants, tasks
 
 from manager_rest import premium_enabled
+from manager_rest.maintenance import get_maintenance_state
 from manager_rest.constants import (DEFAULT_TENANT_NAME,
                                     FILE_SERVER_BLUEPRINTS_FOLDER,
                                     FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER,
@@ -172,7 +173,8 @@ class ResourceManager(object):
             # then, the execution could've been deleted already
             del execution
 
-        if status in ExecutionState.END_STATES:
+        if status in ExecutionState.END_STATES \
+                and get_maintenance_state() is None:
             self.start_queued_executions()
 
         # If the execution is a deployment update, and the status we're

--- a/rest-service/manager_rest/rest/resources_v2_1/maintenance_mode.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/maintenance_mode.py
@@ -17,6 +17,7 @@
 from datetime import datetime
 from flask_security import current_user
 
+from manager_rest.resource_manager import get_resource_manager
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
 from manager_rest.constants import (MAINTENANCE_MODE_ACTIVATED,
@@ -87,7 +88,9 @@ class MaintenanceModeAction(SecuredResource):
         elif maintenance_action == 'deactivate':
             if not state:
                 return {'status': MAINTENANCE_MODE_DEACTIVATED}, 304
-            return remove_maintenance_state()
+            rv = remove_maintenance_state()
+            get_resource_manager().start_queued_executions()
+            return rv
 
         else:
             valid_actions = ['activate', 'deactivate']


### PR DESCRIPTION
No use dequeueing executions while we're in maintenance mode,
they'll just error out starting.
Instead, dequeue them when exiting maintenance mode.