### PR TITLE
RD-5405 Exempt heal from the dependency check

### DIFF
--- a/cloudify_types/cloudify_types/component/operations.py
+++ b/cloudify_types/cloudify_types/component/operations.py
@@ -410,16 +410,24 @@ def heal(timeout=EXECUTIONS_TIMEOUT, **kwargs):
     client, _ = get_client(kwargs)
     deployment_id = _current_deployment_id(**kwargs)
 
-    client.executions.start(
+    heal_execution = client.executions.start(
         deployment_id=deployment_id,
         workflow_id='heal'
+    )
+    ctx.logger.info(
+        'Heal of component deployment: %s, heal execution: %s',
+        deployment_id, heal_execution.id
     )
     poll_with_timeout(
         lambda: is_all_executions_finished(client, deployment_id),
         timeout=timeout,
         expected_result=True
     )
-
+    heal_execution = client.executions.get(heal_execution.id)
+    ctx.logger.info(
+        'Heal of component deployment: %s finished, execution status: %s',
+        deployment_id, heal_execution.status
+    )
     deployment = client.deployments.get(deployment_id)
     validate_deployment_status(deployment)
 

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2518,7 +2518,8 @@ class ResourceManager(object):
                     ]),
                     models.Execution.workflow_id.in_([
                         'stop', 'uninstall', 'update',
-                        'csys_new_deployment_update'
+                        'csys_new_deployment_update',
+                        'heal',
                     ])
                 )
                 .exists()
@@ -2535,7 +2536,8 @@ class ResourceManager(object):
 
     def _verify_dependencies_not_affected(self, execution, force):
         if execution.workflow_id not in [
-            'stop', 'uninstall', 'update', 'csys_new_deployment_update'
+            'stop', 'uninstall', 'update', 'csys_new_deployment_update',
+            'heal',
         ]:
             return
         # if we're in the middle of an execution initiated by the component

--- a/tests/integration_tests/tests/agentless_tests/component/test_workflows.py
+++ b/tests/integration_tests/tests/agentless_tests/component/test_workflows.py
@@ -53,25 +53,24 @@ node_templates:
           id: basic
 """
 
-
-class BasicWorkflowsTest(AgentlessTestCase):
-    def setUp(self):
-        basic_blueprint = """
+BASIC_BLUEPRINT = """
 tosca_definitions_version: cloudify_dsl_1_4
 
 imports:
-  - cloudify/types/types.yaml
+- cloudify/types/types.yaml
 
 node_templates:
   root_node:
     type: cloudify.nodes.Root
 """
-        self.client.blueprints.upload(
-            self.make_yaml_file(basic_blueprint),
-            entity_id='basic'
-        )
 
+
+class BasicWorkflowsTest(AgentlessTestCase):
     def test_basic_components_heal(self):
+        self.client.blueprints.upload(
+            self.make_yaml_file(BASIC_BLUEPRINT),
+            entity_id='basic',
+        )
         test_blueprint_path = self.make_yaml_file(COMPONENT_BLUEPRINT)
         deployment, _ = self.deploy_application(test_blueprint_path)
         assert len(self.client.deployments.list()) == 2
@@ -84,6 +83,10 @@ node_templates:
         assert len(self.client.deployments.list()) == 2
 
     def test_nested_components_heal_success(self):
+        self.client.blueprints.upload(
+            self.make_yaml_file(BASIC_BLUEPRINT),
+            entity_id='basic',
+        )
         test_blueprint = """
 tosca_definitions_version: cloudify_dsl_1_4
 
@@ -117,7 +120,9 @@ node_templates:
         assert len(self.client.deployments.list()) == 3
 
     @pytest.mark.usefixtures('cloudmock_plugin')
-    def test_nested_components_heal_failure(self):
+    def test_heal_failure_reinstall(self):
+        # there's a blueprint with a component, and the component is going
+        # to fail check_status, and heal - it will have to be reinstalled
         test_blueprint = """
 tosca_definitions_version: cloudify_dsl_1_4
 
