### PR TITLE
RD-4626 create_auth_token: replace db.session with sm.put

### DIFF
--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -36,6 +36,7 @@ from .models_base import (
     SQLModelBase,
     UTCDateTime,
 )
+from .storage_manager import get_storage_manager
 
 
 class ProviderContext(SQLModelBase):
@@ -492,11 +493,9 @@ class User(SQLModelBase, UserMixin):
             description=description,
             secret_hash=hash_password(secret),
             expiration_date=expiration_date,
-            _user_fk=self.id,
+            user=self,
         )
-
-        db.session.add(token)
-        db.session.commit()
+        get_storage_manager().put(token)
 
         # Return the token with the secret or it'll never be usable
         token._secret = secret


### PR DESCRIPTION
Avoid committing explicitly, because that could break the encapsulating
transaction. Instead, sm.put commits only when necessary (ie. when
we're not in a transaction).

Also, `user=self,` rather than `_user_fk`, because providing a fk
means that `t.user` will only be set after committing (when the token
object gets repopulated from the database).