### PR TITLE
RD-3911 Dep-update: uninstall removed host-agent plugins

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_plugin_update.py
+++ b/tests/integration_tests/tests/agent_tests/test_plugin_update.py
@@ -81,7 +81,6 @@ class TestPluginUpdate(AgentTestWithPlugins):
     blueprint_name_prefix = 'plugin_update_'
     setup_deployment_ids = None
 
-    @pytest.mark.xfail  # RD-3911
     @uploads_mock_plugins
     def test_plugin_update(self):
         self.setup_deployment_id = 'd{0}'.format(uuid.uuid4())

--- a/tests/integration_tests/tests/agent_tests/test_plugin_update.py
+++ b/tests/integration_tests/tests/agent_tests/test_plugin_update.py
@@ -363,7 +363,12 @@ class TestPluginUpdate(AgentTestWithPlugins):
                    for pstate in target_plugin.installation_state)
         for other_plugin in other_plugins:
             assert all(pstate['state'] != 'installed'
-                       for pstate in other_plugin.installation_state)
+                       for pstate in other_plugin.installation_state
+                       # we only uninstall the plugin on agents, so don't
+                       # check manager plugins. Manager plugins are only
+                       # uninstalled when explicitly requested by the user.
+                       # (because they could be used in other deployments)
+                       if pstate.get('manager') is None)
 
     def _upload_blueprints_and_deploy_base(self):
         self.deploy_application(


### PR DESCRIPTION
Uninstall plugins that are now unused, from the agents.
We're gonna do it by using operations that already exist.

However, this isn't going to uninstall manager plugins. Those
could be used by other deployments as well. The user is always
able to uninstall them, by just doing `cfy plugins delete`.