### PR TITLE
RD-6131 Remove users_roles rows on user/role delete

### DIFF
--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -316,7 +316,9 @@ class User(SQLModelBase, UserMixin):
 
     @declared_attr
     def roles(cls):
-        return many_to_many_relationship(cls, Role, primary_key_tuple=True)
+        return many_to_many_relationship(cls, Role,
+                                         primary_key_tuple=True,
+                                         ondelete='CASCADE')
 
     def has_role_in(self, tenant, list_of_roles):
         user_roles = self.roles_in_tenant(tenant)


### PR DESCRIPTION
Before that patch (some of) the tests failed with the following error messages:
```
12:14:14 [INFO] [Flask Utils] Resetting PostgreSQL DB
14:14:21  Traceback (most recent call last):
14:14:21    File "/opt/manager/env/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1900, in _execute_context
14:14:21      self.dialect.do_execute(
14:14:21    File "/opt/manager/env/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 732, in do_execute
14:14:21      cursor.execute(statement, parameters)
14:14:21  psycopg2.errors.ForeignKeyViolation: update or delete on table "users" violates foreign key constraint "users_roles_user_id_fkey" on table "users_roles"
14:14:21  DETAIL:  Key (id)=(1) is still referenced from table "users_roles".
```