### PR TITLE
RD-5404 Define an update operation for Component

### DIFF
--- a/cloudify_types/cloudify_types/component/__init__.py
+++ b/cloudify_types/cloudify_types/component/__init__.py
@@ -20,3 +20,4 @@ from .operations import refresh  # NOQA
 from .operations import check_drift  # NOQA
 from .operations import check_status  # NOQA
 from .operations import heal  # NOQA
+from .operations import update  # NOQA

--- a/cloudify_types/cloudify_types/utils.py
+++ b/cloudify_types/cloudify_types/utils.py
@@ -464,7 +464,7 @@ def _zipping(source, destination, include_folder=True):
     return destination
 
 
-def capabilities_diff(a, b):
+def dict_sum_diff(a, b):
     a_dict = a if isinstance(a, dict) else {}
     b_dict = b if isinstance(b, dict) else {}
     for k in a_dict.keys() | b_dict.keys():
@@ -472,15 +472,15 @@ def capabilities_diff(a, b):
             yield k
 
 
-def properties_diff(a, b):
-    a_dict = a if isinstance(a, dict) else {}
-    b_dict = b if isinstance(b, dict) else {}
-    for k in a_dict.keys() & b_dict.keys():
-        if isinstance(a_dict[k], dict) and isinstance(b_dict[k], dict):
-            for j in properties_diff(a_dict[k], b_dict[k]):
-                yield j
-        elif a_dict[k] != b_dict[k]:
-            yield k
+def current_deployment_id(**kwargs):
+    config = get_desired_operation_input('resource_config', kwargs)
+    runtime_deployment_prop = ctx.instance.runtime_properties.get(
+        'deployment', {})
+    runtime_deployment_id = runtime_deployment_prop.get('id')
+    deployment = config.get('deployment', {})
+    return runtime_deployment_id \
+        or deployment.get('id') \
+        or ctx.instance.id
 
 
 def validate_deployment_status(deployment):

--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -459,6 +459,8 @@ node_types:
           implementation: cfy_extensions.cloudify_types.component.check_drift
         heal:
           implementation: cfy_extensions.cloudify_types.component.heal
+        update:
+          implementation: cfy_extensions.cloudify_types.component.update
       cloudify.interfaces.validation:
         check_status:
           implementation: cfy_extensions.cloudify_types.component.check_status


### PR DESCRIPTION
* Modify how Component node's properties are compared
  We are comparing only selected node's properties with the same set
  of runtime_properties coming from node_instance.

* Define update operation for component node
  which is to run a deployment update on a deployment it represents.

* Tests

this is a cherry-pick of https://github.com/cloudify-cosmo/cloudify-manager/pull/3776