### PR TITLE
Make _include work with non-orm attributes

### DIFF
--- a/rest-service/manager_rest/storage/filters.py
+++ b/rest-service/manager_rest/storage/filters.py
@@ -47,6 +47,10 @@ def add_attrs_filter_to_query(query, model_class, filter_rule,
 
     joins = get_joins(model_class, [column_name])
     column = get_column(model_class, column_name)
+    if not column:
+        # The attribute passed in via _include isn't a database object,
+        # don't try to filter on it in the DB
+        return query
     for joined_attr in joins:
         target_mapper = joined_attr.prop.mapper
         if target_mapper not in joined_columns_set:

--- a/rest-service/manager_rest/storage/filters.py
+++ b/rest-service/manager_rest/storage/filters.py
@@ -47,7 +47,7 @@ def add_attrs_filter_to_query(query, model_class, filter_rule,
 
     joins = get_joins(model_class, [column_name])
     column = get_column(model_class, column_name)
-    if not column:
+    if column is None:
         # The attribute passed in via _include isn't a database object,
         # don't try to filter on it in the DB
         return query

--- a/rest-service/manager_rest/storage/models_base.py
+++ b/rest-service/manager_rest/storage/models_base.py
@@ -1,18 +1,3 @@
-#########
-# Copyright (c) 2013 GigaSpaces Technologies Ltd. All rights reserved
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  * See the License for the specific language governing permissions and
-#  * limitations under the License.
-
 import json
 
 from collections import OrderedDict
@@ -309,5 +294,7 @@ class SQLModelBase(db.Model):
 
 def is_orm_attribute(item):
     if isinstance(item, AssociationProxyInstance):
+        return False
+    if not hasattr(item, 'is_attribute'):
         return False
     return item.is_attribute

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -420,11 +420,17 @@ class SQLStorageManager(object):
         replace column names with actual SQLA column objects
         """
         include = [get_column(model_class, c) for c in include]
+        include = [item for item in include if item is not None]
         filters = {get_column(model_class, c): filters[c] for c in filters}
+        filters = {k: v for k, v in filters.items() if k is not None}
         substr_filters = {get_column(model_class, c): substr_filters[c]
                           for c in substr_filters}
-        sort = OrderedDict((get_column(model_class, c), sort[c]) for c in sort)
+        substr_filters = {k: v for k, v in substr_filters.items()
+                          if k is not None}
+        sort = OrderedDict((get_column(model_class, c), sort[c]) for c in sort
+                           if get_column(model_class, c) is not None)
         distinct = [get_column(model_class, c) for c in distinct]
+        distinct = [item for item in distinct if item if item is not None]
 
         return include, filters, substr_filters, sort, distinct
 

--- a/rest-service/manager_rest/storage/utils.py
+++ b/rest-service/manager_rest/storage/utils.py
@@ -12,6 +12,9 @@ def get_column(model_class, column_name):
     if is_orm_attribute(column):
         return column
     else:
+        if not hasattr(column, 'remote_attr'):
+            # This is a property or similar, not a real column
+            return None
         # We need to get to the underlying attribute, so we move on to the
         # next remote_attr until we reach one
         while not is_orm_attribute(column.remote_attr):
@@ -30,6 +33,9 @@ def get_joins(model_class, columns):
     for column_name in columns:
         column = getattr(model_class, column_name)
         while not is_orm_attribute(column):
+            if not hasattr(column, 'local_attr'):
+                # This is a property or similar, not a real column
+                break
             join_attr = column.local_attr
 
             # This is a hack, to deal with the fact that SQLA doesn't


### PR DESCRIPTION
Otherwise we can't filter results in new snapshots.