### PR TITLE
RD-6073 Factor out creating the admin user to configure_manager

### DIFF
--- a/rest-service/manager_rest/configure_manager.py
+++ b/rest-service/manager_rest/configure_manager.py
@@ -4,18 +4,39 @@ import random
 import string
 import yaml
 
-from manager_rest import config
+from collections.abc import MutableMapping
+
+from flask_security.utils import hash_password
+
+from manager_rest import config, constants
+from manager_rest.storage import db, models, user_datastore
 from manager_rest.amqp_manager import AMQPManager
-from manager_rest.storage import storage_utils
 from manager_rest.flask_utils import setup_flask_app
 
 
-def _add_default_user_and_tenant(amqp_manager, script_config):
-    storage_utils.create_default_user_tenant_and_roles(
-        admin_username=script_config['admin_username'],
-        admin_password=script_config['admin_password'],
-        amqp_manager=amqp_manager
-    )
+def dict_merge(target, source):
+    """Merge source into target (like dict.update, but deep)
+
+    Returns the merged-into dict.
+    """
+    to_merge = [(target, source)]
+    while to_merge:
+        left, right = to_merge.pop()
+        overrides = {}
+        for k in left.keys() | right.keys():
+            if k not in right:
+                continue
+            original = left.get(k)
+            updated = right[k]
+            if (
+                isinstance(original, MutableMapping) and
+                isinstance(updated, MutableMapping)
+            ):
+                to_merge.append((original, updated))
+            else:
+                overrides[k] = updated
+        left.update(overrides)
+    return target
 
 
 def _generate_password(length=12):
@@ -25,40 +46,150 @@ def _generate_password(length=12):
     return password
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(
-        description='Create admin user in DB'
-    )
-    parser.add_argument(
-        '-c',
-        '--config_file_path',
-        help='Path to a config file containing info needed by this script',
-        required=False,
-        default=os.environ.get('CONFIG_FILE_PATH'),
-    )
-    args = parser.parse_args()
+def _get_admin_username(user_config):
+    try:
+        admin_username = user_config['manager']['security']['admin_username']
+    except KeyError:
+        admin_username = None
+    return admin_username or 'admin'
 
