### PR TITLE
Revert "RD-5513 Use RabbitMQ 3.10.7"

### DIFF
--- a/packaging/cloudify-rabbitmq.spec
+++ b/packaging/cloudify-rabbitmq.spec
@@ -15,7 +15,7 @@ URL:            https://github.com/cloudify-cosmo/cloudify-manager
 Vendor:         Cloudify Platform Ltd.
 Packager:       Cloudify Platform Ltd.
 
-Requires:       rabbitmq-server = 3.10.7
+Requires:       rabbitmq-server = 3.8.4
 
 
 %define _user rabbitmq


### PR DESCRIPTION
Reverts cloudify-cosmo/cloudify-manager#3793

Let's keep the build working before we figure out how to upgrade rmq