### PR TITLE
Perform all joins, even with multiple tables

### DIFF
--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -150,14 +150,14 @@ class SQLStorageManager(object):
         if distinct:
             query = query.distinct(*distinct)
 
-        seen_tables = set()
+        seen_models = set()
         for join in joins:
-            table = join.prop.target
-            if table not in seen_tables:
-                seen_tables.add(table)
+            model = join.prop.mapper.entity
+            if model not in seen_models:
+                seen_models.add(model)
                 query = query.outerjoin(join)
             else:
-                query = query.outerjoin(aliased(table), join.prop.key)
+                query = query.outerjoin(aliased(model), join.prop.key)
         return query
 
     @staticmethod

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -19,7 +19,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from flask_security import current_user
 from sqlalchemy import or_ as sql_or, inspect, func
-from sqlalchemy.orm import RelationshipProperty
+from sqlalchemy.orm import RelationshipProperty, aliased
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from flask import current_app, has_request_context
@@ -150,8 +150,14 @@ class SQLStorageManager(object):
         if distinct:
             query = query.distinct(*distinct)
 
-        if joins:
-            query = query.outerjoin(*joins)
+        seen_tables = set()
+        for join in joins:
+            table = join.prop.target
+            if table not in seen_tables:
+                seen_tables.add(table)
+                query = query.outerjoin(join)
+            else:
+                query = query.outerjoin(aliased(table), join.prop.key)
         return query
 
     @staticmethod
@@ -351,7 +357,7 @@ class SQLStorageManager(object):
         sort = sort or OrderedDict()
         distinct = distinct or []
 
-        all_columns = set(filters.keys()) | set(sort.keys())
+        all_columns = set(include) | set(filters.keys()) | set(sort.keys())
         joins = get_joins(model_class, all_columns)
 
         include, filters, substr_filters, sort, distinct = \

--- a/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins_updates.py
@@ -69,10 +69,19 @@ class PluginsUpdatesTest(PluginsUpdatesBaseTest):
         self.put_blueprint(blueprint_id='hello_world')
         self.client.deployments.create('hello_world', 'd123')
         self.wait_for_deployment_creation(self.client, 'd123')
-        self.client.plugins_update.update_plugins('hello_world')
+        result = self.client.plugins_update.update_plugins('hello_world')
 
-        self.client.plugins_update.list(
-            _include=['blueprint_id', 'temp_blueprint_id'])
+        include_list = ['blueprint_id', 'temp_blueprint_id']
+        expected_updates = [
+            {
+                k: v for k, v in result.items()
+                if k in include_list
+            }
+        ]
+
+        updates_list = self.client.plugins_update.list(_include=include_list)
+
+        assert updates_list.items == expected_updates
 
 
 class PluginsUpdateIdTest(PluginsUpdatesBaseTest):


### PR DESCRIPTION
We need to include the includes in the joins, but we need to alias any duplicated
table names.