### PR TITLE
RD-4627 Use a long-running connection for amqp

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -37,8 +37,7 @@ from manager_rest.constants import (DEFAULT_TENANT_NAME,
                                     FILE_SERVER_BLUEPRINTS_FOLDER,
                                     FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER,
                                     FILE_SERVER_DEPLOYMENTS_FOLDER)
-from manager_rest.utils import (send_event,
-                                get_formatted_timestamp,
+from manager_rest.utils import (get_formatted_timestamp,
                                 is_create_global_permitted,
                                 validate_global_modification,
                                 validate_deployment_and_site_visibility,
@@ -2563,7 +2562,7 @@ class ResourceManager(object):
             }
         }
 
-        send_event(event, 'hook')
+        workflow_executor.send_hook(event)
 
     def update_resource_labels(self,
                                labels_resource_model,

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -364,7 +364,7 @@ class BaseServerTestCase(unittest.TestCase):
             patch('manager_rest.workflow_executor._broadcast_mgmtworker_task'),
             patch('manager_rest.workflow_executor.execute_workflow',
                   mock_send_mgmtworker_task),
-            patch('manager_rest.resource_manager.send_event'),
+            patch('manager_rest.workflow_executor.send_hook'),
         ]
         cls._patchers.extend(amqp_patches)
 

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -80,7 +80,7 @@ from .mocks import (
     MockHTTPClient,
     CLIENT_API_VERSION,
     build_query_string,
-    mock_send_mgmtworker_task,
+    mock_execute_workflow,
     upload_mock_cloudify_license
 )
 
@@ -359,11 +359,9 @@ class BaseServerTestCase(unittest.TestCase):
         """
         amqp_patches = [
             patch('manager_rest.amqp_manager.RabbitMQClient'),
-            patch('manager_rest.workflow_executor._send_mgmtworker_task',
-                  mock_send_mgmtworker_task),
             patch('manager_rest.workflow_executor._broadcast_mgmtworker_task'),
             patch('manager_rest.workflow_executor.execute_workflow',
-                  mock_send_mgmtworker_task),
+                  mock_execute_workflow),
             patch('manager_rest.workflow_executor.send_hook'),
         ]
         cls._patchers.extend(amqp_patches)

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -1031,7 +1031,7 @@ class ExecutionQueueingTests(BaseServerTestCase):
         # execution won't run because it is in a full group now
         assert self._get_queued() == []
 
-    @mock.patch('manager_rest.resource_manager.send_event', mock.Mock())
+    @mock.patch('manager_rest.workflow_executor.send_hook', mock.Mock())
     def test_already_running_queues(self):
         self._make_execution(status=ExecutionState.STARTED)
         exc2 = self._make_execution(status=ExecutionState.PENDING)
@@ -1042,7 +1042,7 @@ class ExecutionQueueingTests(BaseServerTestCase):
         self.rm.prepare_executions([exc2], queue=True)
         assert exc2.status == ExecutionState.QUEUED
 
-    @mock.patch('manager_rest.resource_manager.send_event', mock.Mock())
+    @mock.patch('manager_rest.workflow_executor.send_hook', mock.Mock())
     def test_system_wf_already_running_queues(self):
         exc1 = models.Execution(
             status=ExecutionState.STARTED,
@@ -1058,7 +1058,7 @@ class ExecutionQueueingTests(BaseServerTestCase):
         self.rm.prepare_executions([exc2], queue=True)
         assert exc2.status == ExecutionState.QUEUED
 
-    @mock.patch('manager_rest.resource_manager.send_event', mock.Mock())
+    @mock.patch('manager_rest.workflow_executor.send_hook', mock.Mock())
     def test_queue_before_create_finishes(self):
         """Execs queued before create-dep-env finished, have default params.
 
@@ -1105,7 +1105,7 @@ class ExecutionQueueingTests(BaseServerTestCase):
             'param2': 'default2',
         }
 
