### PR TITLE
deployment create-with-workdir: use makedirs

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -234,7 +234,7 @@ class DeploymentsId(resources_v1.DeploymentsId):
                 try:
                     workdir_path = _get_workdir_path(deployment_id,
                                                      deployment.tenant_name)
-                    os.mkdir(workdir_path)
+                    os.makedirs(workdir_path)
                     zip_path = os.path.join(tmpdir_path, 'dep.zip')
                     with open(zip_path, 'wb') as zip_handle:
                         zip_handle.write(

--- a/tests/integration_tests/resources/scripts/reset_storage.py
+++ b/tests/integration_tests/resources/scripts/reset_storage.py
@@ -121,6 +121,7 @@ def clean_dirs():
         '/opt/mgmtworker/env/source_plugins',
         '/opt/mgmtworker/work/deployments',
         '/opt/manager/resources/blueprints',
+        '/opt/manager/resources/deployments',
         '/opt/manager/resources/uploaded-blueprints',
         '/opt/manager/resources/snapshots/'
     ]


### PR DESCRIPTION
In case the tenant dir is missing (removed by.. something? maybe
removed by the reset-storage!), let's just create it. This also
mirrors the way we do it in create-dep-env, where we do use makedirs.

I'm not 100% happy to change the behaviour, because maybe
reset-storage could've just been more intelligent instead, but...
well, I think it's a good change anyway.