### PR TITLE
RD-2873 Accept blueprints as multipart/form

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -338,8 +338,10 @@ def _create_blueprint_labels(blueprint, provided_labels):
     labels_list = get_labels_from_plan(blueprint.plan,
                                        constants.BLUEPRINT_LABELS)
     if provided_labels:
-        labels_list.extend(tuple(label) for label in provided_labels if
-                           tuple(label) not in labels_list)
+        provided_labels = [(item['key'], item['value'])
+                           for item in provided_labels]
+        labels_list.extend(item for item in provided_labels
+                           if item not in labels_list)
     rm = get_resource_manager()
     rm.create_resource_labels(models.BlueprintLabel, blueprint, labels_list)
 

--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -127,11 +127,14 @@ class BlueprintsId(resources_v2.BlueprintsId):
             rest_utils.validate_visibility(
                 visibility, valid_values=VisibilityState.STATES)
 
+        unique_labels_check = []
         for label in labels:
             parsed_key, parsed_value = rest_utils.parse_label(label['key'],
                                                               label['value'])
             label['key'] = parsed_key
             label['value'] = parsed_value
+            unique_labels_check.append((parsed_key, parsed_value))
+        rest_utils.test_unique_labels(unique_labels_check)
 
         # Fail fast if trying to upload a duplicate blueprint.
         # Allow overriding an existing blueprint which failed to upload

--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -99,7 +99,7 @@ class BlueprintsId(resources_v2.BlueprintsId):
         async_upload = args.get('async_upload', False)
         created_at = args.get('created_at')
         created_by = args.get('created_by')
-        labels = args.get('labels')
+        labels = args.get('labels', [])
         visibility = args.get('visibility')
         private_resource = args.get('private_resource')
         application_file_name = args.get('application_file_name', '')
@@ -126,6 +126,12 @@ class BlueprintsId(resources_v2.BlueprintsId):
         if visibility:
             rest_utils.validate_visibility(
                 visibility, valid_values=VisibilityState.STATES)
+
+        for label in labels:
+            parsed_key, parsed_value = rest_utils.parse_label(label['key'],
+                                                              label['value'])
+            label['key'] = parsed_key
+            label['value'] = parsed_value
 
         # Fail fast if trying to upload a duplicate blueprint.
         # Allow overriding an existing blueprint which failed to upload

--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -123,7 +123,7 @@ class BlueprintsId(resources_v2.BlueprintsId):
             check_user_action_allowed('set_owner', None, True)
             created_by = rest_utils.valid_user(created_by)
 
-        if visibility:
+        if visibility is not None:
             rest_utils.validate_visibility(
                 visibility, valid_values=VisibilityState.STATES)
 

--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -112,9 +112,8 @@ class BlueprintsId(resources_v2.BlueprintsId):
                     'Transfer-Encoding' in request.headers or \
                     'blueprint_archive' in request.files:
                 raise BadParametersError(
-                    "Can pass {0} as only one of: URL via query parameters, "
-                    "request body, multi-form or "
-                    "chunked.".format(self._get_kind()))
+                    "Can pass blueprint as only one of: URL via query "
+                    "parameters, multi-form or chunked.")
 
         if created_at:
             check_user_action_allowed('set_timestamp', None, True)

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -281,12 +281,16 @@ def get_visibility_parameter(optional=False,
         })
         visibility = request_dict.get('visibility', None)
 
+    validate_visibility(visibility, valid_values)
+    return visibility
+
+
+def validate_visibility(visibility, valid_values):
     if visibility is not None and visibility not in valid_values:
         raise manager_exceptions.BadParametersError(
             "Invalid visibility: `{0}`. Valid visibility's values are: {1}"
             .format(visibility, valid_values)
         )
-    return visibility
 
 
 def parse_datetime_string(datetime_str):

--- a/rest-service/manager_rest/test/endpoints/test_blueprints.py
+++ b/rest-service/manager_rest/test/endpoints/test_blueprints.py
@@ -216,22 +216,6 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
         self.assertEqual('b1', blueprints[0].id)
         self.assertEqual('b0', blueprints[1].id)
 
