### PR TITLE
inte-tests: rewrite some test_audit_log asserts

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_audit_log.py
+++ b/tests/integration_tests/tests/agentless_tests/test_audit_log.py
@@ -131,11 +131,11 @@ class AuditLogMultiTenantTest(AgentlessTestCase):
 
         user_0_resource_logs = {
             (log['ref_table'], log['ref_id']) for log in user_0_audit_logs
-            if log['ref_table'] not in  {'usage_collector', 'users'}
+            if log['ref_table'] not in {'usage_collector', 'users'}
         }
         user_1_resource_logs = {
             (log['ref_table'], log['ref_id']) for log in user_1_audit_logs
-            if log['ref_table'] not in  {'usage_collector', 'users'}
+            if log['ref_table'] not in {'usage_collector', 'users'}
         }
         assert user_0_resource_logs.isdisjoint(user_1_resource_logs)
 


### PR DESCRIPTION
Eh. Anyway, asserting on more specific things, rather than the
very-broad "count all auditlogs". We can't guarantee they're always
going to be this way, and this many, in the face of all the users table
and usage_collector table updates (on each request)