### PR TITLE
inte-tests: handle missing stash[benchstorage]

### DIFF
--- a/tests/integration_tests/tests/benchmarks/conftest.py
+++ b/tests/integration_tests/tests/benchmarks/conftest.py
@@ -44,6 +44,6 @@ def pytest_sessionstart(session):
 
 def pytest_sessionfinish(session, exitstatus):
     print('\nBENCHMARK RESULTS')
-    for name, timings in session.stash['benchstorage'].items():
+    for name, timings in session.stash.get('benchstorage', {}).items():
         for timing, (start, stop) in timings.records.items():
             log_result(name, timing, start, stop)


### PR DESCRIPTION
I'm not sure why would it be missing, pytest_sessionstart is right
there, but apparently it sometimes doesnt run.