### PR TITLE
RD-5130 Allow updating plugin state in executions

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/plugins.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/plugins.py
@@ -260,7 +260,7 @@ class PluginsId(resources_v2_1.PluginsId):
         else:
             raise manager_exceptions.UnknownAction(action_dict.get('action'))
 
-    @authorize('plugin_upload')
+    @authorize('plugin_upload', allow_if_execution=True)
     def put(self, plugin_id, **kwargs):
         """Update the plugin, specifically the installation state.
 


### PR DESCRIPTION
Any execution can install a plugin under the hood, and so, this request
should always be allowed, if in an execution. If the user was allowed
to start an execution, they're also allowed to update plugin state,
that's it.