### PR TITLE
RD-4003 A test for wait_after_fail

### DIFF
--- a/tests/integration_tests/resources/dsl/wait_after_fail.yaml
+++ b/tests/integration_tests/resources/dsl/wait_after_fail.yaml
@@ -1,0 +1,21 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+    - cloudify/types/types.yaml
+    - plugin:cloudmock
+
+node_templates:
+    node1:
+        type: cloudify.nodes.Root
+        interfaces:
+            foo:
+                bar: cloudmock.cloudmock.tasks.failing
+
+    node2:
+        type: cloudify.nodes.Root
+        interfaces:
+            foo:
+                bar:
+                    implementation: cloudmock.cloudmock.tasks.wait
+                    inputs:
+                        delay: 5

--- a/tests/integration_tests_plugins/cloudmock/cloudmock/tasks.py
+++ b/tests/integration_tests_plugins/cloudmock/cloudmock/tasks.py
@@ -187,3 +187,8 @@ def workflow1(ctx):
             version=ni.version,
             runtime_properties={'custom_workflow': True}
         )
+
+
+def wait(ctx, delay=5, **kwargs):
+    time.sleep(delay)
+    ctx.logger.info('wait done; slept %s', delay)


### PR DESCRIPTION
Hopefully self-explanatory.
This replaces the removed test in cloudify-cosmo/cloudify-common#971