### PR TITLE
RD-4612 Add drifted/unavailable instance counts

### DIFF
--- a/rest-service/manager_rest/rest/resources_v2/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v2/nodes.py
@@ -17,6 +17,7 @@
 from flask import request
 from flask_restful_swagger import swagger
 
+from manager_rest import manager_exceptions
 from manager_rest.rest import (
     resources_v1,
     rest_decorators,
@@ -57,6 +58,10 @@ class Nodes(resources_v1.Nodes):
             '_get_all_results',
             request.args.get('_get_all_results', False)
         )
+        instance_counts = rest_utils.verify_and_convert_bool(
+            '_instance_counts',
+            request.args.get('_instance_counts', False)
+        )
         nodes_list = get_storage_manager().list(
             models.Node,
             include=_include,
@@ -80,7 +85,32 @@ class Nodes(resources_v1.Nodes):
                     scale_by *= group['properties']['planned_instances']
             node.set_actual_planned_node_instances(
                 scale_by * node.planned_number_of_instances)
+        if instance_counts:
+            if not filters.get('deployment_id'):
+                raise manager_exceptions.ConflictError(
+                    'instance_counts is only available when '
+                    'filtering by deployment_id')
+            self._add_instance_counts(nodes_list)
         return nodes_list
+
+    def _add_instance_counts(self, nodes):
+        """Add instance counts to the given nodes
+
+        Get all instances for these nodes, group them by node, and calculate
+        the amount of drifted/unavailable instances.
+        """
+        instances = models.NodeInstance.query.filter(
+            models.NodeInstance._node_fk.in_([n._storage_id for n in nodes])
+        ).all()
+        instances_by_node = {}
+        for ni in instances:
+            instances_by_node.setdefault(ni._node_fk, set()).add(ni)
+        for node in nodes:
+            instances = instances_by_node.get(node._storage_id)
+            node.set_instance_counts(
+                drifted=sum(ni.has_configuration_drift for ni in instances),
+                unavailable=sum(not ni.is_status_check_ok for ni in instances),
+            )
 
 
 class NodeInstances(resources_v1.NodeInstances):

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -2029,8 +2029,8 @@ class NodeInstance(SQLResourceBase):
     _node_fk = foreign_key(Node._storage_id)
 
     @classproperty
-    def response_fields(cls):
-        fields = super(NodeInstance, cls).response_fields
+    def resource_fields(cls):
+        fields = super(NodeInstance, cls).resource_fields
         fields['is_status_check_ok'] = flask_fields.Boolean
         fields['has_configuration_drift'] = flask_fields.Boolean
         return fields

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1944,8 +1944,12 @@ class Node(SQLResourceBase):
     _extra_fields = {
         'actual_number_of_instances': flask_fields.Integer,
         'actual_planned_number_of_instances': flask_fields.Integer,
+        'drifted_instances': flask_fields.Integer,
+        'unavailable_instances': flask_fields.Integer,
     }
     actual_planned_number_of_instances = 0
+    drifted_instances = None
+    unavailable_instances = None
 
     @hybrid_property
     def actual_number_of_instances(self):
@@ -1976,6 +1980,10 @@ class Node(SQLResourceBase):
         d = super(Node, self).to_dict(suppress_error)
         d['name'] = d['id']
         return d
+
+    def set_instance_counts(self, drifted, unavailable):
+        self.drifted_instances = drifted
+        self.unavailable_instances = unavailable
 
     def set_deployment(self, deployment):
         self._set_parent(deployment)


### PR DESCRIPTION
I'll hide these behind a querystring flag. It's not ideal, but we need to
examine all instances, and there might be quite a few of them.