### PR TITLE
RD-3941 Pass the amqp cert's content

### DIFF
--- a/amqp-postgres/amqp_postgres/main.py
+++ b/amqp-postgres/amqp_postgres/main.py
@@ -20,15 +20,15 @@ CONFIG_PATH = '/opt/manager/cloudify-rest.conf'
 def _create_connections():
     acks_queue = queue.Queue()
     cfy_config = config.instance
-    port = BROKER_PORT_SSL if cfy_config.amqp_ca_path else BROKER_PORT_NO_SSL
+    port = BROKER_PORT_SSL if cfy_config.amqp_ca else BROKER_PORT_NO_SSL
     amqp_client = get_client(
         amqp_host=cfy_config.amqp_host,
         amqp_user=cfy_config.amqp_username,
         amqp_pass=cfy_config.amqp_password,
         amqp_vhost='/',
         amqp_port=port,
-        ssl_enabled=bool(cfy_config.amqp_ca_path),
-        ssl_cert_path=cfy_config.amqp_ca_path,
+        ssl_enabled=bool(cfy_config.amqp_ca),
+        ssl_cert_path=cfy_config.amqp_ca,
         cls=AckingAMQPConnection
     )
     amqp_client.acks_queue = acks_queue

--- a/amqp-postgres/amqp_postgres/main.py
+++ b/amqp-postgres/amqp_postgres/main.py
@@ -28,7 +28,7 @@ def _create_connections():
         amqp_vhost='/',
         amqp_port=port,
         ssl_enabled=bool(cfy_config.amqp_ca),
-        ssl_cert_path=cfy_config.amqp_ca,
+        ssl_cert_data=cfy_config.amqp_ca,
         cls=AckingAMQPConnection
     )
     amqp_client.acks_queue = acks_queue

--- a/amqp-postgres/amqp_postgres/tests/test_amqp_postgres.py
+++ b/amqp-postgres/amqp_postgres/tests/test_amqp_postgres.py
@@ -106,7 +106,7 @@ class TestAMQPPostgres(BaseServerTestCase):
             host=instance.amqp_management_host,
             username=instance.amqp_username,
             password=instance.amqp_password,
-            verify=instance.amqp_ca_path
+            cadata=instance.amqp_ca,
         )
 
     def _create_execution(self, execution_id):

--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -1,4 +1,3 @@
-import atexit
 import itertools
 import jsonschema
 import os

--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -3,7 +3,6 @@ import itertools
 import jsonschema
 import os
 import requests
-import tempfile
 import time
 import yaml
 
@@ -93,7 +92,7 @@ class Config(object):
     amqp_management_host = Setting('amqp_management_host', from_db=False)
     amqp_username = Setting('amqp_username', from_db=False)
     amqp_password = Setting('amqp_password', from_db=False)
-    amqp_ca_path = Setting('amqp_ca_path', from_db=False)
+    amqp_ca = Setting('amqp_ca', from_db=False)
 
     # LDAP settings
     ldap_server = Setting('ldap_server')
@@ -229,10 +228,7 @@ class Config(object):
             self.amqp_username = broker.username
             self.amqp_password = broker.password
         if stored_brokers:
-            with tempfile.NamedTemporaryFile(delete=False, mode='w') as f:
-                f.write(stored_brokers[0].ca_cert_value)
-            self.amqp_ca_path = f.name
-            atexit.register(os.unlink, self.amqp_ca_path)
+            self.amqp_ca = stored_brokers[0].ca_cert_value
 
         stored_roles = session.query(
             models.Role.id,

--- a/rest-service/manager_rest/rest/resources_v3_1/agents.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/agents.py
@@ -243,5 +243,5 @@ class AgentsName(SecuredResource):
             host=instance.amqp_management_host,
             username=instance.amqp_username,
             password=instance.amqp_password,
-            verify=instance.amqp_ca_path
+            cadata=instance.amqp_ca
         )

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -605,7 +605,7 @@ class BaseServerTestCase(unittest.TestCase):
         test_config.amqp_host = 'localhost'
         test_config.amqp_username = 'guest'
         test_config.amqp_password = 'guest'
-        test_config.amqp_ca_path = None
+        test_config.amqp_ca = None
         test_config.amqp_management_host = 'localhost'
         return test_config
 

--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -288,7 +288,7 @@ def send_event(event, message_type):
         amqp_port=BROKER_PORT_SSL,
         amqp_vhost='/',
         ssl_enabled=True,
-        ssl_cert_path=config.instance.amqp_ca_path
+        ssl_cert_data=config.instance.amqp_ca,
     )
 
     events_publisher.publish_message(event, message_type)
@@ -329,7 +329,7 @@ def get_amqp_client():
         amqp_port=BROKER_PORT_SSL,
         amqp_vhost='/',
         ssl_enabled=True,
-        ssl_cert_path=config.instance.amqp_ca_path,
+        ssl_cert_data=config.instance.amqp_ca,
         connect_timeout=3,
     )
 

--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -46,7 +46,7 @@ def get_amqp_client(tenant=None):
         amqp_port=BROKER_PORT_SSL,
         amqp_vhost=vhost,
         ssl_enabled=True,
-        ssl_cert_path=config.instance.amqp_ca_path
+        ssl_cert_data=config.instance.amqp_ca,
     )
     return client
 

--- a/tests/integration_tests/resources/scripts/reset_storage.py
+++ b/tests/integration_tests/resources/scripts/reset_storage.py
@@ -41,11 +41,16 @@ AUTH_TOKEN_LOCATION = '/opt/mgmtworker/work/admin_token'
 
 
 def setup_amqp_manager():
+    kwargs = {}
+    if config.instance.amqp_ca:
+        kwargs['cadata'] = config.instance.amqp_ca
+    else:
+        kwargs['verify'] = DEFAULT_CA_CERT
     amqp_manager = AMQPManager(
         host=config.instance.amqp_management_host or "localhost",
         username=config.instance.amqp_username or "cloudify",
         password=config.instance.amqp_password or "c10udify",
-        verify=config.instance.amqp_ca_path or DEFAULT_CA_CERT,
+        **kwargs,
     )
     return amqp_manager
 

--- a/workflows/cloudify_system_workflows/snapshots/restore_amqp.py
+++ b/workflows/cloudify_system_workflows/snapshots/restore_amqp.py
@@ -30,6 +30,6 @@ with app.app_context():
         host=instance.amqp_management_host,
         username=instance.amqp_username,
         password=instance.amqp_password,
-        verify=instance.amqp_ca_path
+        cadata=instance.amqp_ca,
     )
     amqp_manager.sync_metadata()


### PR DESCRIPTION
Instead of creating a long-lived tempfile, pass it to the amqp client
(and rabbitmq api client) as just a string with the contents.

There's quite a few places!