### PR TITLE
RD-4117 Deployments search new attributes

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -505,7 +505,8 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
 
     @classproperty
     def allowed_filter_attrs(cls):
-        return ['blueprint_id', 'created_by', 'site_name', 'schedules']
+        return ['blueprint_id', 'created_by', 'site_name', 'schedules',
+                'tenant_name', 'display_name']
 
     def to_response(self, include=None, **kwargs):
         include = include or self.response_fields


### PR DESCRIPTION
Allow to search deployments also by `display_name` and `tenant_name` attributes.
