### PR TITLE
snapshot_utils: rewrite migrate_pickle_to_json

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/edd6d829a209_6_4_to_7_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/edd6d829a209_6_4_to_7_0.py
@@ -227,7 +227,7 @@ def add_json_columns():
     op.add_column('plugins',
                   sa.Column('supported_py_versions', JSONString()))
     op.add_column('plugins',
-                  sa.Column('wheels', JSONString(), nullable=False))
+                  sa.Column('wheels', JSONString()))
 
     op.add_column('plugins_updates',
                   sa.Column('deployments_to_update', JSONString()))

--- a/rest-service/manager_rest/snapshot_utils.py
+++ b/rest-service/manager_rest/snapshot_utils.py
@@ -4,6 +4,9 @@ Functions that are called from snapshot-(usually restore), which are always
 ran from the restservice virtualenv, put here for easy testing.
 """
 
+import functools
+import operator
+
 from typing import Dict, List
 
 from cloudify.models_states import DeploymentState
@@ -127,240 +130,79 @@ def populate_deployment_statuses():
     _set_deployment_status()
 
 
-def _migrate_blueprints_table(session: Session, batch_size: int):
-    stmt = select(models.Blueprint).where(
-        (models.Blueprint.plan_p.isnot(None)) &
-        (models.Blueprint.plan == sql_text("'null'"))
-    ).limit(batch_size).with_for_update()
+pickle_migrations = {
+    models.Deployment: [
+        'capabilities', 'groups', 'inputs', 'outputs', 'policy_triggers',
+        'policy_types', 'scaling_groups', 'workflows',
+    ],
+    models.Blueprint: ['plan'],
+    models.DeploymentModification: [
+        'context', 'modified_nodes', 'node_instances',
+    ],
+    models.DeploymentUpdate: [
+        'deployment_plan', 'deployment_update_node_instances',
+        'deployment_update_deployment', 'central_plugins_to_uninstall',
+        'central_plugins_to_install', 'deployment_update_nodes',
+        'modified_entity_ids', 'old_inputs', 'new_inputs',
+    ],
+    models.Execution: ['parameters'],
+    models.Node: [
+        'plugins', 'plugins_to_install', 'properties', 'relationships',
+        'operations', 'type_hierarchy',
+    ],
+    models.NodeInstance: [
+        'relationships', 'runtime_properties', 'scaling_groups',
+    ],
+    models.Plugin: [
+        'excluded_wheels', 'supported_platform', 'supported_py_versions',
+        'wheels',
+    ],
+    models.PluginsUpdate: ['deployments_to_update'],
+}
+
+
+def _column_migrate_condition(model_cls, attr):
+    """The SQL condition to check if the column needs to be migrated"""
+    pickle_column = getattr(model_cls, f'{attr}_p')
+    json_column = getattr(model_cls, attr)
+    pickle_not_empty = pickle_column.isnot(None)
+
+    # We consider the json column empty in both the case of a SQL null,
+    # and the JSON null.
+    # The value will be a SQL null when the row is inserted directly via
+    # SQL (eg. in snapshot-restore), and it will be a JSON null when
+    # inserted using the ORM.
+    # note: db.JSON.NULL doesn't work here, but I don't know why.
+    json_empty = json_column.is_(None) | (json_column == sql_text("'null'"))
+
+    return pickle_not_empty & json_empty
+
+
+def migrate_model(session: Session, model_cls, attributes, batch_size: int):
+    any_column_needs_migrating = functools.reduce(
+        operator.or_,
+        (_column_migrate_condition(model_cls, attr) for attr in attributes)
+    )
+    stmt = (
+        select(model_cls)
+        .where(any_column_needs_migrating)
+        .limit(batch_size)
+        .with_for_update()
+    )
 
     while True:
         results = session.execute(stmt).scalars().all()
-        for bp in results:
-            bp.plan = bp.plan_p
-            session.add(bp)
-        session.flush()
+        for inst in results:
+            if isinstance(inst, models.Execution):
+                inst.allow_custom_parameters = True
+            for attr in attributes:
+                # only set the attribute if it's not already set
+                pickle_attr = getattr(inst, f'{attr}_p')
+                json_attr = getattr(inst, attr)
+                if pickle_attr and not json_attr:
+                    setattr(inst, attr, pickle_attr)
 
-        if len(results) < batch_size:
-            break
-
-
-def _migrate_deployments_table(session: Session, batch_size: int):
-    stmt = select(models.Deployment).where(
-        ((models.Deployment.capabilities_p.isnot(None)) &
-         (models.Deployment.capabilities == sql_text("'null'"))) |
-        ((models.Deployment.groups_p.isnot(None)) &
-         (models.Deployment.groups == sql_text("'null'"))) |
-        ((models.Deployment.inputs_p.isnot(None)) &
-         (models.Deployment.inputs == sql_text("'null'"))) |
-        ((models.Deployment.outputs_p.isnot(None)) &
-         (models.Deployment.outputs == sql_text("'null'"))) |
-        ((models.Deployment.policy_triggers_p.isnot(None)) &
-         (models.Deployment.policy_triggers == sql_text("'null'"))) |
-        ((models.Deployment.policy_types_p.isnot(None)) &
-         (models.Deployment.policy_types == sql_text("'null'"))) |
-        ((models.Deployment.scaling_groups_p.isnot(None)) &
-         (models.Deployment.scaling_groups == sql_text("'null'"))) |
-        ((models.Deployment.workflows_p.isnot(None)) &
-         (models.Deployment.workflows == sql_text("'null'")))
-    ).limit(batch_size).with_for_update()
-
-    while True:
-        results = session.execute(stmt).scalars().all()
-        for dep in results:
-            dep.capabilities = dep.capabilities_p
-            dep.groups = dep.groups_p
-            dep.inputs = dep.inputs_p
-            dep.outputs = dep.outputs_p
-            dep.policy_triggers = dep.policy_triggers_p
-            dep.policy_types = dep.policy_types_p
-            dep.scaling_groups = dep.scaling_groups_p
-            dep.workflows = dep.workflows_p
-            session.add(dep)
-        session.flush()
-
-        if len(results) < batch_size:
-            break
-
-
-def _migrate_deployment_modifications_table(session: Session, batch_size: int):
-    model = models.DeploymentModification
-    stmt = select(model).where(
-        ((model.context_p.isnot(None)) &
-         (model.context == sql_text("'null'"))) |
-        ((model.modified_nodes_p.isnot(None)) &
-         (model.modified_nodes == sql_text("'null'"))) |
-        ((model.node_instances_p.isnot(None)) &
-         (model.node_instances == sql_text("'null'")))
-    ).limit(batch_size).with_for_update()
-
-    while True:
-        results = session.execute(stmt).scalars().all()
-        for dep_mod in results:
-            dep_mod.context = dep_mod.context_p
-            dep_mod.modified_nodes = dep_mod.modified_nodes_p
-            dep_mod.node_instances = dep_mod.node_instances_p
-            session.add(dep_mod)
-        session.flush()
-
-        if len(results) < batch_size:
-            break
-
-
-def _migrate_deployment_updates_table(session: Session, batch_size: int):
-    model = models.DeploymentUpdate
-    stmt = select(model).where(
-        ((model.deployment_plan_p.isnot(None)) &
-         (model.deployment_plan == sql_text("'null'"))) |
-        ((model.deployment_update_node_instances_p.isnot(None)) &
-         (model.deployment_update_node_instances == sql_text("'null'"))) |
-        ((model.deployment_update_deployment_p.isnot(None)) &
-         (model.deployment_update_deployment == sql_text("'null'"))) |
-        ((model.central_plugins_to_uninstall_p.isnot(None)) &
-         (model.central_plugins_to_uninstall == sql_text("'null'"))) |
-        ((model.central_plugins_to_install_p.isnot(None)) &
-         (model.central_plugins_to_install == sql_text("'null'"))) |
-        ((model.deployment_update_nodes_p.isnot(None)) &
-         (model.deployment_update_nodes == sql_text("'null'"))) |
-        ((model.modified_entity_ids_p.isnot(None)) &
-         (model.modified_entity_ids == sql_text("'null'"))) |
-        ((model.old_inputs_p.isnot(None)) &
-         (model.old_inputs == sql_text("'null'"))) |
-        ((model.new_inputs_p.isnot(None)) &
-         (model.new_inputs == sql_text("'null'")))
-    ).limit(batch_size).with_for_update()
-
-    while True:
-        results = session.execute(stmt).scalars().all()
-        for dep_upd in results:
-            dep_upd.deployment_plan = dep_upd.deployment_plan_p
-            dep_upd.deployment_update_node_instances =\
-                dep_upd.deployment_update_node_instances_p
-            dep_upd.deployment_update_deployment =\
-                dep_upd.deployment_update_deployment_p
-            dep_upd.central_plugins_to_uninstall =\
-                dep_upd.central_plugins_to_uninstall_p
-            dep_upd.central_plugins_to_install =\
-                dep_upd.central_plugins_to_install_p
-            dep_upd.deployment_update_nodes = dep_upd.deployment_update_nodes_p
-            dep_upd.modified_entity_ids = dep_upd.modified_entity_ids_p
-            dep_upd.old_inputs = dep_upd.old_inputs_p
-            dep_upd.new_inputs = dep_upd.new_inputs_p
-            session.add(dep_upd)
-        session.flush()
-
-        if len(results) < batch_size:
-            break
-
-
-def _migrate_executions_table(session: Session, batch_size: int):
-    stmt = select(models.Execution).where(
-        (models.Execution.parameters_p.isnot(None)) &
-        (models.Execution.parameters == sql_text("'null'"))
-    ).limit(batch_size).with_for_update()
-
-    while True:
-        results = session.execute(stmt).scalars().all()
-        for execution in results:
-            execution.parameters = execution.parameters_p
-            session.add(execution)
-        session.flush()
-
-        if len(results) < batch_size:
-            break
-
-
-def _migrate_nodes_table(session: Session, batch_size: int):
-    stmt = select(models.Node).where(
-        ((models.Node.plugins_p.isnot(None)) &
-         (models.Node.plugins == sql_text("'null'"))) |
-        ((models.Node.plugins_to_install_p.isnot(None)) &
-         (models.Node.plugins_to_install == sql_text("'null'"))) |
-        ((models.Node.properties_p.isnot(None)) &
-         (models.Node.properties == sql_text("'null'"))) |
-        ((models.Node.relationships_p.isnot(None)) &
-         (models.Node.relationships == sql_text("'null'"))) |
-        ((models.Node.operations_p.isnot(None)) &
-         (models.Node.operations == sql_text("'null'"))) |
-        ((models.Node.type_hierarchy_p.isnot(None)) &
-         (models.Node.type_hierarchy == sql_text("'null'")))
-    ).limit(batch_size).with_for_update()
-
-    while True:
-        results = session.execute(stmt).scalars().all()
-        for node in results:
-            node.plugins = node.plugins_p
-            node.plugins_to_install = node.plugins_to_install_p
-            node.properties = node.properties_p
-            node.relationships = node.relationships_p
-            node.operations = node.operations_p
-            node.type_hierarchy = node.type_hierarchy_p
-            session.add(node)
-        session.flush()
-
-        if len(results) < batch_size:
-            break
-
-
-def _migrate_node_instances_table(session: Session, batch_size: int):
-    stmt = select(models.NodeInstance).where(
-        ((models.NodeInstance.relationships_p.isnot(None)) &
-         (models.NodeInstance.relationships == sql_text("'null'"))) |
-        ((models.NodeInstance.runtime_properties_p.isnot(None)) &
-         (models.NodeInstance.runtime_properties == sql_text("'null'"))) |
-        ((models.NodeInstance.scaling_groups_p.isnot(None)) &
-         (models.NodeInstance.scaling_groups == sql_text("'null'")))
-    ).limit(batch_size).with_for_update()
-
-    while True:
-        results = session.execute(stmt).scalars().all()
-        for ni in results:
-            ni.relationships = ni.relationships_p
-            ni.runtime_properties = ni.runtime_properties_p
-            ni.scaling_groups = ni.scaling_groups_p
-            session.add(ni)
-        session.flush()
-
-        if len(results) < batch_size:
-            break
-
-
-def _migrate_plugins_table(session: Session, batch_size: int):
-    stmt = select(models.Plugin).where(
-        ((models.Plugin.excluded_wheels_p.isnot(None)) &
-         (models.Plugin.excluded_wheels == sql_text("'null'"))) |
-        ((models.Plugin.supported_platform_p.isnot(None)) &
-         (models.Plugin.supported_platform == sql_text("'null'"))) |
-        ((models.Plugin.supported_py_versions_p.isnot(None)) &
-         (models.Plugin.supported_py_versions == sql_text("'null'"))) |
-        ((models.Plugin.wheels_p.isnot(None)) &
-         (models.Plugin.wheels == sql_text("'null'")))
-    ).limit(batch_size).with_for_update()
-
-    while True:
-        results = session.execute(stmt).scalars().all()
-        for plugin in results:
-            plugin.excluded_wheels = plugin.excluded_wheels_p
-            plugin.supported_platform = plugin.supported_platform_p
-            plugin.supported_py_versions = plugin.supported_py_versions_p
-            plugin.wheels = plugin.wheels_p
-            session.add(plugin)
-        session.flush()
-
-        if len(results) < batch_size:
-            break
-
-
-def _migrate_plugins_updates_table(session: Session, batch_size: int):
-    stmt = select(models.PluginsUpdate).where(
-        (models.PluginsUpdate.deployments_to_update_p.isnot(None)) &
-        (models.PluginsUpdate.deployments_to_update == sql_text("'null'"))
-    ).limit(batch_size).with_for_update()
-
-    while True:
-        results = session.execute(stmt).scalars().all()
-        for plug_upd in results:
-            plug_upd.deployments_to_update = plug_upd.deployments_to_update_p
-            session.add(plug_upd)
+            session.add(inst)
         session.flush()
 
         if len(results) < batch_size:
@@ -369,12 +211,5 @@ def _migrate_plugins_updates_table(session: Session, batch_size: int):
 
 def migrate_pickle_to_json(batch_size=PICKLE_TO_JSON_MIGRATION_BATCH_SIZE):
     """Migrate the fields which were pickled to their JSON counterparts"""
-    _migrate_blueprints_table(db.session, batch_size)
-    _migrate_deployments_table(db.session, batch_size)
-    _migrate_deployment_modifications_table(db.session, batch_size)
-    _migrate_deployment_updates_table(db.session, batch_size)
-    _migrate_executions_table(db.session, batch_size)
-    _migrate_nodes_table(db.session, batch_size)
-    _migrate_node_instances_table(db.session, batch_size)
-    _migrate_plugins_table(db.session, batch_size)
-    _migrate_plugins_updates_table(db.session, batch_size)
+    for model, attributes in pickle_migrations.items():
+        migrate_model(db.session, model, attributes, batch_size)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -194,7 +194,7 @@ class Plugin(SQLResourceBase):
     supported_py_versions = db.Column(JSONString)
     uploaded_at = db.Column(UTCDateTime, nullable=False, index=True)
     wheels_p = db.Column(db.PickleType(protocol=2))
-    wheels = db.Column(JSONString, nullable=False)
+    wheels = db.Column(JSONString)
     title = db.Column(db.Text)
     blueprint_labels = db.Column(JSONString)
     labels = db.Column(JSONString)


### PR DESCRIPTION
Rewrite using a loop rather than writing everything out.

Anyway, the real point of this change, is the `json_empty` check: it's not always a json "'null'", because in case of inserting the models directly via sql (eg. in snapshot-restore), it'll be just a SQL null...