### PR TITLE
RD-3855 Declare the check_drift operation

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -29,6 +29,7 @@ node_types:
         delete: {}
         postdelete: {}
         pull: {}
+        check_drift: {}
       cloudify.interfaces.validation:
         create: {}
         delete: {}


### PR DESCRIPTION
Just declaring it is pretty simple, isn't it

This is going to be the operation that checks for "configuration drift",
ie. every node is going to examine it's actual state, and compare with
the declared state (ie. properties)