### PR TITLE
RD-4466 dep-up: add force_reinstall

### DIFF
--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -122,6 +122,7 @@ class DeploymentUpdate(SecuredResource):
                 ('skip_uninstall', False),
                 ('skip_install', False),
                 ('skip_drift_check', False),
+                ('force_reinstall', False),
             ]:
                 execution_args[name] = verify_and_convert_bool(
                     name,

--- a/workflows/cloudify_system_workflows/deployment_update/update_instances.py
+++ b/workflows/cloudify_system_workflows/deployment_update/update_instances.py
@@ -210,6 +210,10 @@ def update_or_reinstall_instances(ctx, graph, dep_up, install_params):
             must_reinstall |= instance.get_contained_subgraph()
     instances_to_update = instances_with_drift - must_reinstall
 
+    if install_params.force_reinstall:
+        must_reinstall |= instances_to_update
+        instances_to_update = set()
+
     if instances_to_update:
         intact_nodes = set(workflow_ctx.node_instances) - instances_to_update
         clear_graph(graph)

--- a/workflows/cloudify_system_workflows/deployment_update/workflow.py
+++ b/workflows/cloudify_system_workflows/deployment_update/workflow.py
@@ -743,6 +743,7 @@ class InstallParameters:
     ignore_failure: bool
     skip_reinstall: bool
     skip_drift_check: bool
+    force_reinstall: bool
 
     def __init__(self, ctx, update_params, dep_update):
         self._update_instances = dep_update['deployment_update_node_instances']
@@ -775,6 +776,7 @@ class InstallParameters:
             ('skip_uninstall', False),
             ('skip_reinstall', False),
             ('skip_drift_check', False),
+            ('force_reinstall', False),
         ]:
             setattr(self, param, update_params.get(param, default))
 

--- a/workflows/cloudify_system_workflows/tests/deployment_update/blueprints/force_reinstall.yaml
+++ b/workflows/cloudify_system_workflows/tests/deployment_update/blueprints/force_reinstall.yaml
@@ -1,0 +1,31 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - minimal_types.yaml
+
+inputs:
+  inp1: {}
+
+node_types:
+  t1:
+    properties:
+      expected_calls:
+        type: list
+      prop1:
+        default: prop1_default
+
+
+node_templates:
+  # n1 has update defined, but with force_reinstall, we'll run create anyway
+  n1:
+    type: t1
+    properties:
+      expected_calls:
+        - create
+      prop1: {get_input: inp1}
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        update:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+        create:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op

--- a/workflows/cloudify_system_workflows/tests/deployment_update/blueprints/minimal_types.yaml
+++ b/workflows/cloudify_system_workflows/tests/deployment_update/blueprints/minimal_types.yaml
@@ -11,3 +11,6 @@ workflows:
       skip_drift_check:
         type: boolean
         default: false
+      force_reinstall:
+        type: boolean
+        default: false

--- a/workflows/cloudify_system_workflows/tests/deployment_update/test_workflow.py
+++ b/workflows/cloudify_system_workflows/tests/deployment_update/test_workflow.py
@@ -67,6 +67,9 @@ def test_change_property():
     ('skip_drift_check.yaml', {
         'skip_drift_check': True,
     }),
+    ('force_reinstall.yaml', {
+        'force_reinstall': True,
+    })
 ])
 def test_update_operation(subtests, blueprint_filename, parameters):
     """Test the update instances flow.


### PR DESCRIPTION
This will force all node-instances that were changed, to be
reinstalled, instead of running their update interfaces.