### PR TITLE
inte-tests: use --lightweight to skip some services

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/status.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/status.py
@@ -37,7 +37,6 @@ except ImportError:
 
 BASE_SERVICES = {
     'nginx': 'Webserver',
-    'cloudify-stage': 'Cloudify Console',
     'cloudify-amqp-postgres': 'AMQP-Postgres',
     'cloudify-mgmtworker': 'Management Worker',
     'cloudify-restservice': 'Manager Rest-Service',
@@ -45,6 +44,7 @@ BASE_SERVICES = {
     'cloudify-execution-scheduler': 'Cloudify Execution Scheduler',
 }
 OPTIONAL_SERVICES = {
+    'cloudify-stage': 'Cloudify Console',
     'haproxy': 'Haproxy for DB HA',
     'patroni': 'Patroni HA Postgres',
     'postgresql-9.5': 'PostgreSQL',

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,7 +25,8 @@ We add several commandline arguments for pytest:
 - `--container-id` - use a pre-spawned container (might be from a separate
   test run that provided --keep-container) for this test. Use this to
   greatly increase iteration speed when working with the tests.
-
+- `--lightweight` - run a container without optional services, making it
+  lighter and faster
 
 ## Source code mounting
 

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -59,7 +59,12 @@ def pytest_addoption(parser):
         help='Run integration tests using specific service management layer. '
              '`supervisord` or `systemd`',
     )
-
+    parser.addoption(
+        '--lightweight',
+        default=False,
+        action='store_true',
+        help='Run a "lightweight" manager, without UI and monitoring',
+    )
 
 # items from tests-source-root to be mounted into the specified
 # on-manager virtualenvs
@@ -166,12 +171,17 @@ def manager_container(request, resource_mapping):
     keep_container = request.config.getoption("--keep-container")
     container_id = request.config.getoption("--container-id")
     service_management = request.config.getoption("--service-management")
+    lightweight = request.config.getoption('--lightweight')
     if container_id:
         reset_storage(container_id)
         keep_container = True
     else:
         container_id = docker.run_manager(
-            image_name, service_management, resource_mapping=resource_mapping)
+            image_name,
+            service_management,
+            resource_mapping=resource_mapping,
+            lightweight=lightweight,
+        )
         docker.upload_mock_license(container_id)
     container_ip = docker.get_manager_ip(container_id)
     container = Env(container_id, container_ip, service_management)

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -66,6 +66,7 @@ def pytest_addoption(parser):
         help='Run a "lightweight" manager, without UI and monitoring',
     )
 
+
 # items from tests-source-root to be mounted into the specified
 # on-manager virtualenvs
 # pairs of (source path, [list of target virtualenvs])

--- a/tests/integration_tests/tests/agentless_tests/test_manager_status.py
+++ b/tests/integration_tests/tests/agentless_tests/test_manager_status.py
@@ -37,14 +37,6 @@ SERVICES = {
 class TestManagerStatus(AgentlessTestCase):
 
     def test_status_response(self):
-        # Force Prometheus to scrape the statuses
-        self.restart_service('blackbox_exporter')
-        self.restart_service('postgres_exporter')
-        self.restart_service('node_exporter')
-        time.sleep(1.5)
-        self.execute_on_manager('bash -c "pkill -SIGHUP prometheus"')
-        time.sleep(0.5)
-
         manager_status = self.client.manager.get_status()
         self.assertEqual(manager_status['status'], ServiceStatus.HEALTHY)
 

--- a/tests/integration_tests/tests/agentless_tests/test_manager_status.py
+++ b/tests/integration_tests/tests/agentless_tests/test_manager_status.py
@@ -65,9 +65,6 @@ class TestManagerStatus(AgentlessTestCase):
         self._test_service_inactive('Cloudify Console')
         self._test_service_inactive('AMQP-Postgres')
 
-    def test_status_optional_service_inactive(self):
-        """One of the optional systemd services is down"""
-        self._test_service_inactive('Cloudify Composer')
 
     def test_status_rabbit_inactive(self):
         self._test_service_inactive('RabbitMQ')

--- a/tests/integration_tests/tests/agentless_tests/test_manager_status.py
+++ b/tests/integration_tests/tests/agentless_tests/test_manager_status.py
@@ -41,14 +41,13 @@ class TestManagerStatus(AgentlessTestCase):
         self.assertEqual(manager_status['status'], ServiceStatus.HEALTHY)
 
         # Services for all-in-one premium manager
-        services = ['Webserver', 'Cloudify Console', 'AMQP-Postgres',
-                    'Management Worker', 'Manager Rest-Service',
-                    'Cloudify API', 'Cloudify Execution Scheduler',
-                    'PostgreSQL', 'RabbitMQ', 'Cloudify Composer',
-                    'Monitoring Service']
-        self.assertEqual(
-            len(manager_status['services']),
-            len(services))
+        services = [
+            'Webserver', 'AMQP-Postgres',
+            'Management Worker', 'Manager Rest-Service',
+            'Cloudify API', 'Cloudify Execution Scheduler',
+            'PostgreSQL', 'RabbitMQ',
+        ]
+
         statuses = [manager_status['services'][service]['status']
                     for service in services]
         self.assertNotIn(NodeServiceStatus.INACTIVE, statuses)

--- a/tests/integration_tests/tests/agentless_tests/test_manager_status.py
+++ b/tests/integration_tests/tests/agentless_tests/test_manager_status.py
@@ -62,9 +62,6 @@ class TestManagerStatus(AgentlessTestCase):
     def test_status_service_inactive(self):
         """One of the systemd services is down"""
         self._test_service_inactive('Management Worker')
-        self._test_service_inactive('Cloudify Console')
-        self._test_service_inactive('AMQP-Postgres')
-
 
     def test_status_rabbit_inactive(self):
         self._test_service_inactive('RabbitMQ')


### PR DESCRIPTION
- you can now run inte-tests with a lightweight managerr
- the status endpoint now considers stage to be optional (RD-5465)
- drop some non-essential parts of the status inte-test