### PR TITLE
RD-5502 Don't bother with drift check after heal

### DIFF
--- a/cloudify_types/cloudify_types/component/operations.py
+++ b/cloudify_types/cloudify_types/component/operations.py
@@ -455,7 +455,7 @@ def heal(timeout=EXECUTIONS_TIMEOUT, **kwargs):
         deployment_id, heal_execution.status
     )
     deployment = client.deployments.get(deployment_id)
-    validate_deployment_status(deployment)
+    validate_deployment_status(deployment, validate_drifted=False)
 
 
 @operation

--- a/cloudify_types/cloudify_types/utils.py
+++ b/cloudify_types/cloudify_types/utils.py
@@ -483,23 +483,23 @@ def current_deployment_id(**kwargs):
         or ctx.instance.id
 
 
-def validate_deployment_status(deployment):
+def validate_deployment_status(deployment, validate_drifted=True):
     if deployment.installation_status != DeploymentState.ACTIVE:
-        raise Exception(
+        raise NonRecoverableError(
             f"Expected deployment '{deployment.id}' to be installed, but got "
             f"installation status: '{deployment.installation_status}'")
     if deployment.deployment_status != DeploymentState.GOOD:
-        raise Exception(
+        raise NonRecoverableError(
             f"Expected deployment '{deployment.id}' to be in a good state, "
             f"but got deployment status: '{deployment.deployment_status}'")
     if deployment.latest_execution_status == ExecutionState.FAILED:
-        raise Exception(
+        raise NonRecoverableError(
             f"The latest execution for '{deployment.id}' failed")
     if deployment.unavailable_instances > 0:
-        raise Exception(
+        raise NonRecoverableError(
             f"There are {deployment.unavailable_instances} unavailable "
             f"instances in deployment '{deployment.id}'")
-    if deployment.drifted_instances > 0:
-        raise Exception(
+    if validate_drifted and deployment.drifted_instances > 0:
+        raise NonRecoverableError(
             f"There are {deployment.drifted_instances} drifted "
             f"instances in deployment '{deployment.id}'")

--- a/rest-service/manager_rest/deployment_update/handlers.py
+++ b/rest-service/manager_rest/deployment_update/handlers.py
@@ -116,7 +116,7 @@ class NodeHandler(FrozenEntitiesHandlerBase):
         """Handles removing a node
         :return: the removed node
         """
-        del(current_entities[ctx.storage_node.id])
+        del current_entities[ctx.storage_node.id]
         return ctx.storage_node.id
 
 
@@ -327,7 +327,7 @@ class OperationHandler(ModifiableEntityHandlerBase):
     @staticmethod
     def _remove_node_operation(ctx, current_entities):
         current_node = current_entities[ctx.raw_node_id]
-        del(current_node[ctx.OPERATIONS][ctx.operation_id])
+        del current_node[ctx.OPERATIONS][ctx.operation_id]
         return ctx.entity_id
 
     @staticmethod
@@ -335,7 +335,7 @@ class OperationHandler(ModifiableEntityHandlerBase):
         current_node = current_entities[ctx.raw_node_id]
         modified_relationship = \
             current_node[ctx.RELATIONSHIPS][ctx.relationship_index]
-        del(modified_relationship[ctx.operations_key][ctx.operation_id])
+        del modified_relationship[ctx.operations_key][ctx.operation_id]
         return ctx.entity_id
 
     def add(self, ctx, current_entities):
@@ -384,7 +384,7 @@ class PropertyHandler(ModifiableEntityHandlerBase):
 
     def remove(self, ctx, current_entities):
         node_id = ctx.raw_node_id
-        del(current_entities[node_id][ctx.PROPERTIES][ctx.property_id])
+        del current_entities[node_id][ctx.PROPERTIES][ctx.property_id]
         return ctx.entity_id
 
     def add(self, ctx, current_entities):
@@ -408,7 +408,7 @@ class WorkflowHandler(ModifiableEntityHandlerBase):
         deployment = self.sm.get(models.Deployment, ctx.deployment_id)
         new_workflows = deployment.workflows.copy()
 
-        del(current_entities[ctx.WORKFLOWS][ctx.workflow_id])
+        del current_entities[ctx.WORKFLOWS][ctx.workflow_id]
         del new_workflows[ctx.workflow_id]
 
         deployment.workflows = new_workflows
@@ -435,7 +435,7 @@ class OutputHandler(ModifiableEntityHandlerBase):
         deployment = self.sm.get(models.Deployment, ctx.deployment_id)
         deployment.outputs = deepcopy(deployment.outputs)
 
-        del(current_entities[ctx.OUTPUTS][ctx.output_id])
+        del current_entities[ctx.OUTPUTS][ctx.output_id]
         del deployment.outputs[ctx.output_id]
 
         self.sm.update(deployment)
@@ -794,7 +794,7 @@ class DeploymentUpdateNodeInstanceHandler(UpdateHandler):
     def _clean_relationship_index_field(relationships):
         for relationship in relationships:
             if 'rel_index' in relationship:
-                del(relationship['rel_index'])
+                del relationship['rel_index']
         return relationships
 
     def _reorder_relationships(self, deployment_id, rel_order_instances):

--- a/rest-service/manager_rest/test/endpoints/test_nodes.py
+++ b/rest-service/manager_rest/test/endpoints/test_nodes.py
@@ -257,7 +257,7 @@ class NodesTest(_NodeSetupMixin, base_test.BaseServerTestCase):
         self.assertNotIn('key', response.runtime_properties)
 
     def test_patch_node_runtime_props_overwrite(self):
-        """Runtime properties update with a preexisting key keeps the new value.
+        """Runtime properties update with a preexisting key keeps the new value
 
         When the new runtime properties have a key that was already in
         runtime properties, the new value wins.


### PR DESCRIPTION
* The post-heal validation check shouldn't raise exceptions when a drift
  is detected (because heal doesn't fix drift, update does).

* Throw a `NonRecoverableError` when deployment is not healthy,
  because it's not likely it'll become healthy and we would be just wasting
  time waiting for 60 retries of `heal`.

This is a cherry-pick of https://github.com/cloudify-cosmo/cloudify-manager/pull/3785