### PR TITLE
inte-tests: bring back py2.7 compat in the cloudmock plugin

### DIFF
--- a/tests/integration_tests_plugins/cloudmock/cloudmock/tasks.py
+++ b/tests/integration_tests_plugins/cloudmock/cloudmock/tasks.py
@@ -214,5 +214,6 @@ def limit_scale(ctx):
     """
     allowed = int(ctx.node.properties['allowed'])
     if ctx.instance.index > allowed:
-        raise NonRecoverableError(f'instance {ctx.instance.index} disallowed')
+        raise NonRecoverableError(
+            'instance {0} disallowed'.format(ctx.instance.index))
     ctx.logger.info('instance %d created', ctx.instance.index)


### PR DESCRIPTION
Well the agent is still on 2.7. Whoops.