### PR TITLE
JSONString: assume literal_bindparam is already jsonified

### DIFF
--- a/rest-service/manager_rest/storage/models_base.py
+++ b/rest-service/manager_rest/storage/models_base.py
@@ -96,7 +96,7 @@ class JSONString(db.TypeDecorator):
         except TypeError:
             if isinstance(value, _literal_bindparam):
                 # this is only ever _literal_bindparam in migrations
-                return json.dumps(value.value)
+                return value.value
             raise
 
     def process_result_value(self, value, engine):


### PR DESCRIPTION
We pass the string `null` here, so no need to jsonify it. Let's treat it like
an actual literal.