### PR TITLE
RD-5502 Don't bother with drift check after heal

### DIFF
--- a/cloudify_types/cloudify_types/component/operations.py
+++ b/cloudify_types/cloudify_types/component/operations.py
@@ -455,7 +455,7 @@ def heal(timeout=EXECUTIONS_TIMEOUT, **kwargs):
         deployment_id, heal_execution.status
     )
     deployment = client.deployments.get(deployment_id)
-    validate_deployment_status(deployment)
+    validate_deployment_status(deployment, validate_drifted=False)
 
 
 @operation

--- a/cloudify_types/cloudify_types/utils.py
+++ b/cloudify_types/cloudify_types/utils.py
@@ -483,7 +483,7 @@ def current_deployment_id(**kwargs):
         or ctx.instance.id
 
 
-def validate_deployment_status(deployment):
+def validate_deployment_status(deployment, validate_drifted=True):
     if deployment.installation_status != DeploymentState.ACTIVE:
         raise Exception(
             f"Expected deployment '{deployment.id}' to be installed, but got "
@@ -499,7 +499,7 @@ def validate_deployment_status(deployment):
         raise Exception(
             f"There are {deployment.unavailable_instances} unavailable "
             f"instances in deployment '{deployment.id}'")
-    if deployment.drifted_instances > 0:
+    if validate_drifted and deployment.drifted_instances > 0:
         raise Exception(
             f"There are {deployment.drifted_instances} drifted "
             f"instances in deployment '{deployment.id}'")


### PR DESCRIPTION
The post-heal validation check shouldn't raise execptions when a drift
is detected (because heal doesn't fix drift, update does).