### PR TITLE
RD-4356 List the plugins installed as caravan

### DIFF
--- a/rest-service/manager_rest/rest/resources_v2/plugins.py
+++ b/rest-service/manager_rest/rest/resources_v2/plugins.py
@@ -93,7 +93,6 @@ class Plugins(SecuredResource):
         """
         storage_manager = get_storage_manager()
         is_caravan = False
-        installed_plugins = []
         get_resource_manager().assert_no_snapshot_creation_running_or_queued()
         try:
             plugins, code = UploadedCaravanManager().receive_uploaded_data(
@@ -107,9 +106,7 @@ class Plugins(SecuredResource):
             plugins = [plugin]
 
         if is_caravan:
-            storage_plugins = storage_manager.list(
-                models.Plugin,
-                filters={'id': [p.id for p in installed_plugins]})
+            storage_plugins = storage_manager.list(models.Plugin)
 
             return ListResponse(items=storage_plugins.items,
                                 metadata=storage_plugins.metadata), code


### PR DESCRIPTION
Until this change, the list of plugins returned after a caravan upload
was empty, which resulted in rather silly:

```
$ cfy plugins bundle-upload
Starting upload of plugins bundle, this may take few minutes to complete.
Bundle uploaded, 0 Plugins installed.
```

This is a cherry-pick of  #3547