### PR TITLE
RD-4482 Blueprint validate: return the execution

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -348,6 +348,7 @@ def _validate_imported_blueprints(sm, blueprint, imported_blueprints):
 
 class BlueprintsIdValidate(BlueprintsId):
     @authorize('blueprint_upload')
+    @rest_decorators.marshal_with(models.Execution)
     def put(self, blueprint_id, **kwargs):
         """
         Validate a blueprint (id specified)

--- a/rest-service/manager_rest/upload_manager.py
+++ b/rest-service/manager_rest/upload_manager.py
@@ -620,11 +620,10 @@ class UploadedBlueprintsValidator(UploadedBlueprintsManager):
                     "chunked.".format(self._get_kind()))
             blueprint_url = request.args[self._get_data_url_key()]
 
-        self._prepare_and_process_doc(
+        return self._prepare_and_process_doc(
             blueprint_id,
             blueprint_url,
             application_file_name=args.application_file_name)
-        return "", 204
 
     def _prepare_and_process_doc(self, data_id, blueprint_url,
                                  application_file_name):
@@ -660,6 +659,7 @@ class UploadedBlueprintsValidator(UploadedBlueprintsManager):
             self.cleanup_blueprint_archive_from_file_server(
                 data_id, current_tenant.name)
             raise
+        return temp_blueprint.upload_execution
 
 
 class UploadedPluginsManager(UploadedDataManager):

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_removal.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_removal.py
@@ -261,13 +261,13 @@ class TestDeploymentUpdateRemoval(DeploymentUpdateBase):
         wait_for_blueprint_upload(BLUEPRINT_ID, self.client)
         self._do_update(deployment.id, BLUEPRINT_ID)
 
-        self.assertRaisesRegexp(CloudifyClientError,
-                                'Workflow {0} does not exist in deployment {1}'
-                                .format(workflow_id, deployment.id),
-                                callable_obj=self.client.executions.start,
-                                deployment_id=deployment.id,
-                                workflow_id=workflow_id,
-                                parameters={'node_id': 'site1'})
+        self.assertRaisesRegex(CloudifyClientError,
+                               'Workflow {0} does not exist in deployment {1}'
+                               .format(workflow_id, deployment.id),
+                               callable_obj=self.client.executions.start,
+                               deployment_id=deployment.id,
+                               workflow_id=workflow_id,
+                               parameters={'node_id': 'site1'})
 
         deployment = self.client.deployments.get(deployment.id)
         self.assertNotIn('my_custom_workflow',

--- a/tests/integration_tests/tests/agentless_tests/test_agent_alive_verification.py
+++ b/tests/integration_tests/tests/agentless_tests/test_agent_alive_verification.py
@@ -33,8 +33,8 @@ class TestAgentAliveVerification(AgentlessTestCase):
                                   })
 
     def test_install(self):
-        with self.assertRaisesRegexp(RuntimeError,
-                                     "Workflow execution failed:"):
+        with self.assertRaisesRegex(RuntimeError,
+                                    "Workflow execution failed:"):
             self.deploy_application(
                     resource("dsl/basic_start_not_exists.yaml"))
 

--- a/tests/integration_tests/tests/agentless_tests/test_blueprint_upload.py
+++ b/tests/integration_tests/tests/agentless_tests/test_blueprint_upload.py
@@ -251,20 +251,16 @@ class BlueprintValidateTest(AgentlessTestCase):
 
     def _verify_blueprint_validation_with_message(
             self, blueprint_id, blueprint_resource, message):
-        self.client.blueprints.validate(
+        exc = self.client.blueprints.validate(
             blueprint_resource,
             entity_id=blueprint_id
         )
+        print('exc', exc.id)
         temp_blueprint_id = self._assert_blueprint_validation_message(
-            blueprint_id, message)
+            exc, message)
         self._assert_cleanup(temp_blueprint_id)
 
-    def _assert_blueprint_validation_message(self, blueprint_id, message):
-        execution = [
-            ex for ex in
-            self.client.executions.list(workflow_id='upload_blueprint') if
-            blueprint_id in ex['parameters']['blueprint_id']
-        ][-1]   # get latest upload execution for blueprint
+    def _assert_blueprint_validation_message(self, execution, message):
         try:
             self.wait_for_execution_to_end(execution)
         except RuntimeError as e:

--- a/tests/integration_tests/tests/agentless_tests/test_blueprint_upload.py
+++ b/tests/integration_tests/tests/agentless_tests/test_blueprint_upload.py
@@ -57,7 +57,7 @@ class BlueprintUploadTest(AgentlessTestCase):
     def test_blueprint_upload_from_unavailable_url(self):
         blueprint_id = 'bp-url-unavailable'
         archive_url = 'http://www.fake.url/does/not/exist'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             CloudifyClientError,
             'failed uploading.* Max retries exceeded with url',
             self.client.blueprints.publish_archive,
@@ -84,7 +84,7 @@ class BlueprintUploadTest(AgentlessTestCase):
         blueprint_id = 'bp-url-bad-format'
         archive_url = 'https://cloudify-tests-files.s3-eu-west-1.amazonaws' \
                       '.com/index.html'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             CloudifyClientError,
             'failed uploading.* '
             'Blueprint archive is of an unrecognized format',
@@ -96,7 +96,7 @@ class BlueprintUploadTest(AgentlessTestCase):
         blueprint_id = 'bp-url-bad-structure'
         archive_url = 'https://cloudify-tests-files.s3-eu-west-1.amazonaws' \
                       '.com/blueprints/not-a-valid-archive.zip'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             CloudifyClientError,
             'failed extracting.* '
             'Archive must contain exactly 1 directory',
@@ -109,7 +109,7 @@ class BlueprintUploadTest(AgentlessTestCase):
         blueprint_filename = 'fancy_name.yaml'
         archive_url = 'https://cloudify-tests-files.s3-eu-west-1.amazonaws' \
                       '.com/blueprints/the-not-blueprint-master.zip'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             CloudifyClientError,
             'failed extracting.* {0} does not exist in the application '
             'directory'.format(blueprint_filename),
@@ -121,11 +121,11 @@ class BlueprintUploadTest(AgentlessTestCase):
     def test_blueprint_reupload_after_fail(self):
         blueprint_id = 're-bp'
         # this should fail due to cloudmock plugin not uploaded
-        self.assertRaisesRegexp(CloudifyClientError,
-                                'Couldn\'t find plugin "cloudmock"',
-                                self.client.blueprints.upload,
-                                resource('dsl/basic.yaml'),
-                                entity_id=blueprint_id)
+        self.assertRaisesRegex(CloudifyClientError,
+                               'Couldn\'t find plugin "cloudmock"',
+                               self.client.blueprints.upload,
+                               resource('dsl/basic.yaml'),
+                               entity_id=blueprint_id)
         blueprint = self.client.blueprints.get(blueprint_id)
         self.assertEqual(blueprint['state'], BlueprintUploadState.INVALID)
         self.assertEqual(blueprint.plan, None)
@@ -169,7 +169,7 @@ class BlueprintUploadTest(AgentlessTestCase):
                                            {'cloudify': cloudify_section})
 
         blueprint_id = 'bp-resolver-error'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             CloudifyClientError,
             'failed parsing.* Failed to instantiate resolver',
             self.client.blueprints.upload,
@@ -181,7 +181,7 @@ class BlueprintUploadTest(AgentlessTestCase):
 
     def test_blueprint_upload_malformed_dsl(self):
         blueprint_id = 'bp-malformed-dsl'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             CloudifyClientError,
             "invalid.* Expected 'dict' type but found 'string' type",
             self.client.blueprints.upload,
@@ -274,10 +274,10 @@ class BlueprintValidateTest(AgentlessTestCase):
 
     def _assert_cleanup(self, blueprint_id):
         # blueprint entry deleted
-        self.assertRaisesRegexp(CloudifyClientError,
-                                '404: .* not found',
-                                self.client.blueprints.get,
-                                blueprint_id)
+        self.assertRaisesRegex(CloudifyClientError,
+                               '404: .* not found',
+                               self.client.blueprints.get,
+                               blueprint_id)
         admin_headers = self.client._client.headers
         # blueprint folder deleted from uploaded blueprints
         resp = requests.get(

--- a/tests/integration_tests/tests/agentless_tests/test_blueprint_upload_autoupload_plugins.py
+++ b/tests/integration_tests/tests/agentless_tests/test_blueprint_upload_autoupload_plugins.py
@@ -29,7 +29,7 @@ class BlueprintUploadAutouploadPluginsTest(AgentlessTestCase):
         blueprint_id = 'bp_bad_version'
         blueprint_filename = 'blueprint_with_plugins_from_' \
                              'catalog_bad_version.yaml'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             CloudifyClientError,
             'Couldn\'t find plugin "cloudify-openstack-plugin" with.*=3.1.99',
             self.client.blueprints.upload,
@@ -42,7 +42,7 @@ class BlueprintUploadAutouploadPluginsTest(AgentlessTestCase):
         blueprint_id = 'bp_bad_plugin'
         blueprint_filename = 'blueprint_with_plugins_from_' \
                              'catalog_bad_plugin.yaml'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             CloudifyClientError,
             'Couldn\'t find plugin "my-custom-plugin"',
             self.client.blueprints.upload,
@@ -55,7 +55,7 @@ class BlueprintUploadAutouploadPluginsTest(AgentlessTestCase):
         blueprint_id = 'bp_two_plugin_versions'
         blueprint_filename = 'blueprint_with_plugins_from_' \
                              'catalog_conflicting_versions.yaml'
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             CloudifyClientError,
             'Could not merge \'plugins\' due to conflict on \'openstack\'',
             self.client.blueprints.upload,

--- a/tests/integration_tests/tests/agentless_tests/test_secrets.py
+++ b/tests/integration_tests/tests/agentless_tests/test_secrets.py
@@ -43,7 +43,7 @@ class SecretsTest(AgentlessTestCase):
         self.assertEqual('test_value2', updated_secret.value)
 
     def test_get_secret_not_found(self):
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             CloudifyClientError,
             '404: Requested `Secret` with ID `test_key` was not found',
             self.client.secrets.get,
@@ -53,7 +53,7 @@ class SecretsTest(AgentlessTestCase):
     def test_get_secret_intrinsic_function(self):
         dsl_path = resource("dsl/basic_get_secret.yaml")
         error_msg = "Required secrets: .* don't exist in this tenant"
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             CloudifyClientError,
             error_msg,
             self.deploy_application,
@@ -71,8 +71,8 @@ class SecretsTest(AgentlessTestCase):
         viewer_client = self.create_rest_client(
             username='user', password='password', tenant='default_tenant',
         )
-        self.assertRaisesRegexp(ForbiddenError,
-                                '403: User `user` is not permitted to perform'
-                                ' the action secret_export in the tenant '
-                                '`default_tenant`',
-                                viewer_client.secrets.export)
+        self.assertRaisesRegex(ForbiddenError,
+                               '403: User `user` is not permitted to perform'
+                               ' the action secret_export in the tenant '
+                               '`default_tenant`',
+                               viewer_client.secrets.export)


### PR DESCRIPTION
Validating a blueprint is async, and only starts an execution in the
background.
Before, the user was expected to list the executions, and find the
one they just started, by workflow id and parameters.
That's a bit silly, so let's just return the execution, so that the
user just receives the id they're supposed to poll.