### PR TITLE
Properly map name_pattern constraints to filter rules

### DIFF
--- a/rest-service/manager_rest/rest/search_utils.py
+++ b/rest-service/manager_rest/rest/search_utils.py
@@ -173,6 +173,13 @@ def get_filter_rules(resource_model,
                                                 resource_model)
         filter_id = raw_filter_id
     elif not raw_filter and dsl_constraints:
+        if 'name_pattern' in dsl_constraints:
+            if resource_model == Deployment:
+                dsl_constraints['display_name_specs'] = \
+                    dsl_constraints.pop('name_pattern')
+            elif resource_model == Blueprint:
+                dsl_constraints['id_specs'] = \
+                    dsl_constraints.pop('name_pattern')
         filter_id, filter_rules = parse_constraints(dsl_constraints)
     elif not raw_filter and not dsl_constraints:
         return []


### PR DESCRIPTION
Because it depends on resource model in use:
* for Blueprints `id` will be compared with constraint's name_pattern
* for Deployments it will be `display_name`