### PR TITLE
RD-4553 update_managers_version: load configuration

### DIFF
--- a/rest-service/manager_rest/update_managers_version.py
+++ b/rest-service/manager_rest/update_managers_version.py
@@ -30,6 +30,14 @@ def update_managers_version(version):
 
 
 if __name__ == '__main__':
+    os.environ.setdefault(
+        'MANAGER_REST_CONFIG_PATH',
+        '/opt/manager/cloudify-rest.conf',
+    )
+    os.environ.setdefault(
+        'MANAGER_REST_SECURITY_CONFIG_PATH',
+        '/opt/manager/rest-security.conf',
+    )
     with setup_flask_app().app_context():
         config.instance.load_configuration()
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
THe envvars are required now.

FWIW
```
[root@89fdec379c0c /]# /opt/manager/env/bin/python -m manager_rest.update_managers_version 6.3.3
[root@89fdec379c0c /]# cfy mana li
You are trying to run cluster related commands on an all-in-one Cloudify Manager!

HA Cluster manager nodes
+--------------+------------+------------+---------+---------+--------------+----------------+--------------------------+---------------------------+
|   hostname   | private_ip | public_ip  | version | edition | distribution | distro_release |        last_seen         |          networks         |
+--------------+------------+------------+---------+---------+--------------+----------------+--------------------------+---------------------------+
| 89fdec379c0c | 172.17.0.2 | 172.17.0.2 |  6.3.3  | premium |    centos    |      Core      | 2022-03-22 09:19:45.137  | {'default': '172.17.0.2'} |
+--------------+------------+------------+---------+---------+--------------+----------------+--------------------------+---------------------------+
```