### PR TITLE
RD-4159 inte-tests: enable external ssl

### DIFF
--- a/tests/integration_tests/framework/docker.py
+++ b/tests/integration_tests/framework/docker.py
@@ -12,6 +12,7 @@ def run_manager(image, service_management, resource_mapping=None,):
 manager:
     security:
         admin_password: admin
+        ssl_enabled: true
 validations:
     skip_validations: true
 sanity:


### PR DESCRIPTION
In cloudify-cosmo/cloudify-manager-install#1323 we made docker managers
don't use external ssl by default. But in these tests, we do expect
the client to be using ssl. So let's enable it.