### PR TITLE
RD-429 External resource settings for cloudify.nodes.Root

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -17,6 +17,19 @@ node_types:
 
   # base type for provided cloudify types
   cloudify.nodes.Root:
+    properties:
+      use_external_resource:
+        description: |
+          Indicate whether the resource exists or if Cloudify should create the
+          resource, true if you are bringing an existing resource, false if you
+          want cloudify to create it.
+        type: boolean
+        default: False
+      resource_id:
+        description: |
+          Property which identifies the external resource.  It's used if the
+          `use_external_resource` is true.
+        required: False
     interfaces:
       cloudify.interfaces.lifecycle:
         # install

--- a/rest-service/manager_rest/test/endpoints/test_labels.py
+++ b/rest-service/manager_rest/test/endpoints/test_labels.py
@@ -221,8 +221,8 @@ class DeploymentsLabelsTestCase(LabelsBaseTestCase):
         node = self.client.nodes.get(deployment.id, 'node1',
                                      evaluate_functions=True)
 
-        self.assertEqual(node.properties, {'prop1': ['key2_val1', 'key2_val2'],
-                                           'prop2': 'key1_val1'})
+        assert node.properties['prop1'] == ['key2_val1', 'key2_val2']
+        assert node.properties['prop2'] == 'key1_val1'
         self.assertEqual(capabilities,
                          {'cap1': 'key1_val2', 'cap2': ['input_value']})
         self.assertEqual(outputs, {'output1': 'default_value',


### PR DESCRIPTION
Add two properties for cloudify.nodes.Root (and all its children) which
are used to handle resources external to Cloudify.

For the implementation details go over to https://github.com/cloudify-cosmo/cloudify-common/pull/1053