### PR TITLE
resources: default creator: avoid None

### DIFF
--- a/rest-service/manager_rest/storage/resource_models_base.py
+++ b/rest-service/manager_rest/storage/resource_models_base.py
@@ -123,7 +123,7 @@ class SQLResourceBase(SQLModelBase):
         with db.session.no_autoflush:
             if not self.creator:
                 user = current_user._get_current_object()
-                if user.is_authenticated:
+                if user is not None and user.is_authenticated:
                     self.creator = user
                 else:
                     self.creator = parent_instance.creator


### PR DESCRIPTION
current_user can be None as well (in the execution-scheduler).
In that case, fall back to the `parent_instance` part.