### PR TITLE
RD-4433 apiservice: hack around asyncpg.connect + sqla + ssl

### DIFF
--- a/api-service/cloudify_api/server.py
+++ b/api-service/cloudify_api/server.py
@@ -1,3 +1,4 @@
+import ssl
 import logging
 
 from fastapi import FastAPI
@@ -8,6 +9,47 @@ from cloudify_api.config import Settings
 from cloudify_api.listener import Listener
 from cloudify_api.log import setup_logger
 from cloudify_api import db
+
+# THIS IS A HACK
+# asyncpg's connect doesn't play nice with sqlalchemy's url parsing.
+# This defines a wrapper around it that fixes up the kwargs to a form
+# that will allow connecting with ssl client certs & CA cert verification
+# This can be removed once sqlalchemy fixes its asyncpg driver
+import asyncpg
+
+original_connect = asyncpg.connect
+
+
+def _hack_asyncpg_ssl_connect(*a, **kw):
+    """Call asyncpg.connect in a way that allows using client & CA certs.
+
+    SQLAlchemy parses the whole db url, and passes here just kwargs, like
+    kw={'host': 'example.com', 'sslcert': '/cert.pem'} etc.
+    This isn't compatible with asyncpg, because asyncpg can accept sslcert,
+    sslkey, sslrootcert and sslcrl as part of the db url, but not as separate
+    kwargs. When passing separate kwargs, like sqlalchemy does, it must be
+    just a "ssl" argument, that is the ssl context, with all the certs
+    already loaded into it.
+    """
+    if 'sslmode' in kw:
+        sslmode = kw.pop('sslmode')
+        if sslmode != 'disable':
+            if 'sslrootcert' in kw:
+                sslrootcert = kw.pop('sslrootcert')
+                sslctx = ssl.create_default_context(
+                    ssl.Purpose.SERVER_AUTH, cafile=sslrootcert)
+                sslctx.check_hostname = True
+            if 'sslcert' in kw:
+                sslcert = kw.pop('sslcert')
+                sslkey = kw.pop('sslkey')
+                sslctx.load_cert_chain(sslcert, sslkey)
+        else:
+            sslctx = False
+        kw['ssl'] = sslctx
+    return original_connect(*a, **kw)
+
+
+asyncpg.connect = _hack_asyncpg_ssl_connect
 
 
 def get_settings():


### PR DESCRIPTION
Just see the docstring for explanation.

With this, apiservice should be able to run on clusters. Otherwise
it doesn't work at all, when postgres ssl verification is requested.