### PR TITLE
RD-4328 Allow filtering graphs by just execution-id

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/operations.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/operations.py
@@ -348,16 +348,20 @@ class TasksGraphs(SecuredResource):
     def get(self, _include=None, pagination=None, **kwargs):
         args = get_args_and_verify_arguments([
             Argument('execution_id', type=text_type, required=True),
-            Argument('name', type=text_type, required=True)
+            Argument('name', type=text_type, required=False)
         ])
         sm = get_storage_manager()
         execution_id = args.get('execution_id')
         name = args.get('name')
-        execution = sm.list(models.Execution, filters={'id': execution_id})[0]
+        execution = sm.get(models.Execution, execution_id)
+        filters = {'execution': execution}
+        if name:
+            filters['name'] = name
         return sm.list(
             models.TasksGraph,
-            filters={'execution': execution, 'name': name},
-            pagination=pagination
+            filters=filters,
+            pagination=pagination,
+            include=_include,
         )
 
 

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -2049,7 +2049,7 @@ class Agent(CreatedAtMixin, SQLResourceBase):
         return agent_dict
 
 
-class TasksGraph(SQLResourceBase):
+class TasksGraph(CreatedAtMixin, SQLResourceBase):
     __tablename__ = 'tasks_graphs'
     __table_args__ = (
         db.Index(
@@ -2062,7 +2062,6 @@ class TasksGraph(SQLResourceBase):
 
     id = db.Column(db.Text, index=True, default=lambda: str(uuid.uuid4()))
     name = db.Column(db.Text, index=True)
-    created_at = db.Column(UTCDateTime, nullable=False, index=True)
 
     _execution_fk = foreign_key(Execution._storage_id)
 

--- a/rest-service/manager_rest/test/endpoints/test_operations.py
+++ b/rest-service/manager_rest/test/endpoints/test_operations.py
@@ -98,30 +98,6 @@ class OperationsTestCase(OperationsTestBase, base_test.BaseServerTestCase):
 
 
 class TasksGraphsTestCase(OperationsTestBase, base_test.BaseServerTestCase):
-    def setUp(self):
-        super(TasksGraphsTestCase, self).setUp()
-        self.execution = self._execution()
-
-    def _execution(self, **kwargs):
-        return models.Execution(
-            created_at=datetime.utcnow(),
-            id='execution_{}'.format(uuid.uuid4()),
-            is_system_workflow=False,
-            workflow_id='install',
-            creator=self.user,
-            tenant=self.tenant,
-            **kwargs
-        )
-
-    def _graph(self, **kwargs):
-        exc = kwargs.pop('execution', self.execution)
-        return models.TasksGraph(
-            execution=exc,
-            creator=self.user,
-            tenant=self.tenant,
-            **kwargs
-        )
-
     def test_list_invalid(self):
         with pytest.raises(CloudifyClientError) as cm:
             self.client.tasks_graphs.list(execution_id='nonexistent')


### PR DESCRIPTION
No need to require the name. We can allow to just list all graphs
for the given execution.