### PR TITLE
RD-5434 node-instance install: always clear drift/status

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/operations.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/operations.py
@@ -263,24 +263,21 @@ class OperationsId(SecuredResource):
         if node_instance.system_properties is None:
             node_instance.system_properties = {}
         if state == 'configured':
-            node_instance.system_properties.setdefault(
-                'configuration_drift', {
+            node_instance.system_properties['configuration_drift'] = {
                     'ok': True,
                     'result': None,
                     'task': None,
                     'timestamp': datetime.utcnow().isoformat(),
-                })
+                }
             node_instance.update_configuration_drift()
         elif state == 'started':
-            node_instance.system_properties.setdefault(
-                'previous_status', None)
-            node_instance.system_properties.setdefault(
-                'status', {
+            node_instance.system_properties['previous_status'] = None
+            node_instance.system_properties['status'] = {
                     'ok': True,
                     'result': None,
                     'task': None,
                     'timestamp': datetime.utcnow().isoformat(),
-                })
+                }
             node_instance.update_status_check()
         node_instance.state = state
         sm.update(node_instance, modified_attrs=('state', 'system_properties'))


### PR DESCRIPTION
Instead of setdefault, just set it. Otherwise, if the node was
considered eg. having drift before the installation, it would still
have it. That doesn't make sense. Installation is supposed to leave
the node pristine and new.

This is mostly only visible in reinstalls (especially called by heal).
Without this, we had eg. the component heal operation, run more times
than necessary (it was still retried after a reinstall, until it
got around to running check_status again)