### PR TITLE
RD-4567 test_audit_log: expect the currently-correct amount of logs

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_audit_log.py
+++ b/tests/integration_tests/tests/agentless_tests/test_audit_log.py
@@ -128,7 +128,8 @@ class AuditLogMultiTenantTest(AgentlessTestCase):
         assert len(all_audit_logs) != []
         assert len(user_0_audit_logs) < len(all_audit_logs)
         assert len(user_1_audit_logs) < len(all_audit_logs)
-        assert len(user_0_audit_logs) == len(user_1_audit_logs)
+        # add +1 because the second auditlog.list call also emits an audit log
+        assert len(user_0_audit_logs) + 1 == len(user_1_audit_logs)
         assert set((log['ref_table'], log['ref_id'])
                    for log in user_0_audit_logs)\
             .isdisjoint(set((log['ref_table'], log['ref_id'])


### PR DESCRIPTION
This is just how many logs we emit right now. Because we also emit
a log on that .list() request as well.

Should we? I don't know. That's for RD-4567 to decide. But for right
now we do it this way, so let's assert this way as well.