### PR TITLE
RD-6131 Let's use connect timeout = read timeout

### DIFF
--- a/mgmtworker/cloudify_system_workflows/dsl_import_resolver/resolver_with_catalog_support.py
+++ b/mgmtworker/cloudify_system_workflows/dsl_import_resolver/resolver_with_catalog_support.py
@@ -160,7 +160,7 @@ class ResolverWithCatalogSupport(DefaultImportResolver):
 
     @staticmethod
     def _download_file(url, dest_path, target_filename=None):
-        with requests.get(url, stream=True, timeout=(5, None)) as resp:
+        with requests.get(url, stream=True, timeout=10.0) as resp:
             resp.raise_for_status()
             if not target_filename:
                 target_filename = os.path.basename(url)


### PR DESCRIPTION
... when fetching objects with `requests.get`.  Otherwise, because of some urllib3 "feature" we're getting slightly misleading error messages: `Read timed out. (read timeout=5)` while the process really times out on connection (not read).