### PR TITLE
RD-5336 `check_drift` properties comparison fixup

### DIFF
--- a/cloudify_types/cloudify_types/utils.py
+++ b/cloudify_types/cloudify_types/utils.py
@@ -476,7 +476,10 @@ def properties_diff(a, b):
     a_dict = a if isinstance(a, dict) else {}
     b_dict = b if isinstance(b, dict) else {}
     for k in a_dict.keys() & b_dict.keys():
-        if a_dict[k] != b_dict[k]:
+        if isinstance(a_dict[k], dict) and isinstance(b_dict[k], dict):
+            for j in properties_diff(a_dict[k], b_dict[k]):
+                yield j
+        elif a_dict[k] != b_dict[k]:
             yield k
 
 


### PR DESCRIPTION
Compare only the fields which are defined both in node's properties and
node instance's runtime properties.