-    app = setup_flask_app()
-    config.instance.load_configuration()
-    user_config = yaml.safe_load(
-        open(args.config_file_path)
+
+def _get_admin_password(user_config):
+    try:
+        admin_password = user_config['manager']['security']['admin_password']
+    except KeyError:
+        admin_password = None
+    return admin_password
+
+
+def _update_admin_user(admin_user, user_config):
+    admin_password = _get_admin_password(user_config)
+    if admin_password:
+        admin_user.password = hash_password(admin_password)
+
+
+def _get_default_tenant():
+    default_tenant = models.Tenant.query.get(
+        constants.DEFAULT_TENANT_ID,
     )
+    return default_tenant
 
-    if not user_config['manager']['security']['admin_password']:
-        user_config['manager']['security']['admin_password'] = \
-            _generate_password()
 
-    user_credentials = {
-        'admin_username': user_config['manager']['security']['admin_username'],
-        'admin_password': user_config['manager']['security']['admin_password'],
-    }
-    amqp_manager = None
+def _create_default_tenant():
+    """Create the default tenant, and its resources in rabbitmq"""
+    default_tenant = models.Tenant(
+        id=constants.DEFAULT_TENANT_ID,
+        name=constants.DEFAULT_TENANT_NAME
+    )
+    db.session.add(default_tenant)
+
     if config.instance.amqp_management_host:
         amqp_manager = AMQPManager(
             host=config.instance.amqp_management_host,
             username=config.instance.amqp_username,
             password=config.instance.amqp_password,
-            cadata=config.instance.amqp_ca
+            cadata=config.instance.amqp_ca,
         )
+        amqp_manager.create_tenant_vhost_and_user(tenant=default_tenant)
 
-    _add_default_user_and_tenant(amqp_manager, user_credentials)
+    return default_tenant
+
+
+def _get_user_tenant_association(user, tenant):
+    user_tenant_association = models.UserTenantAssoc.query.filter_by(
+        user=user,
+        tenant=tenant,
+    ).first()
+    return user_tenant_association
+
+
+def _create_admin_user(user_config):
+    """Create the admin user based on the passed-in config
+
+    The admin user will have the username&password from the config,
+    or use defaults if not provided.
+    """
+    admin_username = _get_admin_username(user_config)
+    admin_password = _get_admin_password(user_config) or _generate_password()
+
+    admin_role = models.Role.query.filter_by(name='sys_admin').one()
+    admin_user = user_datastore.create_user(
+        id=constants.BOOTSTRAP_ADMIN_ID,
+        username=admin_username,
+        password=hash_password(admin_password),
+        roles=[admin_role]
+    )
+
+    print('####################################')
+    print(f'USERNAME: {admin_username}')
+    print(f'PASSWORD: {admin_password}')
+    print('####################################')
+    return admin_user
+
+
+def _setup_user_tenant_assoc(admin_user, default_tenant):
+    user_tenant_association = _get_user_tenant_association(
+        admin_user,
+        default_tenant,
+    )
+
+    if not user_tenant_association:
+        user_role = user_datastore.find_role(constants.DEFAULT_TENANT_ROLE)
+
+        user_tenant_association = models.UserTenantAssoc(
+            user=admin_user,
+            tenant=default_tenant,
+            role=user_role,
+        )
+        db.session.add(user_tenant_association)
+
+
+def configure(user_config):
+    """Configure the manager based on the provided config"""
+    default_tenant = _get_default_tenant()
+    need_assoc = False
+    if not default_tenant:
+        need_assoc = True
+        default_tenant = _create_default_tenant()
+
+    admin_user = user_datastore.get_user(constants.BOOTSTRAP_ADMIN_ID)
+    if admin_user:
+        _update_admin_user(admin_user, user_config)
+    else:
+        admin_user = _create_admin_user(user_config)
+        need_assoc = True
+
+    if need_assoc:
+        _setup_user_tenant_assoc(admin_user, default_tenant)
+
+    db.session.commit()
+
+
+def _load_user_config(paths):
+    """Load and merge the config files provided by paths"""
+    user_config = {}
+    for config_path in paths:
+        if not config_path:
+            continue
+        with open(config_path) as f:
+            config_source = yaml.safe_load(f)
+        dict_merge(user_config, config_source)
+    return user_config
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Create admin user in DB')
+    parser.add_argument(
+        '-c',
+        '--config-file-path',
+        help='Path to a config file containing info needed by this script',
+        action='append',
+        required=False,
+        default=[os.environ.get('CONFIG_FILE_PATH')],
+    )
+    args = parser.parse_args()
+
+    with setup_flask_app().app_context():
+        config.instance.load_configuration()
+        user_config = _load_user_config(args.config_file_path)
+        configure(user_config)

--- a/rest-service/manager_rest/storage/storage_utils.py
+++ b/rest-service/manager_rest/storage/storage_utils.py
@@ -13,15 +13,9 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-from flask_security.utils import hash_password
-
-from manager_rest import constants
 from manager_rest.storage.models import Node
-from manager_rest.storage import user_datastore, db, get_storage_manager
+from manager_rest.storage import db, get_storage_manager
 from manager_rest.manager_exceptions import NotFoundError
-from manager_rest.storage.management_models import (
-    Tenant, UserTenantAssoc, Role
-)
 
 
 def get_node(deployment_id, node_id):
@@ -37,119 +31,6 @@ def get_node(deployment_id, node_id):
             'was not found'.format(node_id, deployment_id)
         )
     return nodes[0]
