### PR TITLE
RD-5653 inte-tests: show wait-for-starter output

### DIFF
--- a/tests/integration_tests/framework/docker.py
+++ b/tests/integration_tests/framework/docker.py
@@ -54,7 +54,11 @@ services_to_install:
     logging.info('Starting container: %s', ' '.join(command))
     manager_id = subprocess.check_output(command).decode('utf-8').strip()
     logging.info('Started container %s', manager_id)
-    execute(manager_id, ['cfy_manager', 'wait-for-starter'])
+    execute(
+        manager_id,
+        ['cfy_manager', 'wait-for-starter'],
+        redirect_logs=True,
+    )
     return manager_id
 
 
@@ -79,7 +83,7 @@ def read_file(container_id, file_path, no_strip=False):
     return result
 
 
-def execute(container_id, command, env=None):
+def execute(container_id, command, env=None, redirect_logs=False):
     if not isinstance(command, list):
         command = shlex.split(command)
     args = ['docker', 'exec']
@@ -91,6 +95,8 @@ def execute(container_id, command, env=None):
     for k, v in env.items():
         args += ['-e', '{0}={1}'.format(k, v)]
     args.append(container_id)
+    if redirect_logs:
+        return subprocess.run(args + command)
     return subprocess.check_output(args + command).decode('utf-8')
 
 

--- a/tests/integration_tests/framework/utils.py
+++ b/tests/integration_tests/framework/utils.py
@@ -59,12 +59,6 @@ def sh_bake(command):
         _err=lambda line: _write(sys.stderr, line))
 
 
-def get_profile_context(container_id):
-    profile_context_cmd =\
-        'cat /root/.cloudify/profiles/manager-local/context.json'
-    return json.loads(docker.execute(container_id, profile_context_cmd))
-
-
 def set_cfy_paths(new_workdir):
     cli_env.CLOUDIFY_WORKDIR = os.path.join(
         new_workdir,

--- a/tests/integration_tests/tests/agentless_tests/security/test_authentication.py
+++ b/tests/integration_tests/tests/agentless_tests/security/test_authentication.py
@@ -22,9 +22,7 @@ pytestmark = pytest.mark.group_premium
 
 class AuthenticationTest(TestAuthenticationBase):
     def test_valid_credentials_authenticate(self):
-        profile_context = utils.get_profile_context(self.env.container_id)
-        self._assert_authorized(username=profile_context['manager_username'],
-                                password=profile_context['manager_password'])
+        self._assert_authorized(username='admin', password='admin')
 
     def test_invalid_credentials_fails(self):
         self._assert_unauthorized(username='wrong_username',

--- a/tests/integration_tests/tests/agentless_tests/test_backwards_rest_api.py
+++ b/tests/integration_tests/tests/agentless_tests/test_backwards_rest_api.py
@@ -53,16 +53,15 @@ class RestApiBackwardsCompatibilityTest(AgentlessTestCase):
         shell_script_path = resource('scripts/test_old_rest_client.sh')
         python_script_path = resource('scripts/test_old_rest_client.py')
         result_path = str(self.workdir / 'result.json')
-        profile_context = utils.get_profile_context(self.env.container_id)
 
         env = os.environ.copy()
         env.update({
             'python_script_path': python_script_path,
             'client_version': client_version,
             'manager_ip': self.get_manager_ip(),
-            'manager_user': profile_context['manager_username'],
-            'manager_password': profile_context['manager_password'],
-            'manager_tenant': profile_context['manager_tenant'],
+            'manager_user': 'admin',
+            'manager_password': 'admin',
+            'manager_tenant': 'default_tenant',
             'url_version_postfix': url_version_postfix,
             'result_path': result_path
         })

--- a/tests/integration_tests/tests/test_cases.py
+++ b/tests/integration_tests/tests/test_cases.py
@@ -27,7 +27,6 @@ from integration_tests.tests.utils import (
     verify_deployment_env_created,
     run_postgresql_command,
     do_retries,
-    do_retries_boolean
 )
 
 from cloudify_rest_client.executions import Execution
@@ -91,9 +90,6 @@ class BaseTestCase(unittest.TestCase):
                 self.env.container_id,
                 ['chown', owner, target]
             )
-        do_retries_boolean(docker.file_exists,
-                           container_id=self.env.container_id,
-                           file_path=target)
         return ret_val
 
     def copy_file_from_manager(self, source, target, owner=None):

--- a/tests/integration_tests/tests/utils.py
+++ b/tests/integration_tests/tests/utils.py
@@ -194,21 +194,6 @@ def do_retries(func,
             time.sleep(0.5)
 
 
-def do_retries_boolean(func, timeout_seconds=10, **kwargs):
-    deadline = time.time() + timeout_seconds
-    while True:
-        return_value = func(**kwargs)
-        if return_value:
-            break
-        else:
-            if time.time() > deadline:
-                raise RuntimeError(
-                    'function {0} did not return True in {1} seconds'
-                    .format(func.__name__, timeout_seconds)
-                )
-            time.sleep(0.5)
-
-
 def tar_blueprint(blueprint_path, dest_dir):
     """
     creates a tar archive out of a blueprint dir.


### PR DESCRIPTION
Showing the output of the manager bootup in the logs is going to make
it way easier to debug some jobs on jenkins (eg. the current aarch tests
failure)