### PR TITLE
FileServerAuth: use check_user_action_allowed directly

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3/manager.py
+++ b/rest-service/manager_rest/rest/resources_v3/manager.py
@@ -67,11 +67,7 @@ class FileServerAuth(SecuredResource):
                 if FileServerAuth._is_global_blueprint(uri):
                     return
 
-                @authorize('file_server_auth', uri_tenant)
-                def _authorize():
-                    pass
-
-                _authorize()
+                check_user_action_allowed('file_server_auth', uri_tenant)
                 return
 
     @staticmethod


### PR DESCRIPTION
calling it in a roundabout way via the `@authorize` hack is a bit
weird. Let's just call it directly.

This fixes integration-tests' ResourcesAvailableTest

...because in #3768 we removed the `tenant_for_auth` argument, which
was indeed never provided by name, but in here, we used to pass the
tenant name positionally. Whoops.