### PR TITLE
Make the test_migration_required test print out the migration

### DIFF
--- a/rest-service/manager_rest/test/migrations/test_migration_required.py
+++ b/rest-service/manager_rest/test/migrations/test_migration_required.py
@@ -1,25 +1,24 @@
 import os
+import logging
 import pytest
 
 from manager_rest.test import base_test
-from manager_rest import server
 
-from flask_migrate import Migrate, migrate, downgrade
+from flask_migrate import migrate
 
 
 class TestDBMigrations(base_test.BaseServerTestCase):
     def test_no_migrations_required(self):
-        Migrate(app=server.app, db=server.db)
         migrate(directory=base_test.MIGRATION_DIR, rev_id='new_test_revision')
         revision_file = os.path.join(
             base_test.MIGRATION_DIR,
             'versions',
             'new_test_revision_.py'
         )
-        new_revision_made = os.path.exists(
-            revision_file
-        )
+        new_revision_made = os.path.exists(revision_file)
         if new_revision_made:
-            downgrade(directory=base_test.MIGRATION_DIR, revision='-1')
+            with open(revision_file) as f:
+                logging.error(
+                    "Here's the generated migration:\n %s\n", f.read())
             os.unlink(revision_file)
             pytest.fail('Your code requires a database migration')


### PR DESCRIPTION
1. Drop the `Migrate()` call, it's not necessary, base_test already
   does it
2. The `downgrade()` isn't needed after all. My fault, sorry! The
   way it works, `migrate()` only creates a migration, doesn't apply
   it (that'd be `upgrade()`). Of course, if we leave the migration
   file around (which we don't, cf. `unlink()`), then the next run
   would've applied it, and THEN we'd need downgrade.
3. Now also printint out the contents of the migration file. This is
   very useful (to me), because now I can just run this test if
   I want to generate some migrations, I don't need to run a manager.