### PR TITLE
RD-4306 Allow migrations to be rendered to SQL

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/1fbd6bf39e84_4_5_to_4_5_5.py
+++ b/resources/rest-service/cloudify/migrations/versions/1fbd6bf39e84_4_5_to_4_5_5.py
@@ -50,7 +50,6 @@ def upgrade():
     op.add_column('executions',
                   sa.Column('scheduled_for', UTCDateTime(), nullable=True))
 
-    op.execute('COMMIT')
     # Add new execution status
     op.execute("alter type execution_status add value 'scheduled'")
     op.add_column(

--- a/resources/rest-service/cloudify/migrations/versions/423a1643f365_4_6_to_5_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/423a1643f365_4_6_to_5_0.py
@@ -70,42 +70,42 @@ def upgrade():
             ),
             dict(
                 name='ldap_server',
-                value=None,
+                value=op.inline_literal('null'),
                 scope='rest',
                 schema={'type': 'string'},
                 is_editable=True
             ),
             dict(
                 name='ldap_username',
-                value=None,
+                value=op.inline_literal('null'),
                 scope='rest',
                 schema={'type': 'string'},
                 is_editable=True
             ),
             dict(
                 name='ldap_password',
-                value=None,
+                value=op.inline_literal('null'),
                 scope='rest',
                 schema={'type': 'string'},
                 is_editable=True
             ),
             dict(
                 name='ldap_domain',
-                value=None,
+                value=op.inline_literal('null'),
                 scope='rest',
                 schema={'type': 'string'},
                 is_editable=True
             ),
             dict(
                 name='ldap_is_active_directory',
-                value=None,
+                value=op.inline_literal('null'),
                 scope='rest',
                 schema={'type': 'boolean'},
                 is_editable=True
             ),
             dict(
                 name='ldap_dn_extra',
-                value=None,
+                value=op.inline_literal('null'),
                 scope='rest',
                 schema=None,
                 is_editable=True
@@ -175,7 +175,7 @@ def upgrade():
             ),
             dict(
                 name='public_ip',
-                value=None,
+                value=op.inline_literal('null'),
                 scope='rest',
                 schema=None,
                 is_editable=False

--- a/resources/rest-service/cloudify/migrations/versions/62a8d746d13b_5_0_to_5_0_5.py
+++ b/resources/rest-service/cloudify/migrations/versions/62a8d746d13b_5_0_to_5_0_5.py
@@ -48,7 +48,7 @@ def upgrade():
     op.bulk_insert(config_table, [
         dict(
             name='ldap_ca_path',
-            value=None,
+            value=op.inline_literal('null'),
             scope='rest',
             schema={'type': 'string'},
             is_editable=True

--- a/resources/rest-service/cloudify/migrations/versions/8e8314b1d848_6_2_to_6_3.py
+++ b/resources/rest-service/cloudify/migrations/versions/8e8314b1d848_6_2_to_6_3.py
@@ -446,45 +446,45 @@ def _create_usage_collector_triggers():
         DECLARE
             _count_deployments INTEGER;
         BEGIN
-            SELECT COUNT(*) INTO _count_deployments FROM deployments; 
-            UPDATE usage_collector SET max_deployments = _count_deployments 
+            SELECT COUNT(*) INTO _count_deployments FROM deployments;
+            UPDATE usage_collector SET max_deployments = _count_deployments
             WHERE _count_deployments > max_deployments;
-            RETURN NULL; 
+            RETURN NULL;
         END;
     $$ LANGUAGE plpgsql;
-    
+
     CREATE FUNCTION increase_blueprints_max() RETURNS TRIGGER AS $$
         DECLARE
             _count_blueprints INTEGER;
         BEGIN
-            SELECT COUNT(*) INTO _count_blueprints FROM blueprints; 
-            UPDATE usage_collector SET max_blueprints = _count_blueprints 
+            SELECT COUNT(*) INTO _count_blueprints FROM blueprints;
+            UPDATE usage_collector SET max_blueprints = _count_blueprints
             WHERE _count_blueprints > max_blueprints;
             RETURN NULL;
         END;
-    $$ LANGUAGE plpgsql; 
-    
+    $$ LANGUAGE plpgsql;
+
     CREATE FUNCTION increase_users_max() RETURNS TRIGGER AS $$
         DECLARE
             _count_users INTEGER;
         BEGIN
-            SELECT COUNT(*) INTO _count_users FROM users; 
-            UPDATE usage_collector SET max_users = _count_users 
+            SELECT COUNT(*) INTO _count_users FROM users;
+            UPDATE usage_collector SET max_users = _count_users
             WHERE _count_users > max_users;
             RETURN NULL;
         END;
-    $$ LANGUAGE plpgsql; 
-    
+    $$ LANGUAGE plpgsql;
+
     CREATE FUNCTION increase_tenants_max() RETURNS TRIGGER AS $$
         DECLARE
             _count_tenants INTEGER;
         BEGIN
-            SELECT COUNT(*) INTO _count_tenants FROM tenants; 
-            UPDATE usage_collector SET max_tenants = _count_tenants 
+            SELECT COUNT(*) INTO _count_tenants FROM tenants;
+            UPDATE usage_collector SET max_tenants = _count_tenants
             WHERE _count_tenants > max_tenants;
             RETURN NULL;
         END;
-    $$ LANGUAGE plpgsql; 
+    $$ LANGUAGE plpgsql;
 
     CREATE FUNCTION increase_deployments_total() RETURNS TRIGGER AS $$
         BEGIN
@@ -500,25 +500,25 @@ def _create_usage_collector_triggers():
             RETURN NULL;
         END;
     $$ LANGUAGE plpgsql;
-    
+
     CREATE FUNCTION increase_executions_total() RETURNS TRIGGER AS $$
         BEGIN
             UPDATE usage_collector SET total_executions = total_executions + 1;
             RETURN NULL;
         END;
-    $$ LANGUAGE plpgsql; 
-    
+    $$ LANGUAGE plpgsql;
+
     CREATE FUNCTION increase_logins_total() RETURNS TRIGGER AS $$
         BEGIN
             UPDATE usage_collector SET total_logins = total_logins + 1;
             IF (OLD.last_login_at IS NULL)
             AND NOT (NEW.last_login_at IS NULL) THEN
-                UPDATE usage_collector 
+                UPDATE usage_collector
                 SET total_logged_in_users = total_logged_in_users + 1;
             END IF;
             RETURN NULL;
         END;
-    $$ LANGUAGE plpgsql; 
+    $$ LANGUAGE plpgsql;
 
     CREATE TRIGGER increase_deployments_max
     AFTER INSERT ON deployments FOR EACH STATEMENT
@@ -528,11 +528,11 @@ def _create_usage_collector_triggers():
     AFTER INSERT ON blueprints FOR EACH STATEMENT
     EXECUTE PROCEDURE increase_blueprints_max();
 
-    CREATE TRIGGER increase_users_max 
+    CREATE TRIGGER increase_users_max
     AFTER INSERT ON users FOR EACH STATEMENT
     EXECUTE PROCEDURE increase_users_max();
 
-    CREATE TRIGGER increase_tenants_max 
+    CREATE TRIGGER increase_tenants_max
     AFTER INSERT ON tenants FOR EACH STATEMENT
     EXECUTE PROCEDURE increase_tenants_max();
 
@@ -544,11 +544,11 @@ def _create_usage_collector_triggers():
     AFTER INSERT ON blueprints FOR EACH ROW
     EXECUTE PROCEDURE increase_blueprints_total();
 
-    CREATE TRIGGER increase_executions_total 
+    CREATE TRIGGER increase_executions_total
     AFTER INSERT ON executions FOR EACH ROW
     EXECUTE PROCEDURE increase_executions_total();
-    
-    CREATE TRIGGER increase_logins_total 
+
+    CREATE TRIGGER increase_logins_total
     AFTER UPDATE OF last_login_at ON users FOR EACH ROW
     EXECUTE PROCEDURE increase_logins_total();
     """)

--- a/resources/rest-service/cloudify/migrations/versions/8e8314b1d848_6_2_to_6_3.py
+++ b/resources/rest-service/cloudify/migrations/versions/8e8314b1d848_6_2_to_6_3.py
@@ -413,13 +413,16 @@ def _add_usage_collector_columns():
     op.execute(
        uc_table.update().values(
           total_deployments=
-          sa.select([sa.func.count(1)]).select_from(sa.table('deployments'))
+          sa.select([sa.func.count(op.inline_literal(1))])
+          .select_from(sa.table('deployments'))
           .scalar_subquery(),
           total_blueprints=
-          sa.select([sa.func.count(1)]).select_from(sa.table('blueprints'))
+          sa.select([sa.func.count(op.inline_literal(1))])
+          .select_from(sa.table('blueprints'))
           .scalar_subquery(),
           total_executions=
-          sa.select([sa.func.count(1)]).select_from(sa.table('executions'))
+          sa.select([sa.func.count(op.inline_literal(1))])
+          .select_from(sa.table('executions'))
           .scalar_subquery(),
        )
     )

--- a/resources/rest-service/cloudify/migrations/versions/9d261e90b1f3_5_1_1_to_5_2.py
+++ b/resources/rest-service/cloudify/migrations/versions/9d261e90b1f3_5_1_1_to_5_2.py
@@ -79,7 +79,7 @@ def add_new_config_entries():
         [
             dict(
                 name=name,
-                value=None,
+                value=op.inline_literal('null'),
                 scope='rest',
                 schema={'type': 'string'},
                 is_editable=True,

--- a/resources/rest-service/cloudify/migrations/versions/a31cb9e704d3_6_0_to_6_1.py
+++ b/resources/rest-service/cloudify/migrations/versions/a31cb9e704d3_6_0_to_6_1.py
@@ -95,9 +95,13 @@ def _change_number_to_integer_in_config_schema():
     for config_row in CONFIG_SCHEMA_UPDATE:
         op.execute(
             config_table.update().
-            where(sa.and_(config_table.c.name == config_row.name,
-                          config_table.c.scope == config_row.scope)).
-            values(schema=config_row.schema_6_1)
+            where(
+                sa.and_(
+                    config_table.c.name == op.inline_literal(config_row.name),
+                    config_table.c.scope == op.inline_literal(config_row.scope)
+                )
+            ).
+            values(schema=op.inline_literal(config_row.schema_6_1))
         )
 
 
@@ -105,7 +109,11 @@ def _change_integer_to_number_in_config_schema():
     for config_row in CONFIG_SCHEMA_UPDATE:
         op.execute(
             config_table.update().
-            where(sa.and_(config_table.c.name == config_row.name,
-                          config_table.c.scope == config_row.scope)).
-            values(schema=config_row.schema_6_0)
+            where(
+                sa.and_(
+                    config_table.c.name == op.inline_literal(config_row.name),
+                    config_table.c.scope == op.inline_literal(config_row.scope)
+                )
+            ).
+            values(schema=op.inline_literal(config_row.schema_6_0))
         )

--- a/resources/rest-service/cloudify/migrations/versions/a6d00b128933_4_4_to_4_5.py
+++ b/resources/rest-service/cloudify/migrations/versions/a6d00b128933_4_4_to_4_5.py
@@ -20,8 +20,6 @@ def upgrade():
     op.add_column('executions',
                   sa.Column('started_at', UTCDateTime(), nullable=True))
 
-    op.execute('COMMIT')
-
     # Add new execution status
     op.execute("alter type execution_status add value 'queued'")
 

--- a/resources/rest-service/cloudify/migrations/versions/c7652b2a97a4_4_3_to_4_4.py
+++ b/resources/rest-service/cloudify/migrations/versions/c7652b2a97a4_4_3_to_4_4.py
@@ -44,7 +44,6 @@ def upgrade():
     op.add_column('executions', sa.Column('ended_at',
                                           UTCDateTime(),
                                           nullable=True))
-    op.execute('COMMIT')
     op.execute("alter type execution_status add value 'kill_cancelling'")
 
 


### PR DESCRIPTION
We used to be able to render migrations to just SQL statements,
but recently we've broken it. This brings it back.

It's not used just yet, but eventually I'd like to render the SQL
at build time, and apply it when installing the manager (instead
of applying python-level migrations).

This will be important for being able to split services into separate
containers, because now the DB will be able to create itself, as
opposed to the restservice creating it.