### PR TITLE
Use correct legacy token get permission

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/tokens.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/tokens.py
@@ -21,7 +21,7 @@ from manager_rest.utils import is_expired
 
 class Tokens(SecuredResource):
 
-    @authorize('user_token')
+    @authorize('token_get')
     def get(self):
         """
         Get token by user id


### PR DESCRIPTION
While stage is switching over, GET on tokens should still work.
With the wrong permission (not copied correctly during the refactor),
it'll only work for admin.