### PR TITLE
RD-5363 Do joinedloads independently

### DIFF
--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -139,7 +139,8 @@ class SQLStorageManager(object):
             if attrs:
                 query = query.options(db.load_only(*attrs))
             if rels:
-                query = query.options(db.joinedload(*rels))
+                for rel in rels:
+                    query = query.options(db.joinedload(rel))
 
         if load_relationships and not include:
             query = query.options(

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -49,6 +49,12 @@ class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
         db.session.add(dep)
         return dep
 
+    def test_dep_group_include_joinedload(self):
+        # RD-5363 Make sure we don't choke on joinedload again
+        self.client.deployment_groups.list(
+            _include=['deployment_ids', 'labels'],
+        )
+
     def test_get_empty(self):
         result = self.client.deployment_groups.list()
         assert len(result) == 0


### PR DESCRIPTION
Otherwise we can manage to end up trying to join deployment_groups on deployments.labels.