-    def test_blueprint_upload_progress(self):
-        tmp_dir = '/tmp/tmp_upload_blueprint'
-        blueprint_path = self._create_big_blueprint('empty_blueprint.yaml',
-                                                    tmp_dir)
-
-        size = self.client.blueprints.calc_size(blueprint_path)
-
-        progress_func = generate_progress_func(total_size=size)
-
-        try:
-            self.client.blueprints.upload(blueprint_path, 'b',
-                                          progress_callback=progress_func,
-                                          async_upload=True)
-        finally:
-            self.quiet_delete_directory(tmp_dir)
-
     def test_blueprint_download_progress(self):
         tmp_dir = '/tmp/tmp_upload_blueprint'
         tmp_local_path = '/tmp/blueprint.bl'

--- a/rest-service/manager_rest/test/endpoints/test_utils.py
+++ b/rest-service/manager_rest/test/endpoints/test_utils.py
@@ -1,19 +1,3 @@
-#########
-# Copyright (c) 2016 GigaSpaces Technologies Ltd. All rights reserved
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  * See the License for the specific language governing permissions and
-#  * limitations under the License.
-
-
 def generate_progress_func(total_size, buffer_size=8192):
     """Generate a function that helps test upload/download progress
 
@@ -30,7 +14,7 @@ def generate_progress_func(total_size, buffer_size=8192):
         read_bytes, total_bytes = watcher.bytes_read, watcher.len
 
         i = iteration[0]
-        assert read_bytes == total_bytes
+        assert read_size == total_bytes
 
         expected_read_value = buffer_size * (i + 1)
         if i < max_iterations:

--- a/rest-service/manager_rest/test/endpoints/test_utils.py
+++ b/rest-service/manager_rest/test/endpoints/test_utils.py
@@ -10,11 +10,15 @@ def generate_progress_func(total_size, buffer_size=8192):
     iteration = [0]
     max_iterations = total_size // buffer_size
 
-    def print_progress(watcher):
-        read_bytes, total_bytes = watcher.bytes_read, watcher.len
+    def print_progress(*args):
+        if len(args) == 2:
+            read_bytes, total_bytes = args
+        else:
+            # This is a MultipartUploadEncoderMonitor
+            read_bytes, total_bytes = args[0].bytes_read, args[0].len
 
         i = iteration[0]
-        assert read_size == total_bytes
+        assert read_bytes == total_bytes
 
         expected_read_value = buffer_size * (i + 1)
         if i < max_iterations:

--- a/rest-service/manager_rest/test/endpoints/test_utils.py
+++ b/rest-service/manager_rest/test/endpoints/test_utils.py
@@ -1,6 +1,5 @@
 def generate_progress_func(total_size, buffer_size=8192):
     """Generate a function that helps test upload/download progress
-
     :param total_size: Total size of the file to upload/download
     :param buffer_size: Size of chunk
     :return: A function that receives 2 ints - number of bytes read so far,
@@ -10,15 +9,15 @@ def generate_progress_func(total_size, buffer_size=8192):
     iteration = [0]
     max_iterations = total_size // buffer_size
 
-    def print_progress(read_bytes, total_bytes):
+    def print_progress(read, total):
         i = iteration[0]
-        assert read_bytes == total_bytes
+        assert total == total_size
 
         expected_read_value = buffer_size * (i + 1)
         if i < max_iterations:
-            assert read_bytes == expected_read_value
+            assert read == expected_read_value
         else:
-            assert read_bytes == total_bytes
+            assert read == total_size
 
         iteration[0] += 1
 

--- a/rest-service/manager_rest/test/endpoints/test_utils.py
+++ b/rest-service/manager_rest/test/endpoints/test_utils.py
@@ -26,15 +26,17 @@ def generate_progress_func(total_size, buffer_size=8192):
     iteration = [0]
     max_iterations = total_size // buffer_size
 
