### PR TITLE
RD-4212 dep-up: remove nodes AFTER removing instances

### DIFF
--- a/workflows/cloudify_system_workflows/deployment_update/workflow.py
+++ b/workflows/cloudify_system_workflows/deployment_update/workflow.py
@@ -632,13 +632,13 @@ def _post_update_graph(ctx, update_id, **kwargs):
     graph = ctx.graph_mode()
     seq = graph.sequence()
     seq.add(
-        ctx.local_task(delete_removed_nodes, kwargs={
-            'update_id': update_id,
-        }, total_retries=0),
         ctx.local_task(delete_removed_relationships, kwargs={
             'update_id': update_id,
         }, total_retries=0),
         ctx.local_task(delete_removed_instances, kwargs={
+            'update_id': update_id,
+        }, total_retries=0),
+        ctx.local_task(delete_removed_nodes, kwargs={
             'update_id': update_id,
         }, total_retries=0),
         ctx.local_task(update_schedules, kwargs={


### PR DESCRIPTION
Well, if we remove nodes first, then removing instances would possibly
fail, because their nodes are already gone.