### PR TITLE
RD-4096 Name the new dep-up workflow "update"

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -638,62 +638,6 @@ workflows:
       node_instance_ids:
         default: []
 
-  update:
-    mapping: default_workflows.cloudify.plugins.workflows.update
-    is_cascading: false
-    parameters:
-      update_id:
-        default: ''
-      skip_install:
-        default: false
-      skip_uninstall:
-        default: false
-      added_instance_ids:
-        default: []
-        type: list
-      added_target_instances_ids:
-        default: []
-        type: list
-      removed_instance_ids:
-        default: []
-        type: list
-      remove_target_instance_ids:
-        default: []
-        type: list
-      modified_entity_ids:
-        default: []
-        type: list
-      extended_instance_ids:
-        default: []
-        type: list
-      extend_target_instance_ids:
-        default: []
-        type: list
-      reduced_instance_ids:
-        default: []
-        type: list
-      reduce_target_instance_ids:
-        default: []
-        type: list
-      ignore_failure:
-        default: false
-        type: boolean
-      install_first:
-        default: false
-        type: boolean
-      node_instances_to_reinstall:
-        default: []
-        type: list
-      central_plugins_to_install:
-        default: []
-        type: list
-      central_plugins_to_uninstall:
-        default: []
-        type: list
-      update_plugins:
-        default: true
-        type: boolean
-
   uninstall:
     mapping: default_workflows.cloudify.plugins.workflows.uninstall
     is_cascading: false

--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -111,6 +111,7 @@ class DeploymentUpdate(SecuredResource):
                 deployment=deployment,
                 workflow_id='update',
                 parameters=execution_args,
+                allow_custom_parameters=True,
             )
             sm.put(update_exec)
             dep_up.execution = update_exec

--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -109,8 +109,8 @@ class DeploymentUpdate(SecuredResource):
             }
             update_exec = models.Execution(
                 deployment=deployment,
-                workflow_id='csys_new_deployment_update',
-                parameters=execution_args
+                workflow_id='update',
+                parameters=execution_args,
             )
             sm.put(update_exec)
             dep_up.execution = update_exec

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1112,7 +1112,7 @@ class Execution(CreatedAtMixin, SQLResourceBase):
             'csys_update_deployment':
                 'cloudify_system_workflows.deployment_environment.'
                 'update_deployment',
-            'csys_new_deployment_update':
+            'update':
                 'cloudify_system_workflows.deployment_update.workflow.'
                 'update_deployment',
         }.get(wf_id)

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -683,7 +683,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
 
         resource_path = '/deployments/{0}'.format(deployment_id)
         workflows = self.get(resource_path).json['workflows']
-        self.assertEqual(16, len(workflows))
+        self.assertEqual(15, len(workflows))
         workflow = next((workflow for workflow in workflows if
                         workflow['name'] == 'mock_workflow'), None)
         self.assertIsNotNone(workflow)

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -92,7 +92,12 @@ sources = [
 sources_static = [
     (
         'cloudify-manager/resources/rest-service/cloudify/migrations',
-        ['/opt/manager/resources/cloudify/migrations']),
+        ['/opt/manager/resources/cloudify/migrations']
+    ),
+    (
+        'cloudify-manager/resources/rest-service/cloudify/types/types.yaml',
+        ['/opt/manager/resources/cloudify/types/types.yaml']
+    ),
 ]
 
 

--- a/tests/integration_tests/resources/dsl/deployment_update/old_workflow/base/old_workflow_base.yaml
+++ b/tests/integration_tests/resources/dsl/deployment_update/old_workflow/base/old_workflow_base.yaml
@@ -1,0 +1,67 @@
+tosca_definitions_version: 'cloudify_dsl_1_3'
+
+imports:
+  - cloudify/types/types.yaml
+
+description: old description
+
+node_templates:
+  site1:
+    type: cloudify.nodes.Root
+
+workflows:
+  update:
+    mapping: default_workflows.cloudify.plugins.workflows.update
+    is_cascading: false
+    parameters:
+      update_id:
+        default: ''
+      skip_install:
+        default: false
+      skip_uninstall:
+        default: false
+      added_instance_ids:
+        default: []
+        type: list
+      added_target_instances_ids:
+        default: []
+        type: list
+      removed_instance_ids:
+        default: []
+        type: list
+      remove_target_instance_ids:
+        default: []
+        type: list
+      modified_entity_ids:
+        default: []
+        type: list
+      extended_instance_ids:
+        default: []
+        type: list
+      extend_target_instance_ids:
+        default: []
+        type: list
+      reduced_instance_ids:
+        default: []
+        type: list
+      reduce_target_instance_ids:
+        default: []
+        type: list
+      ignore_failure:
+        default: false
+        type: boolean
+      install_first:
+        default: false
+        type: boolean
+      node_instances_to_reinstall:
+        default: []
+        type: list
+      central_plugins_to_install:
+        default: []
+        type: list
+      central_plugins_to_uninstall:
+        default: []
+        type: list
+      update_plugins:
+        default: true
+        type: boolean

