### PR TITLE
RD-5988 Fix agent package renaming

### DIFF
--- a/packaging/agents/copy_packages.py
+++ b/packaging/agents/copy_packages.py
@@ -19,7 +19,7 @@ def splitext(filename):
 
 
 def normalize_agent_name(filename):
-    return filename.split("_", 1)[0].lower()
+    return filename.rpartition("_")[0].lower()
 
 
 def normalize_names(directory, target_dir):


### PR DESCRIPTION
The previous code turned e.g. `manylinux-x86_64-agent_7.0.0-.dev1.tar.gz` into `manylinux-x86.tar.gz`