### PR TITLE
RD-4923 Add manager_name/agent_name to logs/events

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/272e61bf5f4a_6_3_to_6_4.py
+++ b/resources/rest-service/cloudify/migrations/versions/272e61bf5f4a_6_3_to_6_4.py
@@ -98,9 +98,12 @@ def recreate_usagecollector_audit():
 
 
 def add_manager_agent_name_columns():
-    op.add_column('operations', sa.Column('manager_name', sa.Text(), nullable=True))
-    op.add_column('operations', sa.Column('agent_name', sa.Text(), nullable=True))
-    op.add_column('events', sa.Column('manager_name', sa.Text(), nullable=True))
+    op.add_column(
+        'operations', sa.Column('manager_name', sa.Text(), nullable=True))
+    op.add_column(
+        'operations', sa.Column('agent_name', sa.Text(), nullable=True))
+    op.add_column(
+        'events', sa.Column('manager_name', sa.Text(), nullable=True))
     op.add_column('events', sa.Column('agent_name', sa.Text(), nullable=True))
     op.add_column('logs', sa.Column('manager_name', sa.Text(), nullable=True))
     op.add_column('logs', sa.Column('agent_name', sa.Text(), nullable=True))

--- a/resources/rest-service/cloudify/migrations/versions/272e61bf5f4a_6_3_to_6_4.py
+++ b/resources/rest-service/cloudify/migrations/versions/272e61bf5f4a_6_3_to_6_4.py
@@ -22,12 +22,14 @@ def upgrade():
     create_tokens()
     upgrade_plugin_updates()
     drop_usagecollector_audit()
+    add_manager_agent_name_columns()
 
 
 def downgrade():
     drop_tokens()
     downgrade_plugin_updates()
     recreate_usagecollector_audit()
+    drop_manager_agent_name_columns()
 
 
 def create_tokens():
@@ -93,3 +95,21 @@ def recreate_usagecollector_audit():
         AFTER INSERT OR UPDATE OR DELETE ON usage_collector FOR EACH ROW
         EXECUTE PROCEDURE write_audit_log_id('usage_collector');
     """)
+
+
+def add_manager_agent_name_columns():
+    op.add_column('operations', sa.Column('manager_name', sa.Text(), nullable=True))
+    op.add_column('operations', sa.Column('agent_name', sa.Text(), nullable=True))
+    op.add_column('events', sa.Column('manager_name', sa.Text(), nullable=True))
+    op.add_column('events', sa.Column('agent_name', sa.Text(), nullable=True))
+    op.add_column('logs', sa.Column('manager_name', sa.Text(), nullable=True))
+    op.add_column('logs', sa.Column('agent_name', sa.Text(), nullable=True))
+
+
+def drop_manager_agent_name_columns():
+    op.drop_column('operations', 'agent_name')
+    op.drop_column('operations', 'manager_name')
+    op.drop_column('events', 'agent_name')
+    op.drop_column('events', 'manager_name')
+    op.drop_column('logs', 'agent_name')
+    op.drop_column('logs', 'manager_name')

--- a/rest-service/manager_rest/rest/resources_v1/events.py
+++ b/rest-service/manager_rest/rest/resources_v1/events.py
@@ -344,6 +344,8 @@ class Events(SecuredResource):
                 select_column('node_id'),
                 select_column('source_id'),
                 select_column('target_id'),
+                select_column('manager_name'),
+                select_column('agent_name'),
                 NodeInstance.id.label('node_instance_id'),
                 Node.id.label('node_name'),
                 select_column('logger'),

--- a/rest-service/manager_rest/rest/resources_v3/events.py
+++ b/rest-service/manager_rest/rest/resources_v3/events.py
@@ -37,6 +37,8 @@ class Events(v2_Events):
             'events': {'optional': True},
             'logs': {'optional': True},
             'execution_id': {'optional': True},
+            'manager_name': {'optional': True},
+            'agent_name': {'optional': True},
         })
 
         raw_events = request_dict.get('events') or []
@@ -61,6 +63,8 @@ class Events(v2_Events):
             '_tenant_id': exc._tenant_id,
             '_creator_id': exc._creator_id,
             'visibility': exc.visibility,
+            'manager_name': request_dict.get('manager_name'),
+            'agent_name': request_dict.get('agent_name'),
         }
         if not raw_events and not raw_logs:
             return None, 204

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1581,6 +1581,8 @@ class Event(SQLResourceBase):
     source_id = db.Column(db.Text)
     target_id = db.Column(db.Text)
     error_causes = db.Column(JSONString)
+    manager_name = db.Column(db.Text)
+    agent_name = db.Column(db.Text)
 
     _execution_fk = foreign_key(Execution._storage_id, nullable=True)
     _execution_group_fk = foreign_key(ExecutionGroup._storage_id,
@@ -1640,6 +1642,8 @@ class Log(SQLResourceBase):
     node_id = db.Column(db.Text, index=True)
     source_id = db.Column(db.Text)
     target_id = db.Column(db.Text)
+    manager_name = db.Column(db.Text)
+    agent_name = db.Column(db.Text)
 
     _execution_fk = foreign_key(Execution._storage_id, nullable=True)
     _execution_group_fk = foreign_key(ExecutionGroup._storage_id,
@@ -2194,6 +2198,9 @@ class Operation(CreatedAtMixin, SQLResourceBase):
     dependencies = db.Column(db.ARRAY(db.Text))
     type = db.Column(db.Text)
     parameters = db.Column(JSONString)
+
+    manager_name = db.Column(db.Text)
+    agent_name = db.Column(db.Text)
 
     _tasks_graph_fk = foreign_key(TasksGraph._storage_id)
 

--- a/rest-service/manager_rest/test/endpoints/test_operations.py
+++ b/rest-service/manager_rest/test/endpoints/test_operations.py
@@ -244,10 +244,16 @@ class OperationsTestCase(OperationsTestBase, base_test.BaseServerTestCase):
         )
         with mock.patch(f'{OPERATIONS_MODULE}.current_execution', exc):
             self.client.operations.update(
-                'op1', state=constants.TASK_SUCCEEDED)
+                'op1',
+                state=constants.TASK_SUCCEEDED,
+                manager_name='manager',
+                agent_name='agent',
+            )
         evts = models.Event.query.all()
         assert len(evts) == 1
         assert evts[0].message == message
+        assert evts[0].manager_name == 'manager'
+        assert evts[0].agent_name == 'agent'
 
     @mock.patch(f'{OPERATIONS_MODULE}.check_user_action_allowed')
     def test_update_SetNodeInstanceStateTask_ni_state(self, *_):


### PR DESCRIPTION
And also to operations!

Now, it'll be possible to know which manager (or which agent) emitted
an event, or was the one handling an operation.