### PR TITLE
RD-2357 If forced, delete the dep, even if del-dep-env fails

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -169,6 +169,8 @@ class ResourceManager(object):
             execution = self.sm.update(execution)
             self.update_deployment_statuses(execution)
             self._send_hook(execution)
+            # render the execution here, because immediately afterwards
+            # we'll delete it, and then we won't be able to render it anymore
             res = execution.to_response()
             # do not use `execution` after this transaction ends, because it
             # would possibly require refetching the related objects, and by
@@ -212,8 +214,6 @@ class ResourceManager(object):
 
         if workflow_id == 'delete_deployment_environment' and \
                 status in ExecutionState.END_STATES:
-            # render the execution here, because immediately afterwards
-            # we'll delete it, and then we won't be able to render it anymore
             if status == ExecutionState.TERMINATED or (
                 status == ExecutionState.FAILED and
                 parameters and parameters.get('force')

--- a/rest-service/manager_rest/rest/resources_v1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v1/deployments.py
@@ -161,7 +161,9 @@ class DeploymentsId(SecuredResource):
         rm = get_resource_manager()
         rm.check_deployment_delete(dep, force=args.force)
         delete_execution = dep.make_delete_environment_execution(
-            delete_logs=args.delete_logs)
+            delete_logs=args.delete_logs,
+            force=args.force,
+        )
         messages = rm.prepare_executions(
             [delete_execution], bypass_maintenance=bypass_maintenance)
         workflow_executor.execute_workflow(messages)

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -1337,7 +1337,8 @@ class DeploymentGroupsId(SecuredResource):
                 for dep in group.deployments:
                     rm.check_deployment_delete(dep, force=args.force)
                     delete_exc = dep.make_delete_environment_execution(
-                        delete_logs=args.delete_logs
+                        delete_logs=args.delete_logs,
+                        force=args.force,
                     )
                     delete_exc_group.executions.append(delete_exc)
                 messages = delete_exc_group.start_executions(sm, rm)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -699,12 +699,12 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
                 f'{ ", ".join(undeclared_inputs) }'
             )
 
-    def make_delete_environment_execution(self, delete_logs=True):
+    def make_delete_environment_execution(self, delete_logs=True, force=False):
         return Execution(
             workflow_id='delete_deployment_environment',
             deployment=self,
             status=ExecutionState.PENDING,
-            parameters={'delete_logs': delete_logs},
+            parameters={'delete_logs': delete_logs, 'force': force},
         )
 
     @hybrid_property


### PR DESCRIPTION
`cfy dep del --force` will now delete the deployment from the
db, even if the workflow fails for some reason.

Now, it shouldn't ever fail, because well, it's just a rmdir. But still.