### PR TITLE
inte-tests: add config.yaml to mounted sources

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -84,6 +84,7 @@ sources = [
     ('cloudify-manager/workflows/cloudify_system_workflows', ['/opt/mgmtworker/env']),  # NOQA
     ('cloudify-manager/cloudify_types/cloudify_types', ['/opt/mgmtworker/env']),  # NOQA
     ('cloudify-manager-install/cfy_manager', ['/opt/cloudify/cfy_manager']),
+    ('cloudify-manager-install/config.yaml', ['/opt/cloudify/cfy_manager']),
     ('cloudify-manager/execution-scheduler/execution_scheduler', ['/opt/manager/env']),  # NOQA
 ]
 


### PR DESCRIPTION
Well, that's a pretty damn weird location for the config.yaml file.
But that's what it currently is, and I want to be able to test out
my nonstandard config.yaml default.