### PR TITLE
RD-3994 Don't fail on SR uninstall failure

### DIFF
--- a/cloudify_types/cloudify_types/shared_resource/tests/test_shared_resource.py
+++ b/cloudify_types/cloudify_types/shared_resource/tests/test_shared_resource.py
@@ -73,6 +73,8 @@ class TestSharedResource(TestSharedResourceBase):
             .assert_not_called()
 
     @mock.patch('cloudify_types.shared_resource.operations.'
+                '_verify_source_deployment_in_consumers')
+    @mock.patch('cloudify_types.shared_resource.operations.'
                 '_checkin_resource_consumer')
     @mock.patch('cloudify_types.shared_resource.operations.'
                 '_checkout_resource_consumer')
@@ -80,7 +82,7 @@ class TestSharedResource(TestSharedResourceBase):
                 '.get_deployment_by_id',
                 return_value=True)
     def test_disconnecting_deployment_removes_deployment_dependency(
-            self, _, checkout, checkin):
+            self, _, checkout, checkin, verify_consumers):
         disconnect_deployment()
 
         self.cfy_mock_client.inter_deployment_dependencies.delete \


### PR DESCRIPTION
We want to be extra-careful when auto-uninstalling a deployment. Added here:
1. A sanity-check that issues a warning if the source deployment (i.e. the consumer of the shared resource) is not labeled as a consumer in the shared resource
2. A try-except around the uninstall of the shared resource. If the uninstall is blocked (because the last labeled consumer which triggers an uninstall of the resource is not _actually_ the last deployment which depends on the resource), we get an 400 error. In such case - don't fail the uninstall of the consumer, but issue an appropriate warning.

Reasons for this to happen:
1. Consumer labels were manually tampered with (we will eventually block this option)
2. Another deployment uses the resource as get-capability, not as a shared resource