### PR TITLE
6.4 migration: fix ordering of drop_drift calls

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/272e61bf5f4a_6_3_to_6_4.py
+++ b/resources/rest-service/cloudify/migrations/versions/272e61bf5f4a_6_3_to_6_4.py
@@ -457,12 +457,6 @@ EXECUTE PROCEDURE recalc_drift_instance_counts_update();
 
 
 def drop_drift_availability_columns():
-    op.drop_column('node_instances', 'is_status_check_ok')
-    op.drop_column('node_instances', 'has_configuration_drift')
-    op.drop_column('deployments', 'unavailable_instances')
-    op.drop_column('deployments', 'drifted_instances')
-    op.drop_column('nodes', 'unavailable_instances')
-    op.drop_column('nodes', 'drifted_instances')
     op.execute("""
 DROP TRIGGER recalc_drift_instance_counts_insert ON node_instances;
 DROP TRIGGER recalc_drift_instance_counts_update ON node_instances;
@@ -470,3 +464,9 @@ DROP FUNCTION recalc_drift_instance_counts_insert();
 DROP FUNCTION recalc_drift_instance_counts_update();
 DROP FUNCTION recalc_drift_instance_counts(integer);
 """)
+    op.drop_column('node_instances', 'is_status_check_ok')
+    op.drop_column('node_instances', 'has_configuration_drift')
+    op.drop_column('deployments', 'unavailable_instances')
+    op.drop_column('deployments', 'drifted_instances')
+    op.drop_column('nodes', 'unavailable_instances')
+    op.drop_column('nodes', 'drifted_instances')


### PR DESCRIPTION
First drop the trigger that uses the column, then drop the column