### PR TITLE
RD-4105 workflows list: also return is_cascading

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -548,7 +548,8 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
                          created_at=None,
                          plugin=wf.get('plugin', ''),
                          operation=wf.get('operation', ''),
-                         parameters=wf.get('parameters', dict()))
+                         parameters=wf.get('parameters', dict()),
+                         is_cascading=wf.get('is_cascading', False))
                 for wf_name, wf in deployment_workflows.items()]
 
     @classmethod


### PR DESCRIPTION
It was missing from the returned object, but it is part of a workflow.
Missing it caused some workflows be mistakenly marked as changed
in dep-updates.