### PR TITLE
RD-6131 More fixes in blueprint validation

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -386,11 +386,13 @@ class BlueprintsIdValidate(BlueprintsId):
             rest_utils.validate_visibility(
                 visibility, valid_values=VisibilityState.STATES)
         application_file_name = args.pop('application_file_name', '')
+        blueprint_archive_url = args.pop('blueprint_archive_url', None)
 
         return UploadedBlueprintsValidator().\
             receive_uploaded_data(data_id=blueprint_id,
                                   visibility=visibility,
-                                  application_file_name=application_file_name)
+                                  application_file_name=application_file_name,
+                                  blueprint_url=blueprint_archive_url)
 
 
 class BlueprintsIdArchive(resources_v1.BlueprintsIdArchive):


### PR DESCRIPTION
... because we also support `blueprint_archive_url`