### PR TITLE
Stop skipping several inte-tests

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_addition.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_addition.py
@@ -17,8 +17,6 @@ import shutil
 import pytest
 import tempfile
 
-from pytest import mark
-
 from integration_tests.tests.utils import (tar_blueprint,
                                            wait_for_blueprint_upload)
 from . import DeploymentUpdateBase, BLUEPRINT_ID

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_addition.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_addition.py
@@ -548,7 +548,6 @@ class TestDeploymentUpdateAddition(DeploymentUpdateBase):
         self._assertDictContainsSubset({'custom_output': {'value': 0}},
                                        deployment.outputs)
 
-    @mark.skip
     def test_add_description(self):
         deployment, modified_bp_path = \
             self._deploy_and_get_modified_bp_path('add_description')
@@ -558,4 +557,4 @@ class TestDeploymentUpdateAddition(DeploymentUpdateBase):
         self._do_update(deployment.id, BLUEPRINT_ID)
 
         deployment = self.client.deployments.get(deployment.id)
-        self.assertRegexpMatches(deployment['description'], 'new description')
+        self.assertRegex(deployment['description'], 'new description')

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_removal.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_removal.py
@@ -392,7 +392,6 @@ class TestDeploymentUpdateRemoval(DeploymentUpdateBase):
         deployment = self.client.deployments.get(deployment.id)
         self.assertNotIn('custom_output', deployment.outputs)
 
-    @mark.skip
     def test_remove_description(self):
         deployment, modified_bp_path = \
             self._deploy_and_get_modified_bp_path('remove_description')

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -145,25 +145,6 @@ class EventsTest(AgentlessTestCase):
         else:
             self.fail("Expected logs to be found")
 
-    @pytest.mark.skip(reason='causes the DB deadlock in snapshot')
-    def test_snapshots_events(self):
-        """ Make sure snapshots events appear when using the
-         'cfy events list' command """
-        # Make sure 'snapshots create' events appear
-        snapshot_id = 's{0}'.format(uuid.uuid4())
-        execution = self.client.snapshots.create(snapshot_id, False, False)
-        self.wait_for_event(execution, CREATE_SNAPSHOT_SUCCESS_MSG)
-
-        # Make sure 'snapshots restore' events appear
-        self.undeploy_application(
-            self.deployment_id, is_delete_deployment=True)
-        execution = self.client.snapshots.restore(snapshot_id, force=True)
-        # give the database some time to downgrade/upgrade before running
-        # requests to avoid the deadlock described in CY-1455
-        time.sleep(10)
-
-        self.wait_for_event(execution, RESTORE_SNAPSHOT_SUCCESS_MSG)
-
     def _events_list(self, **kwargs):
         if 'deployment_id' not in kwargs:
             kwargs['deployment_id'] = self.deployment_id

--- a/tests/integration_tests/tests/agentless_tests/test_events.py
+++ b/tests/integration_tests/tests/agentless_tests/test_events.py
@@ -13,7 +13,6 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-import uuid
 import time
 import pytest
 


### PR DESCRIPTION
Currently we skip 5 inte-tests, and that's always reported by the
slack reporting. Let's stop skipping them - unskipped some, removed some.