### PR TITLE
Autoupload test bump openstack plugin version

### DIFF
--- a/tests/integration_tests/resources/dsl/blueprint_with_plugins_from_catalog.yaml
+++ b/tests/integration_tests/resources/dsl/blueprint_with_plugins_from_catalog.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_4
 
 imports:
   - cloudify/types/types.yaml
-  - plugin:cloudify-openstack-plugin?version= <=2.14.24
+  - plugin:cloudify-openstack-plugin?version= <=2.14.25
   - plugin:cloudify-utilities-plugin
   - plugin:cloudify-fabric-plugin?version= >2
 

--- a/tests/integration_tests/tests/agentless_tests/test_blueprint_upload_autoupload_plugins.py
+++ b/tests/integration_tests/tests/agentless_tests/test_blueprint_upload_autoupload_plugins.py
@@ -20,7 +20,7 @@ class BlueprintUploadAutouploadPluginsTest(AgentlessTestCase):
 
         plugins = {p.package_name: p.package_version
                    for p in self.client.plugins.list()}
-        self.assertEqual(plugins["cloudify-openstack-plugin"], "2.14.24")
+        self.assertEqual(plugins["cloudify-openstack-plugin"], "2.14.25")
         self.assertIn("cloudify-utilities-plugin", plugins)
         self.assertGreater(parse_version(plugins["cloudify-fabric-plugin"]),
                            parse_version("2"))


### PR DESCRIPTION
Since the lowest version of Openstack plugin supported by RedHat 8 is 2.14.25, let's use it in the test