### PR TITLE
RD-4817 Support include on plugin updates

### DIFF
--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -149,11 +149,7 @@ class SQLStorageManager(object):
             query = query.distinct(*distinct)
 
         if joins:
-            query = query.options(db.joinedload(join) for join in joins
-                                  if join.can_joinedload)
-            outer_joins = [join for join in joins if not join.can_joinedload]
-            if outer_joins:
-                query = query.outerjoin(*outer_joins)
+            query = query.outerjoin(*joins)
         return query
 
     @staticmethod

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -349,7 +349,7 @@ class SQLStorageManager(object):
         sort = sort or OrderedDict()
         distinct = distinct or []
 
-        all_columns = set(include) | set(filters.keys()) | set(sort.keys())
+        all_columns = set(filters.keys()) | set(sort.keys())
         joins = get_joins(model_class, all_columns)
 
         include, filters, substr_filters, sort, distinct = \

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -149,7 +149,11 @@ class SQLStorageManager(object):
             query = query.distinct(*distinct)
 
         if joins:
-            query = query.options(db.joinedload(join) for join in joins)
+            query = query.options(db.joinedload(join) for join in joins
+                                  if join.can_joinedload)
+            outer_joins = [join for join in joins if not join.can_joinedload]
+            if outer_joins:
+                query.outerjoin(*outer_joins)
         return query
 
     @staticmethod

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -153,7 +153,7 @@ class SQLStorageManager(object):
                                   if join.can_joinedload)
             outer_joins = [join for join in joins if not join.can_joinedload]
             if outer_joins:
-                query.outerjoin(*outer_joins)
+                query = query.outerjoin(*outer_joins)
         return query
 
     @staticmethod

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -149,7 +149,7 @@ class SQLStorageManager(object):
             query = query.distinct(*distinct)
 
         if joins:
-            query = query.outerjoin(*joins)
+            query = query.options(db.joinedload(join) for join in joins)
         return query
 
     @staticmethod

--- a/rest-service/manager_rest/storage/utils.py
+++ b/rest-service/manager_rest/storage/utils.py
@@ -49,6 +49,8 @@ def get_joins(model_class, columns):
             # because some SQLA elements have their own comparators
             join_attr_name = str(join_attr)
             if join_attr_name not in joins:
+                # Include a bool to determine whether joinedload will work
+                join_attr.can_joinedload = model_class == column.owning_class
                 joins[join_attr_name] = join_attr
             column = column.remote_attr
     return joins.values()

--- a/rest-service/manager_rest/storage/utils.py
+++ b/rest-service/manager_rest/storage/utils.py
@@ -33,7 +33,6 @@ def get_joins(model_class, columns):
     """
     # Using an ordered dict because the order of the joins is important
     joins = OrderedDict()
-    joined_already = set()
     for column_name in columns:
         column = getattr(model_class, column_name, None)
         if column is None:
@@ -44,12 +43,6 @@ def get_joins(model_class, columns):
                 # This is a property or similar, not a real column
                 break
             join_attr = column.local_attr
-
-            # We will be using this for outer joins, and trying to join twice
-            # to the same table will cause problems
-            if column.target_class in joined_already:
-                break
-            joined_already.add(column.target_class)
 
             # This is a hack, to deal with the fact that SQLA doesn't
             # fully support doing something like: `if join_attr in joins`,

--- a/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
@@ -1,18 +1,3 @@
-#########
-# Copyright (c) 2019 Cloudify Platform Ltd. All rights reserved
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  * See the License for the specific language governing permissions and
-#  * limitations under the License.
-
 from copy import deepcopy
 
 import unittest
@@ -75,6 +60,21 @@ class PluginsUpdatesTest(PluginsUpdatesBaseTest):
 
     def test_returns_empty_list_with_no_plugins_updates(self):
         self.assertEqual(0, len(self.client.plugins_update.list().items))
+
+    def test_no_break_on_include_blueprint_columns(self):
+        """Including two columns from the same table has made the storage
+        manager unhappy in the past. Let's not do that again."""
+
+        # Make sure we have a plugins update in case we skip listing when the
+        # table is empty at any point in the future
+        self.put_blueprint(blueprint_id='hello_world')
+        self.client.deployments.create('hello_world', 'd123')
+        self.wait_for_deployment_creation(self.client, 'd123')
+        plugins_update1 = self.client.plugins_update.update_plugins(
+            'hello_world')
+
+        self.client.plugins_update.list(
+            _include=['blueprint_id', 'temp_blueprint_id'])
 
 
 class PluginsUpdateIdTest(PluginsUpdatesBaseTest):

--- a/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
@@ -70,8 +70,7 @@ class PluginsUpdatesTest(PluginsUpdatesBaseTest):
         self.put_blueprint(blueprint_id='hello_world')
         self.client.deployments.create('hello_world', 'd123')
         self.wait_for_deployment_creation(self.client, 'd123')
-        plugins_update1 = self.client.plugins_update.update_plugins(
-            'hello_world')
+        self.client.plugins_update.update_plugins('hello_world')
 
         self.client.plugins_update.list(
             _include=['blueprint_id', 'temp_blueprint_id'])


### PR DESCRIPTION
Without this, including both blueprint_id and temp_blueprint_id causes two
outer joins against the same table, which results in sadness and exception.