### PR TITLE
RD-4002 Change on-demand-install to on-demand-install-off per product…

### DIFF
--- a/cloudify_types/cloudify_types/shared_resource/operations.py
+++ b/cloudify_types/cloudify_types/shared_resource/operations.py
@@ -104,8 +104,8 @@ def _checkout_resource_consumer(client, deployment_id):
     deployment = client.deployments.get(deployment_id)
     type_labels = _get_label_values(deployment.labels, 'csys-obj-type')
     consumers_list = _get_label_values(deployment.labels, 'csys-consumer-id')
-    on_demand_uninstall = ('on-demand-resource' in type_labels or
-                           'on-demand-uninstall' in type_labels)
+    on_demand_uninstall = ('on-demand-resource' in type_labels and
+                           'on-demand-uninstall-off' not in type_labels)
     if (on_demand_uninstall and not consumers_list and
             deployment.installation_status == 'active'):
         try:


### PR DESCRIPTION
… spec. So now we auto-uninstall if the target deployment is an ODSR and **doesn't** have a label which specifies **not** to uninstall.
The logic is:
`csys-obj-type: on-demand-resource` identifies the deployment as an On-demand Shared Resource
`csys-obj-type: on-demand-uninstall-off` identifies it further as an On-demand Shared Resource without an auto-uninstall. This label has no meaning without the previous one.