### PR TITLE
RD-4466 dep-update: allow empty update

### DIFF
--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -150,10 +150,6 @@ class DeploymentUpdate(SecuredResource):
         if not isinstance(reinstall_list, list):
             raise manager_exceptions.BadParametersError(
                 'parameter `reinstall_list` must be of type `list`')
-        if not blueprint_id and not inputs:
-            raise manager_exceptions.BadParametersError(
-                'Must supply either the `blueprint_id` parameter, or new '
-                'inputs, in order the perform a deployment update')
         if blueprint_id is None:
             deployment = get_storage_manager().get(models.Deployment,
                                                    deployment_id)

--- a/rest-service/manager_rest/test/endpoints/test_deployment_updates.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_updates.py
@@ -103,7 +103,6 @@ class TestDeploymentUpdates(base_test.BaseServerTestCase):
         for parameters in [
             {'inputs': {'a': 'b'}, 'reinstall_list': 'not_a_list'},
             {'inputs': 'not a dict'},
-            {},  # missing inputs and blueprint-id
             {'inputs': {'a': 'b'}, 'preview': ['not a bool']}
         ]:
             with self.assertRaises(CloudifyClientError):


### PR DESCRIPTION
Now we want to be able to run an "empty" update, which will not change
the deployment itself, but it'll run the update interfaces as needed.

The other side of this is cloudify-cosmo/cloudify-cli#1423