### PR TITLE
RD-3855 Declare the check_drift operation for rels

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -464,12 +464,14 @@ relationships:
         postconfigure: {}
         establish: {}
         unlink: {}
+        check_drift: {}
     target_interfaces:
       cloudify.interfaces.relationship_lifecycle:
         preconfigure: {}
         postconfigure: {}
         establish: {}
         unlink: {}
+        check_drift: {}
     properties:
       connection_type:
         default: all_to_all


### PR DESCRIPTION
Like #3463 but for relationships.
Each relationship can also check its state and compare it to the
declared configuration. (eg. is a volume mounted at the declared
location, or somewhere else?)