### PR TITLE
RD-4575 components: consider different tenant an external host

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/shared_resource/test_multi_tenancy.py
+++ b/tests/integration_tests/tests/agentless_tests/shared_resource/test_multi_tenancy.py
@@ -1,0 +1,46 @@
+import pytest
+from integration_tests import AgentlessTestCase
+from integration_tests.tests.utils import wait_for_blueprint_upload
+
+pytestmark = pytest.mark.group_premium
+
+
+class TestMultiTenantSharedResource(AgentlessTestCase):
+    def test_install_shared_resource(self):
+        tenant_name = 't2'
+        shared_resource_bp_id = 'shared-resource-bp'
+        shared_resource_path = self.make_yaml_file("""
+tosca_definitions_version: cloudify_dsl_1_3
+imports:
+  - cloudify/types/types.yaml
+""")
+        client_blueprint_path = self.make_yaml_file(f"""
+tosca_definitions_version: cloudify_dsl_1_3
+imports:
+  - cloudify/types/types.yaml
+node_templates:
+  resource_deployment:
+    type: cloudify.nodes.ServiceComponent
+    properties:
+      client:
+        host: 127.0.0.1
+        username: admin
+        password: admin
+        tenant: {tenant_name}
+        protocol: https
+        trust_all: true
+      resource_config:
+        blueprint:
+          external_resource: true
+          id: {shared_resource_bp_id}
+        deployment:
+          id: shared-resource-deployment
+""")
+
+        self.client.tenants.create(tenant_name)
+        t2_client = self.create_rest_client(tenant='t2')
+        t2_client.blueprints.upload(
+            shared_resource_path, shared_resource_bp_id)
+        wait_for_blueprint_upload(shared_resource_bp_id, t2_client)
+
+        self.deploy_application(client_blueprint_path)


### PR DESCRIPTION
Yeah, I don't know what else to do. 
It doesn't seem there's a REST call we can do that'd make sense, to
attach those IDDs - neither of the clients (local or external) is guaranteed
to have access to both tenants. In fact, that might very well be the reason
we use a separate client, because our current user doesn't have access
to the other tenant.

So, I just give up, and treat the "other tenant" client as an external client.
This means no blocking IDDs between them. Too bad.
