### PR TITLE
RD-4466 The new update-or-reinstall flow

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -74,9 +74,11 @@ pipeline {
                 echo 'Running pytest <<workflows>>'
                 sh '''
                   . .venv/bin/activate
+                  cd workflows
+                  pip install -Ur test-requirements.txt
                   pytest \
                     -sv \
-                    workflows
+                    cloudify_system_workflows
                 '''
                 echo 'Running pytest <<cloudify_types>>'
                 sh '''

--- a/workflows/cloudify_system_workflows/deployment_update/update_instances.py
+++ b/workflows/cloudify_system_workflows/deployment_update/update_instances.py
@@ -1,15 +1,18 @@
 """Deployment update: node-instance reinstallation
 
 This is the part of the update workflow that makes sure node-instances that
-changed are reinstalled.
+changed are updated or reinstalled.
 """
+from itertools import chain
+
 from cloudify.state import workflow_ctx
-from cloudify.plugins import lifecycle
+from cloudify.plugins import lifecycle, workflows
 
 from .utils import clear_graph
 
 
-def _find_reinstall_instances(steps):
+def _find_changed_instances(steps):
+    """Instances that are changed and need to be updated/reinstalled"""
     nodes_to_reinstall = set()
     for step in steps:
         if step['entity_type'] not in ('property', 'operation'):
@@ -17,48 +20,186 @@ def _find_reinstall_instances(steps):
         if not step['entity_id'] or step['entity_id'][0] != 'nodes':
             continue
         nodes_to_reinstall.add(step['entity_id'][1])
-    to_reinstall = []
+    changed = set()
     for node_id in nodes_to_reinstall:
         node = workflow_ctx.get_node(node_id)
-        to_reinstall.extend(node.instances)
-    return to_reinstall
+        changed.update(node.instances)
+    return changed
 
 
-def reinstall_instances(
+def _get_drift_sources(instance):
+    """Drift is defined in system_properties, in several places.
+
+    This yields the instance drift itself, and also drift for each of its
+    relationships. This way, we can find if the instance has _any_ drift.
+    """
+    props = instance.system_properties
+
+    for drift in chain(
+        [props.get('configuration_drift')],
+        props.get('target_relationships_configuration_drift', {}).values(),
+        props.get('source_relationships_configuration_drift', {}).values()
+    ):
+        if drift:
+            yield drift
+
+
+def _has_drift(instance):
+    """Does the instance have any drift, itself of relationship?"""
+    for drift in _get_drift_sources(instance):
+        if drift.get('result'):
+            return True
+    return False
+
+
+def _has_failed_drift_check(instance):
+    """Did any of the check_drift calls for the instance fail?"""
+    for drift in _get_drift_sources(instance):
+        if not drift.get('ok'):
+            return True
+    return False
+
+
+def _do_check_drift(ctx, instances):
+    """Run the check_drift operation on instances.
+
+    Returns a set of instances that do have drift, and a set of instances
+    that failed the drift check (those will need to be reinstalled).
+    """
+    graph = workflows._make_check_drift_graph(
+        ctx, node_instance_ids={ni.id for ni in instances},
+        name='update_check_drift',
+        ignore_failure=True,
+    )
+    graph.execute()
+    instances_with_drift = set()
+    failed_check = set()
+    for instance in instances:
+        if _has_failed_drift_check(instance):
+            failed_check.add(instance)
+        elif _has_drift(instance):
+            instances_with_drift.add(instance)
+    return instances_with_drift, failed_check
+
+
+def _can_be_updated(instance):
+    """Can this instance be updated, or does it need to be reinstalled?
+
+    If this instance defines an update operation, it can be updated. Otherwise,
+    we'll need to fall back to reinstalling it.
+    """
+    props = instance.system_properties
+
+    if props.get('configuration_drift', {}).get('result'):
+        if not any(instance.node.has_operation(op) for op in [
+            'cloudify.interfaces.lifecycle.update',
+            'cloudify.interfaces.lifecycle.update_config',
+            'cloudify.interfaces.lifecycle.update_apply',
+        ]):
+            return False
+    # TODO also check relationships drift
+    return True
+
+
+def _find_update_failed_instances(ctx, instances):
+    """Find instances that failed the update operation.
+
+    The update_failed flag is set in the failure callback in the update
+    subgraph.
+    """
+    update_failed = set()
+    for instance in instances:
+        try:
+            if instance.system_properties['update_failed'] == ctx.execution_id:
+                update_failed.add(instance)
+        except KeyError:
+            pass
+    return update_failed
+
+
+def _clean_updated_property(ctx, instances):
+    for instance in instances:
+        system_properties = instance.system_properties or {}
+        if 'update_failed' not in system_properties:
+            continue
+        del system_properties['update_failed']
+        ctx.update_node_instance(
+            instance.id,
+            force=True,
+            system_properties=system_properties
+        )
+
+
+def update_or_reinstall_instances(
+    ctx,
     graph,
     dep_up,
     to_install,
     to_uninstall,
     ignore_failure=False,
-    skip_reinstall=False
+    skip_reinstall=False,
 ):
-    install_ids = {ni.id for ni in to_install}
-    uninstall_ids = {ni.id for ni in to_uninstall}
-    skip_ids = install_ids | uninstall_ids
-    subgraph = set()
-    if skip_reinstall:
-        to_reinstall = []
-    else:
-        to_reinstall = _find_reinstall_instances(dep_up.steps)
-    for ni in to_reinstall:
-        if ni.id in skip_ids:
+    to_skip = set(to_install) | set(to_uninstall)
+    consider_for_update = set(workflow_ctx.node_instances) - to_skip
+    changed_instances = _find_changed_instances(dep_up.steps)
+    instances_with_check_drift = {
+        instance
+        for instance in consider_for_update
+        if instance.node.has_operation(
+            'cloudify.interfaces.lifecycle.check_drift'
+        )
+    }
+
+    must_reinstall = set()
+    instances_with_drift = set()
+    if instances_with_check_drift:
+        clear_graph(graph)
+        instances_with_drift, failed_check = _do_check_drift(
+            ctx, instances_with_check_drift)
+        for instance in failed_check:
+            must_reinstall |= instance.get_contained_subgraph()
+
+    # instances that we know have changed, but don't define a way to check
+    # drift, are considered to have drifted by default
+    instances_with_drift |= changed_instances - instances_with_check_drift
+    for instance in instances_with_drift:
+        if instance in must_reinstall:
             continue
-        subgraph |= ni.get_contained_subgraph()
-    subgraph -= set(to_uninstall)
-    intact_nodes = (
-        set(workflow_ctx.node_instances)
-        - subgraph
-        - set(to_uninstall)
-    )
-    for n in subgraph:
-        for r in n._relationship_instances:
-            if r in uninstall_ids:
-                n._relationship_instances.pop(r)
-    if subgraph:
+        if not _can_be_updated(instance):
+            must_reinstall |= instance.get_contained_subgraph()
+
+    instances_to_update = instances_with_drift - must_reinstall
+
+    if instances_to_update:
+        intact_nodes = set(workflow_ctx.node_instances) - instances_to_update
+        clear_graph(graph)
+        lifecycle.update_node_instances(
+            graph=graph,
+            node_instances=instances_to_update,
+            related_nodes=intact_nodes,
+        )
+        failed_update = _find_update_failed_instances(
+            ctx,
+            {ctx.get_node_instance(ni.id) for ni in instances_to_update},
+        )
+        _clean_updated_property(ctx, failed_update)
+        must_reinstall |= failed_update
+
+    if must_reinstall and not skip_reinstall:
+        intact_nodes = (
+            set(workflow_ctx.node_instances)
+            - must_reinstall
+            - set(to_uninstall)
+        )
+        uninstall_ids = {ni.id for ni in to_uninstall}
+        for n in must_reinstall:
+            for r in n._relationship_instances:
+                if r in uninstall_ids:
+                    n._relationship_instances.pop(r)
         clear_graph(graph)
         lifecycle.reinstall_node_instances(
             graph=graph,
-            node_instances=subgraph,
+            node_instances=must_reinstall,
             related_nodes=intact_nodes,
             ignore_failure=ignore_failure
         )

--- a/workflows/cloudify_system_workflows/deployment_update/workflow.py
+++ b/workflows/cloudify_system_workflows/deployment_update/workflow.py
@@ -16,7 +16,7 @@ from ..deployment_environment import format_plan_schedule
 from ..search_utils import GetValuesWithRest, get_instance_ids_by_node_ids
 
 from .step_extractor import extract_steps
-from .update_instances import reinstall_instances
+from .update_instances import update_or_reinstall_instances
 from .utils import clear_graph
 
 
@@ -872,7 +872,8 @@ def _execute_deployment_update(ctx, update_id, install_params):
         clear_graph(graph)
         _establish_relationships(ctx, graph, install_params)
 
-    reinstall_instances(
+    update_or_reinstall_instances(
+        ctx,
         graph,
         dep_up,
         install_params.added_instances,

--- a/workflows/cloudify_system_workflows/tests/deployment_update/blueprints/property_input.yaml
+++ b/workflows/cloudify_system_workflows/tests/deployment_update/blueprints/property_input.yaml
@@ -1,0 +1,18 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - minimal_types.yaml
+
+inputs:
+  inp1: {}
+
+node_types:
+  t1:
+    properties:
+      prop1: {}
+
+node_templates:
+  n1:
+    type: t1
+    properties:
+      prop1: {get_input: inp1}

--- a/workflows/cloudify_system_workflows/tests/deployment_update/blueprints/update_operation.yaml
+++ b/workflows/cloudify_system_workflows/tests/deployment_update/blueprints/update_operation.yaml
@@ -1,0 +1,137 @@
+# test blueprint for checking the update flow. This contains several nodes,
+# each with a different setup, and when we run the update workflow on a
+# deployment created from this blueprint (with changing an input), each node
+# will have some operations called on it, and we'll assert that the operations
+# are as expected.
+
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - minimal_types.yaml
+
+inputs:
+  inp1: {}
+
+node_types:
+  t1:
+    properties:
+      expected_calls:
+        type: list
+      prop1:
+        default: prop1_default
+
+node_templates:
+  # n1 has not changed, and check_drift returns null:
+  # only check_drift is called, but not update
+  n1:
+    type: t1
+    properties:
+      expected_calls:
+        - check_drift
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        check_drift:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+        update:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+
+  # n2 has changed, and doesn't declare check_drift:
+  # update is called
+  n2:
+    type: t1
+    properties:
+      prop1: {get_input: inp1}
+      expected_calls:
+        - update
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        update:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+
+  # n3 has not changed, and doesn't declare check_drift:
+  # update is not called
+  n3:
+    type: t1
+    properties:
+      expected_calls: []
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        update:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+
+  # n4 has not changed, but check_drift reports drift:
+  # update is called (create is defined but not called)
+  n4:
+    type: t1
+    properties:
+      expected_calls:
+        - check_drift
+        - update
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        check_drift:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+          inputs:
+            return_value: {drift: true}
+        create:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+        update:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+
+  # n5 has not changed, but check_drift reports drift, and update is not defined:
+  # instance is reinstalled
+  n5:
+    type: t1
+    properties:
+      expected_calls:
+        - check_drift
+        - create
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        check_drift:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+          inputs:
+            return_value: {drift: true}
+        create:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+
+  # n6 has not changed, but check_drift reports drift, and update fails:
+  # update is called, but since it failed, instance is reinstalled
+  n6:
+    type: t1
+    properties:
+      expected_calls:
+        - check_drift
+        - update
+        - create
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        check_drift:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+          inputs:
+            return_value: {drift: true}
+        update:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+          inputs:
+            fail: true
+        create:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+
+  # n7 has not changed, but check_drift fails:
+  # instance is reinstalled
+  n7:
+    type: t1
+    properties:
+      expected_calls:
+        - check_drift
+        - create
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        check_drift:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+          inputs:
+            fail: true
+        update:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+        create:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op

--- a/workflows/cloudify_system_workflows/tests/deployment_update/test_workflow.py
+++ b/workflows/cloudify_system_workflows/tests/deployment_update/test_workflow.py
@@ -7,27 +7,52 @@ def dsl_path_base():
     return os.path.join(os.path.dirname(__file__), 'blueprints')
 
 
+def deploy(blueprint_filename, resource_id='d1', storage=None, inputs=None):
+    if storage is None:
+        storage = local.InMemoryStorage()
+    blueprint_path = os.path.join(dsl_path_base(), blueprint_filename)
+    storage.create_blueprint(resource_id, blueprint_path)
+    storage.create_deployment(resource_id, resource_id, inputs=inputs)
+    return storage
+
+
+def test_empty_update():
+    storage = deploy('empty.yaml', resource_id='d1')
+    dep_env = local.load_env('d1', storage)
+    storage.create_deployment_update('d1', 'update1', {})
+    dep_env.execute('update', parameters={'update_id': 'update1'})
+    executions = dep_env.storage.get_executions()
+    assert len(executions) == 1
+    assert executions[0]['workflow_id'] == 'update'
+    assert executions[0]['status'] == 'terminated'
+
+
 def test_run_update_workflow():
-    storage = local.InMemoryStorage()
-    storage.create_blueprint(
-        'bp1',
-        os.path.join(dsl_path_base(), 'empty.yaml'),
-    )
+    storage = deploy('empty.yaml', resource_id='d1')
     storage.create_blueprint(
         'bp2',
         os.path.join(dsl_path_base(), 'description.yaml'),
     )
-    storage.create_deployment('dep1', 'bp1')
-    original_description = storage.get_deployment('dep1').description
-    dep_env = local.load_env('dep1', storage)
-    storage.create_deployment_update('dep1', 'update1', {
-        'id': 'update1',
+    original_description = storage.get_deployment('d1').description
+    dep_env = local.load_env('d1', storage)
+    storage.create_deployment_update('d1', 'update1', {
         'new_blueprint_id': 'bp2',
-        'old_blueprint_id': 'bp1',
-        'new_inputs': {},
-        'runtime_only_evaluation': False,
-        'deployment_id': 'dep1',
     })
     dep_env.execute('update', parameters={'update_id': 'update1'})
-    changed_description = storage.get_deployment('dep1').description
+    changed_description = storage.get_deployment('d1').description
     assert changed_description != original_description
+
+
+def test_change_property():
+    storage = deploy('property_input.yaml', resource_id='d1', inputs={
+        'inp1': 'value1',
+    })
+    dep_env = local.load_env('d1', storage)
+    storage.create_deployment_update('d1', 'update1', {
+        'new_inputs': {'inp1': 'value2'}
+    })
+    dep_env.execute('update', parameters={'update_id': 'update1'})
+    # reload the storage to get the updated deployment + node
+    dep_env = local.load_env('d1', storage)
+    node = dep_env.storage.get_node('n1', evaluate_functions=True)
+    assert node.properties['prop1'] == 'value2'

--- a/workflows/test-requirements.txt
+++ b/workflows/test-requirements.txt
@@ -1,3 +1,4 @@
 mock
 pytest
 pytest-cov
+pytest-subtests


### PR DESCRIPTION
Now, node-instances, instead of just always being reinstalled, will
be either reinstalled, or have the update interfaces called instead.