### PR TITLE
RD-2873 Provide tasks graph ID with operations

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -2291,6 +2291,7 @@ class Operation(CreatedAtMixin, SQLResourceBase):
     agent_name = db.Column(db.Text)
 
     _tasks_graph_fk = foreign_key(TasksGraph._storage_id)
+    tasks_graph_id = association_proxy('tasks_graph', 'id')
 
     @declared_attr
     def tasks_graph(cls):

--- a/rest-service/manager_rest/test/endpoints/test_operations.py
+++ b/rest-service/manager_rest/test/endpoints/test_operations.py
@@ -226,6 +226,7 @@ class OperationsTestCase(OperationsTestBase, base_test.BaseServerTestCase):
         assert cm.value.status_code == 404
         op = self.client.operations.get('op1')
         assert op.id == 'op1'
+        assert op.task_graph_id == tg1.id
 
     def test_update_SendNodeEventTask(self):
         """When setting a SendNodeEventTask finished, an event is emitted"""

--- a/rest-service/manager_rest/test/endpoints/test_operations.py
+++ b/rest-service/manager_rest/test/endpoints/test_operations.py
@@ -226,7 +226,7 @@ class OperationsTestCase(OperationsTestBase, base_test.BaseServerTestCase):
         assert cm.value.status_code == 404
         op = self.client.operations.get('op1')
         assert op.id == 'op1'
-        assert op.task_graph_id == tg1.id
+        assert op.tasks_graph_id == tg1.id
 
     def test_update_SendNodeEventTask(self):
         """When setting a SendNodeEventTask finished, an event is emitted"""


### PR DESCRIPTION
Otherwise we can't restore operations to the appropriate tasks graph
without doing one list call per tasks graph (rather than per execution).