### PR TITLE
RD-4306 Migrations: do `alter type` outside transactions

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/1fbd6bf39e84_4_5_to_4_5_5.py
+++ b/resources/rest-service/cloudify/migrations/versions/1fbd6bf39e84_4_5_to_4_5_5.py
@@ -51,7 +51,8 @@ def upgrade():
                   sa.Column('scheduled_for', UTCDateTime(), nullable=True))
 
     # Add new execution status
-    op.execute("alter type execution_status add value 'scheduled'")
+    with op.get_context().autocommit_block():
+        op.execute("alter type execution_status add value 'scheduled'")
     op.add_column(
         'deployments',
         sa.Column('capabilities', sa.PickleType(comparator=lambda *a: False))

--- a/resources/rest-service/cloudify/migrations/versions/a6d00b128933_4_4_to_4_5.py
+++ b/resources/rest-service/cloudify/migrations/versions/a6d00b128933_4_4_to_4_5.py
@@ -20,8 +20,9 @@ def upgrade():
     op.add_column('executions',
                   sa.Column('started_at', UTCDateTime(), nullable=True))
 
-    # Add new execution status
-    op.execute("alter type execution_status add value 'queued'")
+    with op.get_context().autocommit_block():
+        # Add new execution status
+        op.execute("alter type execution_status add value 'queued'")
 
     # add execution_fk index to logs and events
     op.create_index(

--- a/resources/rest-service/cloudify/migrations/versions/c7652b2a97a4_4_3_to_4_4.py
+++ b/resources/rest-service/cloudify/migrations/versions/c7652b2a97a4_4_3_to_4_4.py
@@ -44,7 +44,8 @@ def upgrade():
     op.add_column('executions', sa.Column('ended_at',
                                           UTCDateTime(),
                                           nullable=True))
-    op.execute("alter type execution_status add value 'kill_cancelling'")
+    with op.get_context().autocommit_block():
+        op.execute("alter type execution_status add value 'kill_cancelling'")
 
 
 def downgrade():


### PR DESCRIPTION
Look, the `COMMIT` calls, that I got rid of in #3538, were required
after all!

Turns out, `alter type` must not run in a transaction:
```
sqlalchemy.exc.InternalError: (psycopg2.errors.ActiveSqlTransaction) ALTER TYPE ... ADD cannot run inside a transaction block
```

Unfortunate. But at least, instead of a bare `COMMIT`, we can use this
feature, that alembic added _specifically_ for this case.

It at least suggests that this is the command that must run outside
transactions, as opposed to a seemingly-unrelated bare `COMMIT`.

ref https://alembic.sqlalchemy.org/en/latest/api/runtime.html#alembic.runtime.migration.MigrationContext.autocommit_block