### PR TITLE
RD-4410 Permissions api: handle duplicated permissions

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/permissions.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/permissions.py
@@ -52,12 +52,20 @@ class PermissionsRoleId(SecuredResource):
     def put(self, role_name, permission_name):
         """Allow role_name the permission permission_name"""
         sm = get_storage_manager()
-        role = sm.get(models.Role, None, filters={'name': role_name})
-        perm = models.Permission(
-            role=role,
-            name=permission_name
-        )
         with sm.transaction():
+            role = sm.get(models.Role, None, filters={'name': role_name})
+            already_exists = models.Permission.query.filter_by(
+                role=role,
+                name=permission_name,
+            ).first()
+            if already_exists:
+                raise manager_exceptions.ConflictError(
+                    f'{role_name} already has permission {permission_name}')
+
+            perm = models.Permission(
+                role=role,
+                name=permission_name
+            )
             role.updated_at = datetime.utcnow()
             sm.put(perm)
             sm.put(role)

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -55,7 +55,7 @@ class Permission(SQLModelBase):
     role_id = foreign_key('roles.id')
     name = db.Column(db.Text, nullable=False)
 
-    role = db.relationship(Role)
+    role = db.relationship(Role, backref='permissions')
     role_name = association_proxy('role', 'name')
 
     def to_response(self, include=None, get_data=False, **kwargs):

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -264,6 +264,7 @@ class BaseServerTestCase(unittest.TestCase):
                         client.execution_schedules.api = mock_http_client
                         client.blueprints_labels.api = mock_http_client
                         client.workflows.api = mock_http_client
+                        client.permissions.api = mock_http_client
 
         return client
 

--- a/rest-service/manager_rest/test/endpoints/test_permissions.py
+++ b/rest-service/manager_rest/test/endpoints/test_permissions.py
@@ -1,0 +1,48 @@
+import mock
+import pytest
+
+from cloudify_rest_client.exceptions import UserUnauthorizedError
+
+from manager_rest.storage import db, models
+from manager_rest.test import base_test
+
+
+class TestPermissions(base_test.BaseServerTestCase):
+    def test_not_admin(self):
+        with mock.patch('manager_rest.utils.is_administrator',
+                        return_value=False):
+            with pytest.raises(UserUnauthorizedError):
+                self.client.permissions.list()
+
+    def test_get_all(self):
+        permissions = self.client.permissions.list()
+        assert len(permissions) == models.Permission.query.count()
+
+    def test_get_for_role(self):
+        role = models.Role.query.first()
+        permissions = self.client.permissions.list(role=role.name)
+        assert len(permissions) == len(role.permissions)
+
+    def test_put(self):
+        role = models.Role.query.first()
+        permission_name = 'something very unique'
+        self.client.permissions.add(
+            role=role.name,
+            permission=permission_name,
+        )
+        retrieved = self.client.permissions.list(role=role.name)
+        assert permission_name in {p['permission'] for p in retrieved}
+
+    def test_delete(self):
+        role = models.Role.query.first()
+        permission_name = 'something very unique'
+        self.client.permissions.add(
+            role=role.name,
+            permission=permission_name,
+        )
+        self.client.permissions.delete(
+            role=role.name,
+            permission=permission_name,
+        )
+        retrieved = self.client.permissions.list(role=role.name)
+        assert permission_name not in {p['permission'] for p in retrieved}

--- a/rest-service/manager_rest/test/endpoints/test_permissions.py
+++ b/rest-service/manager_rest/test/endpoints/test_permissions.py
@@ -1,7 +1,10 @@
 import mock
 import pytest
 
-from cloudify_rest_client.exceptions import UserUnauthorizedError
+from cloudify_rest_client.exceptions import (
+    CloudifyClientError,
+    UserUnauthorizedError
+)
 
 from manager_rest.storage import db, models
 from manager_rest.test import base_test
@@ -46,3 +49,30 @@ class TestPermissions(base_test.BaseServerTestCase):
         )
         retrieved = self.client.permissions.list(role=role.name)
         assert permission_name not in {p['permission'] for p in retrieved}
+
+    def test_put_already_existing(self):
+        role = models.Role.query.first()
+        permission = role.permissions[0]
+        with pytest.raises(CloudifyClientError) as cm:
+            self.client.permissions.add(
+                role=role.name,
+                permission=permission.name,
+            )
+        assert cm.value.status_code == 409
+
+    def test_put_two_roles(self):
+        """Put the same permission for two roles.
+
+        Let's make sure that the uniqueness check doesn't actually break
+        giving two different roles the same permission!
+        """
+        role1, role2 = models.Role.query.limit(2)
+        permission_name = 'something very unique'
+        for role in role1, role2:
+            self.client.permissions.add(
+                role=role.name,
+                permission=permission_name,
+            )
+        for role in role1, role2:
+            retrieved = self.client.permissions.list(role=role.name)
+            assert permission_name in {p['permission'] for p in retrieved}


### PR DESCRIPTION
- don't allow creating the same permission twice
- ..but if someone did, do allow deleting them

Like, this would've been better as a `UNIQUE` constraint, but
I'm not gonna add a constraint before new snapshots. Because
that would just explode in upgrade, if someone already had
duplicates.