### PR TITLE
RD-4466 dep-update: skip reinstalling removed instances

### DIFF
--- a/workflows/cloudify_system_workflows/deployment_update/update_instances.py
+++ b/workflows/cloudify_system_workflows/deployment_update/update_instances.py
@@ -189,7 +189,7 @@ def update_or_reinstall_instances(ctx, graph, dep_up, install_params):
         }
         clear_graph(graph)
         instances_with_drift, failed_check = _do_check_drift(
-            ctx, set(ctx.node_instances) - to_skip)
+            ctx, consider_for_update - to_skip)
         for instance in failed_check:
             must_reinstall |= instance.get_contained_subgraph()
     else:
@@ -225,6 +225,7 @@ def update_or_reinstall_instances(ctx, graph, dep_up, install_params):
         _clean_updated_property(ctx, failed_update)
         must_reinstall |= failed_update
 
+    must_reinstall -= to_skip
     if must_reinstall and not install_params.skip_reinstall:
         intact_nodes = (
             set(workflow_ctx.node_instances)


### PR DESCRIPTION
1. Check drift only on the instances considered for update, no need to
   check drift on instances that were removed, or just added
2. Also remove those instances from the must-reinstall list; they can
   get there when their containing instance is reinstalled, because
   we then also add to must_reinstall its whole contained subgraph