### PR TITLE
RD-4688 kill-cancel: kill mgmtworker operations

### DIFF
--- a/mgmtworker/mgmtworker/worker.py
+++ b/mgmtworker/mgmtworker/worker.py
@@ -285,6 +285,7 @@ class MgmtworkerServiceTaskConsumer(ServiceTaskConsumer):
         }
         if target == self.exchange:
             client = get_client()
+            exchange_type = 'fanout'
         else:
             tenant = get_tenant()
             client = get_client(
@@ -292,8 +293,13 @@ class MgmtworkerServiceTaskConsumer(ServiceTaskConsumer):
                 amqp_pass=tenant['rabbitmq_password'],
                 amqp_vhost=tenant['rabbitmq_vhost']
             )
+            exchange_type = 'direct'
 
-        handler = SendHandler(exchange=target, routing_key='service')
+        handler = SendHandler(
+            exchange=target,
+            routing_key='service',
+            exchange_type=exchange_type,
+        )
         client.add_handler(handler)
         with client:
             handler.publish(message)

--- a/mgmtworker/mgmtworker/worker.py
+++ b/mgmtworker/mgmtworker/worker.py
@@ -11,7 +11,6 @@ from contextlib import contextmanager
 from cloudify import broker_config
 from cloudify.logs import setup_agent_logger
 from cloudify.utils import get_admin_api_token, get_tenant
-from cloudify.constants import MGMTWORKER_QUEUE
 from cloudify.models_states import ExecutionState
 from cloudify.state import current_workflow_ctx
 from cloudify.manager import get_rest_client, update_execution_status

--- a/mgmtworker/mgmtworker/worker.py
+++ b/mgmtworker/mgmtworker/worker.py
@@ -283,7 +283,7 @@ class MgmtworkerServiceTaskConsumer(ServiceTaskConsumer):
                 'kwargs': {'execution_id': execution_id}
             }
         }
-        if target == MGMTWORKER_QUEUE:
+        if target == self.exchange:
             client = get_client()
         else:
             tenant = get_tenant()
@@ -304,7 +304,7 @@ class MgmtworkerServiceTaskConsumer(ServiceTaskConsumer):
         Note that mgmtworker is related to all executions, since every
         execution might have a central_deployment_agent operation.
         """
-        yield MGMTWORKER_QUEUE
+        yield self.exchange
         execution = rest_client.executions.get(execution_id)
         node_instances = rest_client.node_instances.list(
             deployment_id=execution.deployment_id,

--- a/tests/integration_tests/tests/agent_tests/test_cancel.py
+++ b/tests/integration_tests/tests/agent_tests/test_cancel.py
@@ -1,0 +1,86 @@
+import subprocess
+
+import pytest
+import retrying
+
+from integration_tests import AgentTestCase
+
+pytestmark = pytest.mark.group_workflows
+
+
+@pytest.mark.usefixtures('cloudmock_plugin')
+@pytest.mark.usefixtures('dockercompute_plugin')
+class TestAgentCancel(AgentTestCase):
+    def test_kill_cancel(self):
+        """Check that kill-cancel does kill operations
+
+        Run operations that take a long time, kill-cancel the execution,
+        and assert that the operation processes exist no longer (eventually,
+        it's all async).
+        """
+        blueprint_path = self.make_yaml_file("""
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+    - cloudify/types/types.yaml
+    - plugin:cloudmock
+    - plugin:dockercompute
+
+node_templates:
+    agent_node:
+        type: cloudify.nodes.docker.Compute
+        interfaces:
+            test:
+                op:
+                    implementation: cloudmock.cloudmock.tasks.store_pid
+                    executor: host_agent
+    mgmtworker_node:
+        type: cloudify.nodes.Root
+        interfaces:
+            test:
+                op:
+                    implementation: cloudmock.cloudmock.tasks.store_pid
+                    executor: central_deployment_agent
+
+""")
+        dep, _ = self.deploy_application(blueprint_path)
+
+        pids = {'agent_node': None, 'mgmtworker_node': None}
+        exc = self.client.executions.start(
+            deployment_id=dep.id,
+            workflow_id='execute_operation',
+            parameters={'operation': 'test.op'},
+        )
+
+        @retrying.retry(wait_fixed=500, stop_max_attempt_number=120)
+        def wait_for_exec_to_start():
+            """Wait for the execution to start and store PIDs
+
+            The execution will store PIDs as runtime-props when the operations
+            actually run, which is going to take on the order of seconds
+            normally, but could take a bit more - the agent will have to
+            install the plugin.
+            """
+            node_instances = self.client.node_instances.list()
+            for ni in node_instances:
+                # this will keyerror out (and be retried) if the operation
+                # didnt run yet
+                pids[ni.node_id] = ni.runtime_properties['pid']
+
+        wait_for_exec_to_start()
+        assert None not in pids.values()
+
+        self.client.executions.cancel(exc.id, kill=True)
+
+        @retrying.retry(wait_fixed=500, stop_max_attempt_number=60)
+        def wait_for_cancel():
+            """Wait for the operation processes to be dead.
+
+            This should take on the order of seconds.
+            """
+            for pid in pids.values():
+                # ps will return nonzero when the pid doesn't exist
+                with pytest.raises(subprocess.CalledProcessError):
+                    self.execute_on_manager(['ps', str(pid)])
+
+        wait_for_cancel()

--- a/tests/integration_tests_plugins/cloudmock/cloudmock/tasks.py
+++ b/tests/integration_tests_plugins/cloudmock/cloudmock/tasks.py
@@ -13,6 +13,7 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
+import os
 import time
 from cloudify.decorators import operation, workflow
 from cloudify.exceptions import NonRecoverableError
@@ -192,3 +193,14 @@ def workflow1(ctx):
 def wait(ctx, delay=5, **kwargs):
     time.sleep(delay)
     ctx.logger.info('wait done; slept %s', delay)
+
+
+@operation
+def store_pid(ctx, delay=180, **kwargs):
+    """Store our PID and sleep.
+
+    Useful for tests that involve kill-cancel.
+    """
+    ctx.instance.runtime_properties['pid'] = os.getpid()
+    ctx.instance.update()
+    time.sleep(delay)


### PR DESCRIPTION
Mgmtworker operations weren't killed, just because we used to send
the message to the wrong exchange. Whoops.