### PR TITLE
RD-4408 Instance drift/status counts

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v1/nodes.py
@@ -247,6 +247,5 @@ class NodeInstancesId(SecuredResource):
         if instance.system_properties == old_properties:
             # nothing changed, so nothing to do
             return
-        instance.has_configuration_drift = \
-            instance.compute_configuration_drift()
-        instance.is_status_check_ok = instance.compute_status_check()
+        instance.update_configuration_drift()
+        instance.update_status_check()

--- a/rest-service/manager_rest/rest/resources_v1/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v1/nodes.py
@@ -247,5 +247,6 @@ class NodeInstancesId(SecuredResource):
         if instance.system_properties == old_properties:
             # nothing changed, so nothing to do
             return
-        instance.has_configuration_drift = instance.compute_configuration_drift()
+        instance.has_configuration_drift = \
+            instance.compute_configuration_drift()
         instance.is_status_check_ok = instance.compute_status_check()

--- a/rest-service/manager_rest/rest/resources_v2/nodes.py
+++ b/rest-service/manager_rest/rest/resources_v2/nodes.py
@@ -17,7 +17,6 @@
 from flask import request
 from flask_restful_swagger import swagger
 
-from manager_rest import manager_exceptions
 from manager_rest.rest import (
     resources_v1,
     rest_decorators,

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -466,6 +466,11 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
     latest_execution_total_operations = association_proxy(
         'latest_execution', 'total_operations')
 
+    drifted_instances =\
+        db.Column(db.Integer, server_default='0', nullable=False, default=0)
+    unavailable_instances =\
+        db.Column(db.Integer, server_default='0', nullable=False, default=0)
+
     @classproperty
     def autoload_relationships(cls):
         return [
@@ -1988,6 +1993,11 @@ class Node(SQLResourceBase):
     type = db.Column(db.Text, nullable=False, index=True)
     type_hierarchy = db.Column(db.PickleType(protocol=2))
 
+    drifted_instances =\
+        db.Column(db.Integer, server_default='0', nullable=False, default=0)
+    unavailable_instances =\
+        db.Column(db.Integer, server_default='0', nullable=False, default=0)
+
     _deployment_fk = foreign_key(Deployment._storage_id)
 
     # These are for fixing a bug where wrong number of instances was returned
@@ -1995,12 +2005,8 @@ class Node(SQLResourceBase):
     _extra_fields = {
         'actual_number_of_instances': flask_fields.Integer,
         'actual_planned_number_of_instances': flask_fields.Integer,
-        'drifted_instances': flask_fields.Integer,
-        'unavailable_instances': flask_fields.Integer,
     }
     actual_planned_number_of_instances = 0
-    drifted_instances = None
-    unavailable_instances = None
 
     @hybrid_property
     def actual_number_of_instances(self):
@@ -2031,10 +2037,6 @@ class Node(SQLResourceBase):
         d = super(Node, self).to_dict(suppress_error)
         d['name'] = d['id']
         return d
-
-    def set_instance_counts(self, drifted, unavailable):
-        self.drifted_instances = drifted
-        self.unavailable_instances = unavailable
 
     def set_deployment(self, deployment):
         self._set_parent(deployment)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -2064,6 +2064,7 @@ class NodeInstance(SQLResourceBase):
         v1=['scaling_groups'],
         v2=['scaling_groups']
     )
+
     def __init__(self, *args, **kwargs):
         super(NodeInstance, self).__init__(*args, **kwargs)
         # those values are recomputed on update, but let's default them too,

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -2129,7 +2129,7 @@ class NodeInstance(SQLResourceBase):
         """
         props = self.system_properties or {}
         status = props.get('status') or {}
-        return bool(status.get('ok', True))
+        return bool(status.get('ok', False))
 
     def compute_configuration_drift(self):
         """Has this NI's configuration drifted?

--- a/rest-service/manager_rest/test/endpoints/test_nodes.py
+++ b/rest-service/manager_rest/test/endpoints/test_nodes.py
@@ -733,7 +733,7 @@ class NodeInstancesDeleteTest(_NodeSetupMixin, base_test.BaseServerTestCase):
 ])
 def test_status_check_ok(system_properties, expected_status):
     ni = models.NodeInstance(system_properties=system_properties)
