### PR TITLE
RD-4429 deployment labels: don't update computed labels

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2634,20 +2634,35 @@ class ResourceManager(object):
                                     creator=creator,
                                     created_at=created_at)
 
-    @staticmethod
-    def get_labels_to_create(resource, new_labels):
-        new_labels_set = set(new_labels)
+    def is_computed_label(self, resource, key):
+        """Is this label computed by the manager?
+
+        Some labels aren't governed by the user, but are set by the manager
+        based on the resource itself. For example, the csys-consumer-id is
+        based on the dependencies of the deployment.
+        """
+        if isinstance(resource, models.Deployment):
+            if key == 'csys-consumer-id':
+                return True
+        return False
+
+    def get_labels_to_create(self, resource, new_labels):
+        new_labels_set = {
+            label for label in new_labels
+            if not self.is_computed_label(resource, label[0])
+        }
         existing_labels = resource.labels
         existing_labels_tup = set(
             (label.key, label.value) for label in existing_labels)
 
         return new_labels_set - existing_labels_tup
 
-    @staticmethod
-    def get_labels_to_delete(resource, new_labels):
+    def get_labels_to_delete(self, resource, new_labels):
         labels_to_delete = set()
         new_labels_set = set(new_labels)
         for label in resource.labels:
+            if self.is_computed_label(resource, label.key):
+                continue
             if (label.key, label.value) not in new_labels_set:
                 labels_to_delete.add(label)
         return labels_to_delete

--- a/rest-service/manager_rest/test/endpoints/test_labels.py
+++ b/rest-service/manager_rest/test/endpoints/test_labels.py
@@ -353,6 +353,38 @@ class DeploymentsLabelsTestCase(LabelsBaseTestCase):
                                self.client.deployments.outputs.get,
                                deployment_id='dep1')
 
+    def test_add_computed_label(self):
+        """Attempting to add a label that is computed, does nothing"""
+        dep = models.Deployment(
+            id='dep1',
+            blueprint=self.bp,
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        self.assertEqual(dep.labels, [])
+        self.client.deployments.update_labels(
+            dep.id, [{'csys-consumer-id': 'ignored'}])
+        # the label was not stored, because it's computed-only
+        self.assertEqual(dep.labels, [])
+
+    def test_remove_computed_label(self):
+        """Attempting to remove a label that is computed, does nothing"""
+        label = models.DeploymentLabel(
+            key='csys-consumer-id',
+            value='consumer',
+            creator=self.user,
+        )
+        dep = models.Deployment(
+            id='dep1',
+            blueprint=self.bp,
+            creator=self.user,
+            tenant=self.tenant,
+            labels=[label],
+        )
+        self.assertEqual(dep.labels, [label])
+        self.client.deployments.update_labels(dep.id, [])
+        self.assertEqual(dep.labels, [label])
+
 
 class BlueprintsLabelsTestCase(LabelsBaseTestCase):
     __test__ = True


### PR DESCRIPTION
Some labels (currently only csys-consumer-id) are computed by the
manager, so setting them by the user doesn't make sense.

Originally the idea was to throw a 4xx error when the user attempts
to change that label (add or remove), but I think it's better to
just ignore that label.

This is because the update_labels rest call wants the user to provide
the set of the new labels (which it must, to allow deletion). So we'd
be requiring the user to always pass through the computed label
unchanged. That seems silly. Let's allow the user to pass it, or not
pass it, and we'll just keep the label as it needs to be anyway.