### PR TITLE
RD-2617 Dep-update: update the stored instance amounts

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/nodes.py
@@ -111,6 +111,7 @@ class NodesId(SecuredResource):
             'operations': {'optional': True},
             'relationships': {'optional': True},
             'properties': {'optional': True},
+            'capabilities': {'optional': True},
         })
         sm = get_storage_manager()
         with sm.transaction():
@@ -125,6 +126,21 @@ class NodesId(SecuredResource):
                 node.relationships = request_dict['relationships']
             if request_dict.get('properties'):
                 node.properties = request_dict['properties']
+            if request_dict.get('capabilities'):
+                scalable = request_dict['capabilities'].get('scalable', {})\
+                    .get('properties', {})
+                if 'max_instances' in scalable:
+                    node.max_number_of_instances = scalable['max_instances']
+                if 'min_instances' in scalable:
+                    node.min_number_of_instances = scalable['min_instances']
+                if 'current_instances' in scalable:
+                    node.number_of_instances = scalable['current_instances']
+                if 'default_instances' in scalable:
+                    node.deploy_number_of_instances = \
+                        scalable['default_instances']
+                if 'planned_instances' in scalable:
+                    node.planned_number_of_instances = \
+                        scalable['planned_instances']
             sm.update(node)
         return None, 204
 

--- a/tests/integration_tests/resources/dsl/deployment_update/scale_instance/base/scale_instance_base.yaml
+++ b/tests/integration_tests/resources/dsl/deployment_update/scale_instance/base/scale_instance_base.yaml
@@ -1,0 +1,14 @@
+tosca_definitions_version: 'cloudify_dsl_1_3'
+
+imports:
+  - cloudify/types/types.yaml
+
+node_templates:
+  site1:
+    type: cloudify.nodes.Root
+    instances:
+      deploy: 1
+  site2:
+    type: cloudify.nodes.Root
+    instances:
+      deploy: 3

--- a/tests/integration_tests/resources/dsl/deployment_update/scale_instance/modification/scale_instance_modification.yaml
+++ b/tests/integration_tests/resources/dsl/deployment_update/scale_instance/modification/scale_instance_modification.yaml
@@ -1,0 +1,14 @@
+tosca_definitions_version: 'cloudify_dsl_1_3'
+
+imports:
+  - cloudify/types/types.yaml
+
+node_templates:
+  site1:
+    type: cloudify.nodes.Root
+    instances:
+      deploy: 3
+  site2:
+    type: cloudify.nodes.Root
+    instances:
+      deploy: 1

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_modification.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_modification.py
@@ -23,6 +23,33 @@ pytestmark = pytest.mark.group_deployments
 
 
 class TestDeploymentUpdateModification(DeploymentUpdateBase):
+    def test_scale(self):
+        # this test is WIP; it will be checking more things than just
+        # the declared numbers.
+        deployment, modified_bp_path = \
+            self._deploy_and_get_modified_bp_path('scale_instance')
+
+        self.client.blueprints.upload(modified_bp_path, BLUEPRINT_ID)
+        wait_for_blueprint_upload(BLUEPRINT_ID, self.client)
+
+        expected_instances = {
+            'site1': 1,
+            'site2': 3,
+        }
+        nodes = self.client.nodes.list(deployment_id=deployment.id)
+        assert expected_instances == {
+            n['id']: n['deploy_number_of_instances'] for n in nodes
+        }
+        self._do_update(deployment.id, BLUEPRINT_ID)
+        nodes = self.client.nodes.list(deployment_id=deployment.id)
+        expected_instances = {
+            'site1': 3,
+            'site2': 1,
+        }
+        assert expected_instances == {
+            n['id']: n['deploy_number_of_instances'] for n in nodes
+        }
+
     def test_modify_relationships(self):
         deployment, modified_bp_path = \
             self._deploy_and_get_modified_bp_path('modify_relationship')


### PR DESCRIPTION
A Node has all the fields counting its instances, but they aren't
updated right now.

Let's update them.

This will allow further work with implementing scaling in dep-update.