-
-
-def create_default_user_tenant_and_roles(admin_username,
-                                         admin_password,
-                                         amqp_manager,
-                                         password_hash=None):
-    """
-    Create the bootstrap admin, the default tenant and the security roles,
-    as well as a RabbitMQ vhost and user corresponding to the default tenant
-
-    :return: The default tenant
-    """
-    sm = get_storage_manager()
-    admin_role = sm.get(Role, None, filters={'name': 'sys_admin'})
-    default_tenant = _get_default_tenant() or _create_default_tenant()
-
-    if amqp_manager:
-        amqp_manager.create_tenant_vhost_and_user(tenant=default_tenant)
-
-    admin_user = user_datastore.get_user(constants.BOOTSTRAP_ADMIN_ID)
-
-    if admin_user:
-        admin_user.password = password_hash or hash_password(admin_password)
-        db.session.commit()
-    else:
-        admin_user = user_datastore.create_user(
-            id=constants.BOOTSTRAP_ADMIN_ID,
-            username=admin_username,
-            password=password_hash or hash_password(admin_password),
-            roles=[admin_role]
-        )
-
-    print('####################################')
-    print(f'USERNAME: {admin_username}')
-    print(f'PASSWORD: {admin_password}')
-    print('####################################')
-
-    # The admin user is assigned to the default tenant.
-    # This is the default role when a user is added to a tenant.
-    # Anyway, `sys_admin` will be the effective role since is the system role.
-    user_tenant_association = _get_user_tenant_association(
-        admin_user,
-        default_tenant,
-    )
-
-    if not user_tenant_association:
-        user_role = user_datastore.find_role(constants.DEFAULT_TENANT_ROLE)
-
-        user_tenant_association = UserTenantAssoc(
-            user=admin_user,
-            tenant=default_tenant,
-            role=user_role,
-        )
-
-    admin_user.tenant_associations.append(user_tenant_association)
-    user_datastore.commit()
-    return default_tenant
-
-
-def create_status_reporter_user_and_assign_role(username,
-                                                password,
-                                                role,
-                                                user_id):
-    """Creates a user and assigns its given role.
-    """
-    user = user_datastore.create_user(
-        username=username,
-        password=hash_password(password),
-        roles=[role],
-        id=user_id
-    )
-
-    default_tenant = Tenant.query.filter_by(
-        id=constants.DEFAULT_TENANT_ID).first()
-    reporter_role = user_datastore.find_role(role)
-    if not reporter_role:
-        raise NotFoundError("The username \"{0}\" cannot have the role \"{1}\""
-                            " as the role doesn't exist"
-                            "".format(username, role))
-    user_tenant_association = UserTenantAssoc(
-        user=user,
-        tenant=default_tenant,
-        role=reporter_role,
-    )
-    user.tenant_associations.append(user_tenant_association)
-    user_datastore.commit()
-    return user
-
-
-def _get_user_tenant_association(user, tenant):
-    user_tenant_association = UserTenantAssoc.query.filter_by(
-        user=user,
-        tenant=tenant,
-    ).first()
-
-    return user_tenant_association
-
-
-def _get_default_tenant():
-    default_tenant = Tenant.query.get(
-        constants.DEFAULT_TENANT_ID,
-    )
-
-    return default_tenant
-
-
-def _create_default_tenant():
-    default_tenant = Tenant(
-        id=constants.DEFAULT_TENANT_ID,
-        name=constants.DEFAULT_TENANT_NAME
-    )
-    db.session.add(default_tenant)
-    return default_tenant
 
 
 def try_acquire_lock_on_table(lock_number):

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -307,16 +307,11 @@ class BaseServerTestCase(unittest.TestCase):
             password='admin',
             roles=['sys_admin'],
         )
