### PR TITLE
Use correct python for agent packaging

### DIFF
--- a/packaging/cloudify-agents.spec
+++ b/packaging/cloudify-agents.spec
@@ -54,7 +54,7 @@ Cloudify Agent packages
 %install
 
 mkdir -p %{buildroot}%_agents_dir
-python ${RPM_SOURCE_DIR}/packaging/agents/copy_packages.py "${RPM_SOURCE_DIR}" "%{buildroot}%_agents_dir"
+python3 ${RPM_SOURCE_DIR}/packaging/agents/copy_packages.py "${RPM_SOURCE_DIR}" "%{buildroot}%_agents_dir"
 
 
 %pre


### PR DESCRIPTION
We only asked for python3 to be installed, not 'python' (2).