### PR TITLE
RD-4613 Don't allow intrinsic functions as `capability_value`

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/searches.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/searches.py
@@ -4,6 +4,8 @@ from flask import request
 from flask_restful.reqparse import Argument
 from flask_restful_swagger import swagger
 
+from dsl_parser.functions import is_function
+
 from manager_rest import manager_exceptions
 from manager_rest.security import SecuredResource
 from manager_rest.security.authorization import authorize
@@ -335,6 +337,8 @@ class CapabilitiesSearches(ResourceSearches):
             if not dep.capabilities:
                 continue
             for key, capability in dep.capabilities.items():
+                if is_function(capability.get('value')):
+                    continue
                 if capability_matches(key, capability, constraints, search):
                     dep_capabilities[dep.id].append({key: capability})
 

--- a/rest-service/manager_rest/rest/search_utils.py
+++ b/rest-service/manager_rest/rest/search_utils.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 
+from dsl_parser.functions import is_function
+
 from manager_rest.manager_exceptions import BadParametersError
 from manager_rest.storage.models import (Blueprint, BlueprintsFilter,
                                          Deployment, DeploymentsFilter,
@@ -162,6 +164,8 @@ class GetValuesWithStorageManager:
             if not dep.capabilities:
                 continue
             for key, capability in dep.capabilities.items():
+                if is_function(capability.get('value')):
+                    continue
                 if capability_matches(key, capability, capability_value,
                                       valid_values, capability_key_specs):
                     dep_capabilities[dep.id].append({key: capability})


### PR DESCRIPTION
Inputs or workflow parameters of type `capability_value` should not be
allowed to be in a form of an intrinsic functions.