-    def print_progress(read, total):
+    def print_progress(watcher):
+        read_bytes, total_bytes = watcher.bytes_read, watcher.len
+
         i = iteration[0]
-        assert total == total_size
+        assert read_bytes == total_bytes
 
         expected_read_value = buffer_size * (i + 1)
         if i < max_iterations:
-            assert read == expected_read_value
+            assert read_bytes == expected_read_value
         else:
-            assert read == total_size
+            assert read_bytes == total_bytes
 
         iteration[0] += 1
 

--- a/rest-service/manager_rest/test/endpoints/test_utils.py
+++ b/rest-service/manager_rest/test/endpoints/test_utils.py
@@ -10,13 +10,7 @@ def generate_progress_func(total_size, buffer_size=8192):
     iteration = [0]
     max_iterations = total_size // buffer_size
 
-    def print_progress(*args):
-        if len(args) == 2:
-            read_bytes, total_bytes = args
-        else:
-            # This is a MultipartUploadEncoderMonitor
-            read_bytes, total_bytes = args[0].bytes_read, args[0].len
-
+    def print_progress(read_bytes, total_bytes):
         i = iteration[0]
         assert read_bytes == total_bytes
 

--- a/rest-service/manager_rest/test/endpoints/test_utils.py
+++ b/rest-service/manager_rest/test/endpoints/test_utils.py
@@ -11,7 +11,9 @@ def generate_progress_func(total_size, buffer_size=8192):
 
     def print_progress(read, total):
         i = iteration[0]
-        assert total == total_size
+
+        # We need to allow larger, as multipart has some overhead
+        assert total >= total_size
 
         expected_read_value = buffer_size * (i + 1)
         if i < max_iterations:

--- a/rest-service/manager_rest/test/mocks.py
+++ b/rest-service/manager_rest/test/mocks.py
@@ -115,10 +115,14 @@ class MockHTTPClient(HTTPClient):
                             stream=open(body[entry][1].name, 'rb'))
 
                 # Remove application/json header to not override multipart
-                for header in headers:
-                    if headers[header] == 'application/json':
-                        break
-                headers.pop(header)
+                headers = {
+                    header: value
+                    for header, value in headers.items()
+                    if not (
+                        header.lower() == 'content-type'
+                        and value.lower() == 'application/json'
+                    )
+                }
 
             response = self.app.put(request_url,
                                     headers=headers,

--- a/rest-service/manager_rest/upload_manager.py
+++ b/rest-service/manager_rest/upload_manager.py
@@ -176,6 +176,9 @@ class UploadedDataManager(object):
             elif file_key == 'blueprint_archive':
                 self._save_bytes(request.files[file_key],
                                  archive_target_path)
+            elif file_key == 'snapshot_archive':
+                self._save_bytes(request.files[file_key],
+                                 archive_target_path)
         return inputs
 
     @staticmethod

--- a/rest-service/manager_rest/upload_manager.py
+++ b/rest-service/manager_rest/upload_manager.py
@@ -176,7 +176,7 @@ class UploadedDataManager(object):
             elif file_key == 'blueprint_archive':
                 self._save_bytes(request.files[file_key],
                                  archive_target_path)
-            elif file_key == 'snapshot_archive':
+            elif file_key == 'archive':
                 self._save_bytes(request.files[file_key],
                                  archive_target_path)
         return inputs

--- a/rest-service/manager_rest/upload_manager.py
+++ b/rest-service/manager_rest/upload_manager.py
@@ -176,9 +176,6 @@ class UploadedDataManager(object):
             elif file_key == 'blueprint_archive':
                 self._save_bytes(request.files[file_key],
                                  archive_target_path)
-            elif file_key == 'archive':
-                self._save_bytes(request.files[file_key],
-                                 archive_target_path)
         return inputs
 
     @staticmethod


### PR DESCRIPTION
This means we can stop messing around with dict encoding in query params.