### PR TITLE
RD-6086 inte-tests follow_events: use the non-deprecated method

### DIFF
--- a/tests/integration_tests/resources/scripts/follow_events.py
+++ b/tests/integration_tests/resources/scripts/follow_events.py
@@ -79,7 +79,7 @@ def db_conn():
 
 
 def run_loop(conn):
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     loop.add_reader(conn, lambda: handle(conn))
     loop.run_forever()
 


### PR DESCRIPTION
as of 3.10, this is the new way. Could also maybe rewrite this script to be asyncio.run, but this is fine too.