-    assert ni.compute_status_check() == expected_status
+    assert ni.is_status_check_ok == expected_status
 
 
 @pytest.mark.parametrize('system_properties,expected_drift', [
@@ -791,4 +791,4 @@ def test_status_check_ok(system_properties, expected_status):
 ])
 def test_has_drift(system_properties, expected_drift):
     ni = models.NodeInstance(system_properties=system_properties)
-    assert ni.compute_configuration_drift() == expected_drift
+    assert ni.has_configuration_drift == expected_drift

--- a/rest-service/manager_rest/test/endpoints/test_nodes.py
+++ b/rest-service/manager_rest/test/endpoints/test_nodes.py
@@ -138,10 +138,6 @@ class NodesTest(_NodeSetupMixin, base_test.BaseServerTestCase):
             node=node,
             system_properties={'configuration_drift': {'result': 'drift'}}
         )
-        with self.assertRaises(CloudifyClientError) as cm:
-            self.client.nodes.list(_instance_counts=True)
-        assert cm.exception.status_code == 409
-
         nodes = self.client.nodes.list(
             deployment_id='d1', _instance_counts=True)
         assert len(nodes) == 1
@@ -737,7 +733,7 @@ class NodeInstancesDeleteTest(_NodeSetupMixin, base_test.BaseServerTestCase):
 ])
 def test_status_check_ok(system_properties, expected_status):
     ni = models.NodeInstance(system_properties=system_properties)
-    assert ni.is_status_check_ok == expected_status
+    assert ni.compute_status_check() == expected_status
 
 
 @pytest.mark.parametrize('system_properties,expected_drift', [
@@ -795,4 +791,4 @@ def test_status_check_ok(system_properties, expected_status):
 ])
 def test_has_drift(system_properties, expected_drift):
     ni = models.NodeInstance(system_properties=system_properties)
-    assert ni.has_configuration_drift == expected_drift
+    assert ni.compute_configuration_drift() == expected_drift

--- a/rest-service/manager_rest/test/endpoints/test_nodes.py
+++ b/rest-service/manager_rest/test/endpoints/test_nodes.py
@@ -99,7 +99,7 @@ class NodesTest(_NodeSetupMixin, base_test.BaseServerTestCase):
         assert response.status_code == 200
         assert response.json['id'] == '1234'
         assert response.json['runtime_properties'] == {'key': 'value'}
-        assert response.json['is_status_check_ok']
+        assert not response.json['is_status_check_ok']
         assert not response.json['has_configuration_drift']
 
     def test_sort_nodes_list(self):
@@ -126,7 +126,7 @@ class NodesTest(_NodeSetupMixin, base_test.BaseServerTestCase):
         self._instance(
             'ni1',
             node=node,
-            system_properties={}
+            system_properties={'status': {'ok': True}},
         )
         self._instance(
             'ni2',
@@ -141,7 +141,7 @@ class NodesTest(_NodeSetupMixin, base_test.BaseServerTestCase):
         nodes = self.client.nodes.list(
             deployment_id='d1', _instance_counts=True)
         assert len(nodes) == 1
-        assert nodes[0].unavailable_instances == 1
+        assert nodes[0].unavailable_instances == 2
         assert nodes[0].drifted_instances == 1
 
     def test_bad_patch_node(self):
@@ -727,9 +727,9 @@ class NodeInstancesDeleteTest(_NodeSetupMixin, base_test.BaseServerTestCase):
     ({'status': {'ok': True}}, True),
     ({'status': {'ok': False}}, False),
     ({'status': {'ok': None}}, False),
-    ({'status': {}}, True),
-    ({}, True),
-    (None, True),
+    ({'status': {}}, False),
+    ({}, False),
+    (None, False),
 ])
 def test_status_check_ok(system_properties, expected_status):
     ni = models.NodeInstance(system_properties=system_properties)

--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -155,7 +155,6 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         self.sm.put(dep)
 
         serialized_dep = dep.to_response()
-        self.assertEqual(40, len(serialized_dep))
         self.assertEqual(dep.id, serialized_dep['id'])
         self.assertEqual(dep.created_at, serialized_dep['created_at'])
         self.assertEqual(dep.updated_at, serialized_dep['updated_at'])


### PR DESCRIPTION
Store the counts of drifted/unavailable instances on the node, and on
the deployment, as a column. That way, we'll be able to list those
in a performant manner, and also filter on them as well.

I do recommend reading the commits separately!