-    @mock.patch('manager_rest.resource_manager.send_event', mock.Mock())
+    @mock.patch('manager_rest.workflow_executor.send_hook', mock.Mock())
     def test_queue_nonexistent_workflow(self):
         """Dequeueing an execution of a nonexistent workflow, fails."""
         dep = models.Deployment(

--- a/rest-service/manager_rest/test/mocks.py
+++ b/rest-service/manager_rest/test/mocks.py
@@ -191,7 +191,7 @@ def task_state():
     return Execution.TERMINATED
 
 
-def mock_send_mgmtworker_task(messages, **_):
+def mock_execute_workflow(messages, **_):
     for message in messages:
         execution_id = message['id']
         sm = get_storage_manager()

--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -18,10 +18,9 @@ from flask_security import current_user
 
 from dsl_parser.constants import HOST_AGENT_PLUGINS_TO_INSTALL
 
-from cloudify import logs
 from cloudify.constants import BROKER_PORT_SSL
 from cloudify.models_states import VisibilityState
-from cloudify.amqp_client import create_events_publisher, get_client
+from cloudify.amqp_client import get_client
 
 from manager_rest import constants, config, manager_exceptions
 

--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -264,22 +264,6 @@ def remove(path):
             shutil.rmtree(path)
 
 
-def send_event(event, message_type):
-    logs.populate_base_item(event, 'cloudify_event')
-    events_publisher = create_events_publisher(
-        amqp_host=config.instance.amqp_host,
-        amqp_user=config.instance.amqp_username,
-        amqp_pass=config.instance.amqp_password,
-        amqp_port=BROKER_PORT_SSL,
-        amqp_vhost='/',
-        ssl_enabled=True,
-        ssl_cert_data=config.instance.amqp_ca,
-    )
-
-    events_publisher.publish_message(event, message_type)
-    events_publisher.close()
-
-
 def is_visibility_wider(first, second):
     states = VisibilityState.STATES
     return states.index(first) > states.index(second)

--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -45,6 +45,12 @@ def execute_workflow(messages):
         handler.publish(message)
 
 
+def send_hook(event):
+    logs.populate_base_item(event, 'cloudify_event')
+    handler = get_amqp_handler('hook')
+    handler.publish(event)
+
+
 def _get_tenant_dict():
     return {'name': utils.current_tenant.name}
 
@@ -66,6 +72,11 @@ def get_amqp_client(tenant=None):
 
 def workflow_sendhandler() -> SendHandler:
     return SendHandler(MGMTWORKER_QUEUE, 'direct', routing_key='workflow')
+
+
+def hooks_sendhandler() -> SendHandler:
+    return SendHandler(EVENTS_EXCHANGE_NAME, exchange_type='topic',
+                       routing_key='events.hooks')
 
 
 def _send_mgmtworker_task(message, exchange=MGMTWORKER_QUEUE,

--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -79,17 +79,6 @@ def hooks_sendhandler() -> SendHandler:
                        routing_key='events.hooks')
 
 
-def _send_mgmtworker_task(message, exchange=MGMTWORKER_QUEUE,
-                          exchange_type='direct', routing_key='workflow'):
-    """Send a message to the mgmtworker exchange"""
-    client = get_amqp_client()
-    send_handler = SendHandler(exchange, exchange_type,
-                               routing_key=routing_key)
-    client.add_handler(send_handler)
-    with client:
-        send_handler.publish(message)
-
-
 def _broadcast_mgmtworker_task(message, exchange='cloudify-mgmtworker-service',
                                exchange_type='fanout', routing_key='service'):
     """Broadcast a message to all mgmtworkers in a cluster."""

--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -59,6 +59,7 @@ def get_amqp_client(tenant=None):
         amqp_vhost=vhost,
         ssl_enabled=True,
         ssl_cert_data=config.instance.amqp_ca,
+        connect_timeout=None,
     )
     return client
 


### PR DESCRIPTION
Instead of creating the amqp client when necessary, create it on first
access, and store it. That way, we only pay the high cost of setting up
a TLS connection to rabbitmq once.