### PR TITLE
RD-5353 dep-up: skip updating uninitialized instances

### DIFF
--- a/workflows/cloudify_system_workflows/deployment_update/update_instances.py
+++ b/workflows/cloudify_system_workflows/deployment_update/update_instances.py
@@ -177,6 +177,11 @@ def _clean_drift(ctx, instance):
 def update_or_reinstall_instances(ctx, graph, dep_up, install_params):
     to_skip = set(install_params.added_instances) \
               | set(install_params.removed_instances)
+    # update must not touch instances that weren't installed previously
+    to_skip |= {
+        ni for ni in workflow_ctx.node_instances
+        if ni.state != 'started'
+    }
     consider_for_update = set(workflow_ctx.node_instances) - to_skip
     changed_instances = _find_changed_instances(dep_up.steps)
 

--- a/workflows/cloudify_system_workflows/deployment_update/update_instances.py
+++ b/workflows/cloudify_system_workflows/deployment_update/update_instances.py
@@ -183,7 +183,7 @@ def update_or_reinstall_instances(ctx, graph, dep_up, install_params):
         if ni.state != 'started'
     }
     consider_for_update = set(workflow_ctx.node_instances) - to_skip
-    changed_instances = _find_changed_instances(dep_up.steps)
+    changed_instances = _find_changed_instances(dep_up.steps) - to_skip
 
     must_reinstall = set()
     instances_with_drift = set()
@@ -198,7 +198,7 @@ def update_or_reinstall_instances(ctx, graph, dep_up, install_params):
         }
         clear_graph(graph)
         instances_with_drift, failed_check = _do_check_drift(
-            ctx, consider_for_update - to_skip)
+            ctx, consider_for_update)
         for instance in failed_check:
             must_reinstall |= instance.get_contained_subgraph()
     else:

--- a/workflows/cloudify_system_workflows/deployment_update/update_instances.py
+++ b/workflows/cloudify_system_workflows/deployment_update/update_instances.py
@@ -66,14 +66,18 @@ def _do_check_drift(ctx, instances):
     Returns a set of instances that do have drift, and a set of instances
     that failed the drift check (those will need to be reinstalled).
     """
+    instances_with_drift = set()
+    failed_check = set()
+    if not instances:
+        # avoid running _make_check_drift_graph with empty instances,
+        # because then it'll check all instances in the deployment
+        return instances_with_drift, failed_check
     graph = workflows._make_check_drift_graph(
         ctx, node_instance_ids={ni.id for ni in instances},
         name='update_check_drift',
         ignore_failure=True,
     )
     graph.execute()
-    instances_with_drift = set()
-    failed_check = set()
     for instance in instances:
         if _has_failed_drift_check(instance):
             failed_check.add(instance)

--- a/workflows/cloudify_system_workflows/tests/deployment_update/blueprints/minimal_types.yaml
+++ b/workflows/cloudify_system_workflows/tests/deployment_update/blueprints/minimal_types.yaml
@@ -3,6 +3,8 @@ plugins:
     install: false
     executor: central_deployment_agent
 workflows:
+  install:
+    mapping: builtin.cloudify.plugins.workflows.install
   update:
     mapping: builtin.cloudify_system_workflows.deployment_update.workflow.update_deployment
     parameters:

--- a/workflows/cloudify_system_workflows/tests/deployment_update/blueprints/without_install.yaml
+++ b/workflows/cloudify_system_workflows/tests/deployment_update/blueprints/without_install.yaml
@@ -1,0 +1,52 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - minimal_types.yaml
+
+inputs:
+  inp1: {}
+
+node_types:
+  t1:
+    properties:
+      expected_calls:
+        type: list
+      prop1:
+        default: prop1_default
+
+
+node_templates:
+  # n1 was not installed, so it is not updated
+  n1:
+    type: t1
+    properties:
+      expected_calls: []
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        check_drift:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+          inputs:
+            return_value: {drift: true}
+        update:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+        create:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+
+  # n2 was not installed, but is changed in the blueprint. Either way, it is not touched.
+  n2:
+    type: t1
+    properties:
+      prop1: {get_input: inp1}
+      expected_calls: []
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        check_drift:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+          inputs:
+            return_value: {drift: true}
+        update:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+        create:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+        delete:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op

--- a/workflows/cloudify_system_workflows/tests/deployment_update/test_workflow.py
+++ b/workflows/cloudify_system_workflows/tests/deployment_update/test_workflow.py
@@ -52,6 +52,7 @@ def test_change_property():
         'inp1': 'value1',
     })
     dep_env = local.load_env('d1', storage)
+    dep_env.execute('install')
     storage.create_deployment_update('d1', 'update1', {
         'new_inputs': {'inp1': 'value2'}
     })
@@ -81,6 +82,7 @@ def test_update_operation(subtests, blueprint_filename, parameters):
         'inp1': 'value1',
     })
     dep_env = local.load_env('d1', storage)
+    dep_env.execute('install')
     storage.create_deployment_update('d1', 'update1', {
         'new_inputs': {'inp1': 'value2'}
     })
@@ -88,8 +90,6 @@ def test_update_operation(subtests, blueprint_filename, parameters):
     dep_env.execute('update', parameters=parameters)
 
     for ni in dep_env.storage.get_node_instances():
-        # if ni.node_id != 'n2':
-        #     continue
         with subtests.test(ni.node_id):
             node = dep_env.storage.get_node(ni.node_id)
             actual_calls = ni.runtime_properties.get('invocations', [])
@@ -102,6 +102,8 @@ def op(ctx, return_value=None, fail=False):
 
     Store the call in runtime-properties, and return the given value, or fail.
     """
+    if ctx.workflow_id != 'update':
+        return
     if ctx.type == RELATIONSHIP_INSTANCE:
         if ctx._context['related']['is_target']:
             prefix = 'target_'


### PR DESCRIPTION
Things that were never installed, must not be touched by update at all.