@@ -135,20 +140,80 @@ node_templates:
         deployment:
           id: component
 """
+        component_blueprint = """
+tosca_definitions_version: cloudify_dsl_1_4
+
+imports:
+  - cloudify/types/types.yaml
+  - plugin:cloudmock
+
+node_templates:
+  root_node:
+    type: cloudify.nodes.Root
+    interfaces:
+      cloudify.interfaces.validation:
+        check_status: cloudmock.cloudmock.tasks.maybe_failing
+      cloudify.interfaces.lifecycle:
+        create: cloudmock.cloudmock.tasks.clear_fail_flag
+        heal: cloudmock.cloudmock.tasks.failing
+"""
         self.client.blueprints.upload(
-            self.make_yaml_file(FAILING_HEAL_COMPONENT_BLUEPRINT),
-            entity_id='component'
+            self.make_yaml_file(component_blueprint),
+            entity_id='component',
         )
         test_blueprint_path = self.make_yaml_file(test_blueprint)
         deployment, _ = self.deploy_application(test_blueprint_path)
-        assert len(self.client.deployments.list()) == 3
-
-        self.client.deployments.delete('basic', force=True)
-        _wait_until(lambda: not self.client.deployments.get('basic'))
         assert len(self.client.deployments.list()) == 2
 
+        # now, let's update the node-instance inside the component deployment
+        # to fail check_status: it will keep failing until reinstalled
+        # (because the create operation clears the fail flag, allowing
+        # check_status to succeed; but the heal operation always fails)
+        ni = self.client.node_instances.list(
+            deployment_id='component',
+            node_id='root_node',
+        ).one()
+        self.client.node_instances.update(
+            ni.id,
+            version=ni.version,
+            runtime_properties={'fail': True},
+        )
+        with self.assertRaises(RuntimeError):
+            self.execute_workflow('check_status', 'component')
+
         self.execute_workflow('heal', deployment.id)
-        assert len(self.client.deployments.list()) == 3
+        component_executions = [
+            exc.workflow_id
+            for exc in self.client.executions.list(deployment_id='component')
+        ]
+        # there's 2 check_status executions: one we called directly above,
+        # and one called by the check_status operation on the Component
+        # node in the main deployment
+        assert component_executions.count('check_status') == 2
+
+        # there's only 1 heal execution: the one called by the heal operation
+        # on the Component node in the main deployment
+        assert component_executions.count('heal') == 1
+
+        heal_execution = self.client.executions.list(
+            deployment_id='component',
+            workflow_id='heal',
+        ).one()
+        heal_graphs = [
+            tg.name for tg in self.client.tasks_graphs.list(heal_execution.id)
+        ]
+        # check that heal did call exactly the graphs we expected:
+        # a check_status first (which failed), then a heal (which also failed),
+        # and then a fallback to reinstall
+        # NOTE: this assert is VERY tighly coupled to the implementation. If it
+        # fails often when changing the heal workflow impl, we can make it
+        # more lenient
+        assert heal_graphs == [
+            'check_status',
+            'heal',
+            'reinstall-uninstall',
+            'reinstall-install',
+        ]
 
 
 def _wait_until(fn,

--- a/tests/integration_tests_plugins/cloudmock/cloudmock/tasks.py
+++ b/tests/integration_tests_plugins/cloudmock/cloudmock/tasks.py
@@ -217,3 +217,16 @@ def limit_scale(ctx):
         raise NonRecoverableError(
             'instance {0} disallowed'.format(ctx.instance.index))
     ctx.logger.info('instance %d created', ctx.instance.index)
+
+
+@operation
+def clear_fail_flag(ctx, **kwargs):
+    """Clear the fail flag, so that the maybe_failing task doesn't fail"""
+    ctx.instance.runtime_properties['fail'] = False
+
+
+@operation
+def maybe_failing(ctx, **kwargs):
+    """Fail only if the fail flag is set"""
+    if ctx.instance.runtime_properties.get('fail'):
+        raise NonRecoverableError('Error')


### PR DESCRIPTION
Similar to uninstall (and update), heal needs to be considered an ok
workflow to run in components as well: it can do uninstall...

This is to mean: a component is fine to run a heal, if its parent is
currently running a heal. (same logic as for uninstall)