### PR TITLE
cloudify-types: use find_packages in setup.py

### DIFF
--- a/cloudify_types/setup.py
+++ b/cloudify_types/setup.py
@@ -13,7 +13,7 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 setup(
@@ -21,11 +21,7 @@ setup(
     version='6.4.0.dev1',
     author='Cloudify',
     author_email='cosmo-admin@cloudify.co',
-    packages=[
-        'cloudify_types',
-        'cloudify_types.component',
-        'cloudify_types.shared_resource'
-    ],
+    packages=find_packages(),
     license='LICENSE',
     description='Various special Cloudify types implementation.',
     install_requires=[


### PR DESCRIPTION
We're missing the new password_secret subpackage... let's just use
find_packages so next time we add one, it's not a problem again