-        rabbitmq_password = \
-            'gAAAAABb9p7U_Lnlmg7vyijjoxovyg215ThYi-VCTCzVYa1p-vpzi31WGko' \
-            'KD_hK1mQyKgjRss_Nz-3m-cgHpZChnVT4bxZIjnOnL6sF8RtozvlRoGHtnF' \
-            'G6jxqQDeEf5Heos0ia4Q5H  '
         self.tenant = models.Tenant(
             id=constants.DEFAULT_TENANT_ID,
             name=constants.DEFAULT_TENANT_NAME,
             rabbitmq_username='rabbitmq_username_default_tenant',
             rabbitmq_vhost='rabbitmq_vhost_defualt_tenant',
-            rabbitmq_password=rabbitmq_password,
         )
 
         self.user.tenant_associations.append(models.UserTenantAssoc(

--- a/rest-service/manager_rest/test/infrastructure/test_configure_manager.py
+++ b/rest-service/manager_rest/test/infrastructure/test_configure_manager.py
@@ -1,0 +1,78 @@
+from manager_rest.configure_manager import (
+    configure,
+    dict_merge,
+    _load_user_config,
+)
+from manager_rest.storage import db, models
+from manager_rest.test import base_test
+
+
+def test_dict_merge():
+    assert dict_merge({}, {}) == {}
+    assert dict_merge({}, {1: 2}) == {1: 2}
+    assert dict_merge({1: 2}, {}) == {1: 2}
+    assert dict_merge({1: 2}, {3: 4}) == {1: 2, 3: 4}
+    assert dict_merge({1: 2}, {1: 3}) == {1: 3}
+    assert dict_merge({1: {2: 3}}, {1: {3: 4}}) == {1: {2: 3, 3: 4}}
+    assert dict_merge({1: {2: 3}}, {1: {2: 4}}) == {1: {2: 4}}
+    assert dict_merge({1: {2: {3: 4}}}, {1: {2: {3: 5}}}) == {1: {2: {3: 5}}}
+
+
+def test_load_user_config(tmpdir):
+    conf1 = tmpdir / 'conf1.yaml'
+    conf2 = tmpdir / 'conf2.yaml'
+    conf1.write_text('a: 1\nb: 2', encoding='utf-8')
+    conf2.write_text('a: 1\nb: 3', encoding='utf-8')
+    loaded = _load_user_config([
+        str(conf1),
+        str(conf2),
+        None,
+    ])
+    assert loaded == {
+        'a': 1,
+        'b': 3,
+    }
+
+
+class TestConfigureManager(base_test.BaseServerTestCase):
+    def test_create_admin(self):
+        # delete the admin user first
+        db.session.delete(self.user)
+        assert models.User.query.count() == 0
+        # empty config, so the username & password will be defaulted
+        configure({})
+        assert models.User.query.count() == 1
+
+    def test_create_admin_username(self):
+        db.session.delete(self.user)
+        assert models.User.query.count() == 0
+        configure({
+            'manager': {
+                'security': {
+                    'admin_username': 'admin2',
+                }
+            }
+        })
+        assert models.User.query.count() == 1
+        models.User.query.filter_by(username='admin2').one()  # doesn't throw
+
+    def test_update_admin_password(self):
+        assert models.User.query.count() == 1
+        original_password = models.User.query.first().password
+
+        configure({
+            'manager': {
+                'security': {
+                    'admin_password': 'abcdefgh',
+                }
+            }
+        })
+        assert original_password != models.User.query.first().password
+
+    def test_create_default_tenant(self):
+        db.session.delete(self.tenant)
+        assert self.user.tenant_associations == []
+
+        configure({})
+        assert models.Tenant.query.count() == 1
+        assert len(self.user.tenant_associations) == 1

--- a/rest-service/manager_rest/test/security_utils.py
+++ b/rest-service/manager_rest/test/security_utils.py
@@ -15,15 +15,6 @@
 
 from flask_security.utils import hash_password
 
-from cloudify.cluster_status import (
-    DB_STATUS_REPORTER,
-    BROKER_STATUS_REPORTER,
-    MANAGER_STATUS_REPORTER,
-    MANAGER_STATUS_REPORTER_ID,
-    BROKER_STATUS_REPORTER_ID,
-    DB_STATUS_REPORTER_ID
-)
-
 from manager_rest.storage.models import Tenant, UserTenantAssoc
 from manager_rest.storage import user_datastore
 from manager_rest.constants import (
@@ -42,29 +33,6 @@ def get_admin_user():
         'password': 'admin',
         'role': ADMIN_ROLE
     }
-
-
-def get_status_reporters():
-    return [
-        {
-            'username': MANAGER_STATUS_REPORTER,
-            'password': 'password',
-            'role': MANAGER_STATUS_REPORTER,
-            'id': MANAGER_STATUS_REPORTER_ID
-        },
-        {
-            'username': BROKER_STATUS_REPORTER,
-            'password': 'password',
-            'role': BROKER_STATUS_REPORTER,
-            'id': BROKER_STATUS_REPORTER_ID
-        },
-        {
-            'username': DB_STATUS_REPORTER,
-            'password': 'password',
-            'role': DB_STATUS_REPORTER,
-            'id': DB_STATUS_REPORTER_ID
-        },
-    ]
 
 
 def get_test_users():


### PR DESCRIPTION
The original reason for this was that we used to use `create_default_user_tenant_and_roles` in only a few places, and one of them was tests. And that meant we printed out the username&password A LOT of times when running the tests.

Well, there's not that many places that use this function. Turns out we don't need it at all.

Instead:
 - configure_manager will be the main place that creates (or updates) the user during installation/setup
 - base_test will have its own short way of creating the user. It was mocking out the big thing (rabbitmq) anyway
 - reset_storage.py (inte-tests) will just... not remove the admin user. It'll remove other users instead. That'll make the reset script way faster (no rabbitmq interaction needed), but it does mean inte-tests must not change the admin user's password (which they don't do right now anyway)

Additionally:
 - we now support passing multiple config files (to mirror what `cfy_manager` does)
 - there's a bunch of tests
 - drop some unused bullshit from tests (status reporter users)


As usual, I do recommend viewing the commits separately.