### PR TITLE
RD-3951 update_idds: filter the labels query

### DIFF
--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -497,7 +497,11 @@ def update_inter_deployment_dependencies(sm, deployment):
 def _add_new_consumer_labels(sm, source_id, consumer_labels_to_add):
     existing_consumer_labels = {
         lb.deployment for lb in
-        sm.list(models.DeploymentLabel, filters={'key': 'csys-consumer-id'})
+        models.DeploymentLabel.query
+        .filter(models.DeploymentLabel.key == 'csys-consumer-id')
+        .filter(models.DeploymentLabel.value == source_id)
+        .distinct(models.DeploymentLabel._labeled_model_fk)
+        .all()
     }
     consumer_labels_to_add -= existing_consumer_labels
     for target in consumer_labels_to_add:

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -428,26 +428,25 @@ def update_deployment_dependencies_from_plan(deployment_id,
 
 
 def update_inter_deployment_dependencies(sm, deployment):
-    dependencies = (
+    dependencies = {
+        dep for dep in
         db.session.query(models.InterDeploymentDependencies)
         .filter(
             models.InterDeploymentDependencies._source_deployment
             == deployment._storage_id
         )
         .all()
-    )
+        if dep.target_deployment_func or dep.target_deployment
+        and not dep.external_target
+    }
     if not dependencies:
         return
+
     dependents = {
         d._source_deployment
         for d in deployment.get_dependents(fetch_deployments=False)
     } | {deployment._storage_id}
 
-    dependencies = {
-        dep for dep in dependencies
-        if dep.target_deployment_func or dep.target_deployment
-        and not dep.external_target
-    }
     new_dependency_deployments = set()
     for dependency in dependencies:
         eval_target_deployment = _get_deployment_from_target_func(

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -485,24 +485,22 @@ def update_inter_deployment_dependencies(sm, deployment):
         # Add source to target's consumers (except where target is a component)
         if dependency.target_deployment in components_list:
             continue
-        consumer_labels_to_add.add((dependency.source_deployment_id,
-                                    dependency.target_deployment))
+        consumer_labels_to_add.add(dependency.target_deployment)
 
     # Add consumer labels for shared resources
     for shared_resource in shared_resources_list:
-        consumer_labels_to_add.add((deployment.id, shared_resource))
+        consumer_labels_to_add.add(shared_resource)
 
-    _add_new_consumer_labels(sm, consumer_labels_to_add)
+    _add_new_consumer_labels(sm, deployment.id, consumer_labels_to_add)
 
 
-def _add_new_consumer_labels(sm, consumer_labels_to_add):
+def _add_new_consumer_labels(sm, source_id, consumer_labels_to_add):
     existing_consumer_labels = {
-        (lb.value, lb.deployment) for lb in
+        lb.deployment for lb in
         sm.list(models.DeploymentLabel, filters={'key': 'csys-consumer-id'})
     }
     consumer_labels_to_add -= existing_consumer_labels
-    for label in consumer_labels_to_add:
-        source_id, target = label
+    for target in consumer_labels_to_add:
         sm.put(models.DeploymentLabel(
             key='csys-consumer-id',
             value=source_id,

--- a/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
@@ -1,4 +1,5 @@
 import uuid
+import pytest
 
 from cloudify.models_states import DeploymentState
 from cloudify_rest_client.exceptions import CloudifyClientError
@@ -437,6 +438,11 @@ class TestUpdateIDDs(_DependencyTestUtils, BaseServerTestCase):
         assert len(target.source_of_dependency_in) == 0
         assert len(target.target_of_dependency_in) == 1
 
+    # this fails because update_idds prepares its `components_list`
+    # before the IDDs are actually filled in, and so it ends up with a
+    # None target deployment id, because the target deployment will only be
+    # figured out based on target_deployment_func later
+    @pytest.mark.xfail
     def test_component_dependency(self):
         source = self._deployment(id='source')
         target = self._deployment(id='target')
@@ -458,6 +464,8 @@ class TestUpdateIDDs(_DependencyTestUtils, BaseServerTestCase):
         assert len(target.source_of_dependency_in) == 0
         assert len(target.target_of_dependency_in) == 1
 
+    # this fails for the same reason as test_component_dependency
+    @pytest.mark.xfail
     def test_sharedresource_dependency(self):
         source = self._deployment(id='source')
         target = self._deployment(id='target')

--- a/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
@@ -1,5 +1,4 @@
 import uuid
-import pytest
 
 from cloudify.models_states import DeploymentState
 from cloudify_rest_client.exceptions import CloudifyClientError

--- a/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
@@ -438,11 +438,6 @@ class TestUpdateIDDs(_DependencyTestUtils, BaseServerTestCase):
         assert len(target.source_of_dependency_in) == 0
         assert len(target.target_of_dependency_in) == 1
 
-    # this fails because update_idds prepares its `components_list`
-    # before the IDDs are actually filled in, and so it ends up with a
-    # None target deployment id, because the target deployment will only be
-    # figured out based on target_deployment_func later
-    @pytest.mark.xfail
     def test_component_dependency(self):
         source = self._deployment(id='source')
         target = self._deployment(id='target')
@@ -464,8 +459,6 @@ class TestUpdateIDDs(_DependencyTestUtils, BaseServerTestCase):
         assert len(target.source_of_dependency_in) == 0
         assert len(target.target_of_dependency_in) == 1
 
-    # this fails for the same reason as test_component_dependency
-    @pytest.mark.xfail
     def test_sharedresource_dependency(self):
         source = self._deployment(id='source')
         target = self._deployment(id='target')


### PR DESCRIPTION
Avoid just a `sm.list()` that queries for all csys-consumer-id labels,
because that would also return labels of unrelated deployments, and
we'd end up missing the ones we're actually looking for, because
they could be paginated away.

Also some refactors.