### PR TITLE
REST tests: select the expected user/tenant

### DIFF
--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -317,8 +317,16 @@ class BaseServerTestCase(unittest.TestCase):
         self.initialize_provider_context()
         self.addCleanup(self._drop_db, keep_tables=['config'])
         self.addCleanup(self._clean_tmpdir)
-        self.user = db.session.query(models.User).first()
-        self.tenant = db.session.query(models.Tenant).first()
+        self.user = (
+            db.session.query(models.User)
+            .filter_by(username='admin')
+            .one()
+        )
+        self.tenant = (
+            db.session.query(models.Tenant)
+            .filter_by(name='default_tenant')
+            .one()
+        )
 
     @staticmethod
     def _drop_db(keep_tables=None):


### PR DESCRIPTION
We can't just .first without an ordering. What user would that be?
There's more than one in the db after all (eg. admin and
status_reporter).

I think this is why we've been seeing pretty-rare flakiness on the
tests, where eg. in the config tests, the updater was a different
user than we expected.