--- a/tests/integration_tests/resources/dsl/deployment_update/old_workflow/modification/old_workflow_modification.yaml
+++ b/tests/integration_tests/resources/dsl/deployment_update/old_workflow/modification/old_workflow_modification.yaml
@@ -1,0 +1,67 @@
+tosca_definitions_version: 'cloudify_dsl_1_3'
+
+imports:
+  - cloudify/types/types.yaml
+
+description: new description
+
+node_templates:
+  site1:
+    type: cloudify.nodes.Root
+
+workflows:
+  update:
+    mapping: default_workflows.cloudify.plugins.workflows.update
+    is_cascading: false
+    parameters:
+      update_id:
+        default: ''
+      skip_install:
+        default: false
+      skip_uninstall:
+        default: false
+      added_instance_ids:
+        default: []
+        type: list
+      added_target_instances_ids:
+        default: []
+        type: list
+      removed_instance_ids:
+        default: []
+        type: list
+      remove_target_instance_ids:
+        default: []
+        type: list
+      modified_entity_ids:
+        default: []
+        type: list
+      extended_instance_ids:
+        default: []
+        type: list
+      extend_target_instance_ids:
+        default: []
+        type: list
+      reduced_instance_ids:
+        default: []
+        type: list
+      reduce_target_instance_ids:
+        default: []
+        type: list
+      ignore_failure:
+        default: false
+        type: boolean
+      install_first:
+        default: false
+        type: boolean
+      node_instances_to_reinstall:
+        default: []
+        type: list
+      central_plugins_to_install:
+        default: []
+        type: list
+      central_plugins_to_uninstall:
+        default: []
+        type: list
+      update_plugins:
+        default: true
+        type: boolean

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_misc.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_misc.py
@@ -552,3 +552,17 @@ class TestDeploymentUpdateMisc(DeploymentUpdateBase):
         assert {s['id'] for s in schedules} == {'s1', 's2', 's3'}
         modified_sched = next(s for s in schedules if s['id'] == 's1')
         assert modified_sched['next_occurrence'].startswith('3535')
+
+    def test_old_workflow(self):
+        # the blueprint contains a 6.2-era update workflow definition
+        deployment, modified_bp_path = \
+            self._deploy_and_get_modified_bp_path('old_workflow')
+
+        assert deployment['description'] == 'old description'
+
+        self.client.blueprints.upload(modified_bp_path, BLUEPRINT_ID)
+        wait_for_blueprint_upload(BLUEPRINT_ID, self.client)
+        self._do_update(deployment.id, BLUEPRINT_ID)
+
+        deployment = self.client.deployments.get(deployment.id)
+        assert deployment['description'] == 'new description'

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_misc.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_misc.py
@@ -289,8 +289,6 @@ class TestDeploymentUpdateMisc(DeploymentUpdateBase):
         workflows = [e['workflow_id'] for e in
                      self.client.executions.list(deployment_id=deployment.id,
                                                  _include=['workflow_id'])]
-
-        self.assertNotIn('update', workflows)
         self.assertIn('custom_workflow', workflows)
 
     def _test_skip_install(self, skip):

--- a/tests/integration_tests/tests/agentless_tests/test_deployment_workflows.py
+++ b/tests/integration_tests/tests/agentless_tests/test_deployment_workflows.py
@@ -40,7 +40,7 @@ class TestDeploymentWorkflows(AgentlessTestCase):
         deployment, _ = self.deploy_application(dsl_path)
         deployment_id = deployment.id
         workflows = self.client.deployments.get(deployment_id).workflows
-        self.assertEqual(16, len(workflows))
+        self.assertEqual(15, len(workflows))
         wf_ids = [x.name for x in workflows]
         self.assertIn('uninstall', wf_ids)
         self.assertIn('install', wf_ids)
@@ -49,7 +49,6 @@ class TestDeploymentWorkflows(AgentlessTestCase):
         self.assertIn('scale', wf_ids)
         self.assertIn('heal', wf_ids)
         self.assertIn('install_new_agents', wf_ids)
-        self.assertIn('update', wf_ids)
         self.assertIn('start', wf_ids)
         self.assertIn('stop', wf_ids)
         self.assertIn('restart', wf_ids)


### PR DESCRIPTION
The `csys-new-deployment-update` idea is wrong, because
people do rely on the update workflow's name being actually
"update".
So, let's rename it to `update`, then. This also, hopefully, keeps
back-compat with old blueprints.