### PR TITLE
RD-2617 Implement deleting node-instances

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/__init__.py
@@ -118,6 +118,7 @@ from .nodes import (  # NOQA
     Nodes,
     NodesId,
     NodeInstances,
+    NodeInstancesId,
 )
 
 from .searches import (  # NOQA

--- a/rest-service/manager_rest/rest/resources_v3_1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/nodes.py
@@ -1,6 +1,9 @@
 from collections import defaultdict
 
-from ..resources_v3 import Nodes as v3_Nodes
+from ..resources_v3 import (
+    Nodes as v3_Nodes,
+    NodeInstancesId as v3_NodeInstancesId,
+)
 from ..resources_v2 import NodeInstances as v2_NodeInstances
 
 from manager_rest.rest import rest_utils
@@ -221,3 +224,14 @@ class NodeInstances(v2_NodeInstances):
             raw_instance.setdefault('relationships', [])
             raw_instance.setdefault('scaling_groups', [])
             raw_instance.setdefault('host_id', None)
+
+
+class NodeInstancesId(v3_NodeInstancesId):
+    @authorize('node_instance_delete')
+    @only_deployment_update
+    def delete(self, node_instance_id):
+        sm = get_storage_manager()
+        with sm.transaction():
+            instance = sm.get(models.NodeInstance, node_instance_id)
+            sm.delete(instance)
+        return None, 204


### PR DESCRIPTION
This is going to be only useful from dep-update. Don't you dare
use it otherwise.

I mean, you can, if you want to break your shit. I'll still try to stop
you, via the `@only_deployment_update`.