### PR TITLE
RD-4995 auditlog: clear variables on each request

### DIFF
--- a/rest-service/manager_rest/security/audit.py
+++ b/rest-service/manager_rest/security/audit.py
@@ -14,6 +14,13 @@ def set_username(username: str):
                        params={'name': username})
 
 
+def reset():
+    """Clean all session variables"""
+    set_audit_method(None)
+    db.session.execute("RESET audit.username")
+    db.session.execute("RESET audit.execution_id")
+
+
 def set_tenant(tenant: str):
     flask.g.audit_tenant = tenant
 

--- a/rest-service/manager_rest/security/user_handler.py
+++ b/rest-service/manager_rest/security/user_handler.py
@@ -69,7 +69,7 @@ def _get_user_from_execution_token(request):
 
     # Support using the exec token as an auth token for workflows
     execution = get_current_execution_by_token(execution_token or token)
-    set_current_execution(execution)  # Sets request current execution
+    set_current_execution(execution)
     if not execution:
         if execution_token:
             # execution not found, but we were explicitly given an exec-token

--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -150,6 +150,7 @@ class CloudifyFlaskApp(Flask):
         self.before_request(query_service_settings)
         self.before_request(maintenance_mode_handler)
         self.after_request(log_response)
+        self.before_request(audit.reset)
         self.after_request(audit.extend_headers)
         self._set_flask_security()
 


### PR DESCRIPTION
Otherwise, we never clear current execution id from the audit log,
and then it persists between requests.