### PR TITLE
RD-4616 Disallow starting unavailable workflows

### DIFF
--- a/rest-service/manager_rest/manager_exceptions.py
+++ b/rest-service/manager_rest/manager_exceptions.py
@@ -112,6 +112,11 @@ class NonexistentWorkflowError(ManagerException):
     status_code = 400
 
 
+class UnavailableWorkflowError(ManagerException):
+    error_code = 'unavailable_workflow_error'
+    status_code = 400
+
+
 class AppNotSecuredError(ManagerException):
     error_code = 'application_not_secured_error'
     status_code = 401

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1177,6 +1177,10 @@ class Execution(CreatedAtMixin, SQLResourceBase):
             import GetValuesWithStorageManager
 
         workflow = self.get_workflow(deployment, workflow_id)
+        if not deployment._is_workflow_available(workflow):
+            raise manager_exceptions.UnavailableWorkflowError(
+                f'Workflow not available: {workflow_id}')
+
         workflow_parameters = workflow.get('parameters', {})
         custom_parameters = parameters.keys() - workflow_parameters.keys()
         if not self.allow_custom_parameters and custom_parameters:

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -934,6 +934,19 @@ class TestExecutionModelValidationTests(unittest.TestCase):
         assert exc.visibility == d.visibility
         assert exc.tenant == d.tenant
 
+    def test_unavailable_workflow(self):
+        d = models.Deployment(workflows={
+            'wf': {'availability_rules': {'available': False}},
+        })
+        with self.assertRaisesRegex(
+            manager_exceptions.UnavailableWorkflowError, 'wf'
+        ):
+            models.Execution(
+                parameters={},
+                deployment=d,
+                workflow_id='wf',
+            )
+
 
 @mock.patch(
     'manager_rest.resource_manager.workflow_executor.workflow_sendhandler',


### PR DESCRIPTION
Fortunately, all the infra for throwing exceptions is already there,
because we already disallow starting executions in some cases
(eg. wrong input types). So all we need to do is to throw
an exception and that's that.