### PR TITLE
Revert "RD-4788 Define Cloudify DSL version 1.4 (#3655)"

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -1,8 +1,8 @@
 ##################################################################################
 # The types defined here make use of features only available in the
-# 'cloudify_dsl_1_4' tosca definitions version
+# 'cloudify_dsl_1_3' tosca definitions version
 ##################################################################################
-tosca_definitions_version: cloudify_dsl_1_4
+tosca_definitions_version: cloudify_dsl_1_3
 
 ##################################################################################
 # Cloudify basic types metadata


### PR DESCRIPTION
This reverts commit 0d48407415359e011cd5ca50db6db6e84b8e5f51.

This is because we allow importing files which use earlier version of
DSL than the blueprint.  One can use `cloudify_dsl_1_3` types.yaml in a
`cloudify_dsl_1_4` blueprint.

https://github.com/cloudify-cosmo/cloudify-common/pull/1045