### PR TITLE
RD-4400 Scale rollback: keep preexisting instances around

### DIFF
--- a/tests/integration_tests/resources/dsl/agent_tests/with_agent_scalable.yaml
+++ b/tests/integration_tests/resources/dsl/agent_tests/with_agent_scalable.yaml
@@ -1,0 +1,24 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+    - cloudify/types/types.yaml
+    - plugin:dockercompute
+
+node_templates:
+  agent_host:
+    type: cloudify.nodes.docker.Compute
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        precreate: dockercompute.dockercompute.operations.fail_on_scale
+
+groups:
+  group1:
+    members:
+      - agent_host
+
+policies:
+  policy:
+    type: cloudify.policies.scaling
+    targets: [group1]
+    properties:
+      default_instances: 1

--- a/tests/integration_tests/tests/agent_tests/test_agent_scale.py
+++ b/tests/integration_tests/tests/agent_tests/test_agent_scale.py
@@ -1,0 +1,34 @@
+import pytest
+
+from integration_tests import AgentTestCase
+from integration_tests.tests.utils import get_resource as resource
+
+pytestmark = pytest.mark.group_agents
+
+
+class TestScaleWithAgents(AgentTestCase):
+    def test_failed_scale_with_agents(self):
+        """After a failed scale, pre-existing agent entries aren't removed"""
+        deployment1, _ = self.deploy_application(resource(
+            "dsl/agent_tests/with_agent_scalable.yaml"), deployment_id='d1')
+        dep_id = deployment1.id
+        instances = self.client.node_instances.list(deployment_id=dep_id)
+        assert len(instances) == 1
+        agent_list = self.client.agents.list()
+        assert len(agent_list.items) == 1
+        exc = self.client.executions.start(
+            deployment_id=dep_id,
+            workflow_id='scale',
+            parameters={
+                'delta': 1,
+                'scalable_entity_name': 'group1',
+            },
+        )
+        with pytest.raises(RuntimeError):
+            self.wait_for_execution_to_end(exc)
+
+        instances = self.client.node_instances.list(deployment_id=dep_id)
+        assert len(instances) == 1
+        agent_list = self.client.agents.list()
+        assert len(agent_list.items) == 1
+        self.undeploy_application(dep_id)

--- a/tests/integration_tests_plugins/dockercompute/dockercompute/operations.py
+++ b/tests/integration_tests_plugins/dockercompute/dockercompute/operations.py
@@ -20,6 +20,7 @@ import tempfile
 
 from cloudify import ctx
 from cloudify.decorators import operation
+from cloudify.exceptions import NonRecoverableError
 
 
 @operation
@@ -68,3 +69,9 @@ def delete(**_):
 
     shutil.rmtree(os.path.expanduser('~cfyuser/{0}'.format(ctx.instance.id)))
     ctx.instance.runtime_properties.pop('ip', None)
+
+
+@operation
+def fail_on_scale(ctx, **_):
+    if ctx.workflow_id == 'scale':
+        raise NonRecoverableError("fail!")

--- a/tests/integration_tests_plugins/dockercompute/dockercompute/operations.py
+++ b/tests/integration_tests_plugins/dockercompute/dockercompute/operations.py
@@ -52,13 +52,18 @@ def start(ctx, **_):
 
 @operation
 def store_envdir(ctx, **_):
-    envdir = ctx.instance.runtime_properties['cloudify_agent']['envdir']
+    try:
+        envdir = ctx.instance.runtime_properties['cloudify_agent']['envdir']
+    except KeyError:
+        envdir = None
     ctx.instance.runtime_properties['envdir'] = envdir
 
 
 @operation
 def delete(**_):
     envdir = ctx.instance.runtime_properties['envdir']
+    if not envdir:
+        return
     daemon_delete_cmd = [
         os.path.join(envdir, 'bin', 'cfy-agent'),
         'daemons', 'delete', '--name', ctx.instance.id


### PR DESCRIPTION
We can't just delete all of them and then recreate. That of course
would cascade and delete all related objects (eg: agents table).

Instead, do the usual 3-step program of "delete the ones that are
missing from old, add the ones that are missing from new, update
otherwise".

Also add an inte-test