### PR TITLE
RD-6091 Intrinsic functions in workflow parameters

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1083,7 +1083,7 @@ def evaluate_workflow_parameters(deployment_id: str, parameters: dict):
     from manager_rest.dsl_functions import evaluate_intrinsic_functions
 
     to_evaluate = {k: v for k, v in parameters.items()
-                   if isinstance(v, dict)}
+                   if isinstance(v, (list, dict))}
     evaluated = evaluate_intrinsic_functions(to_evaluate, deployment_id)
     parameters.update(evaluated)
 

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -673,6 +673,34 @@ class ExecutionsTestCase(BaseServerTestCase):
         self.client.executions.delete(to_datetime=datetime.utcnow())
         assert len(self.client.executions.list()) == 1   # skip ep.env.create
 
+    def test_intrinsic_fn_execution_parameters(self):
+        sm_mock = mock.patch(
+            'manager_rest.dsl_functions.get_storage_manager',
+            return_value=self.sm
+        )
+        with sm_mock, self.sm.transaction():
+            bp = models.Blueprint(
+                id='bp',
+                creator=self.user,
+                tenant=self.tenant
+            )
+            dep = models.Deployment(
+                id='dep',
+                blueprint=bp,
+                scaling_groups={},
+                workflows={'test': {'parameters': {'x': {}}}},
+                inputs={'inp1': 'foobar'},
+                creator=self.user,
+                tenant=self.tenant,
+            )
+            db.session.flush()
+            exc = models.Execution(
+                parameters={'x': {'get_input': 'inp1'}},
+                deployment=dep,
+                workflow_id='test',
+            )
+        assert exc.parameters['x'] == 'foobar'
+
     def _create_execution_and_update_token(self, deployment_id, token):
         self.put_deployment(deployment_id, blueprint_id=deployment_id)
         execution = self.client.executions.start(deployment_id, 'install')

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -1098,7 +1098,9 @@ class ExecutionQueueingTests(BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        create_dep_env = dep.make_create_environment_execution()
+        with mock.patch('manager_rest.dsl_functions.get_storage_manager',
+                        return_value=self.sm):
+            create_dep_env = dep.make_create_environment_execution()
         exc = models.Execution(
             workflow_id='workflow1',
             parameters={
@@ -1118,8 +1120,10 @@ class ExecutionQueueingTests(BaseServerTestCase):
             }
         }
 
-        self.rm.update_execution_status(
-            create_dep_env.id, ExecutionState.TERMINATED, None)
+        with mock.patch('manager_rest.dsl_functions.get_storage_manager',
+                        return_value=self.sm):
+            self.rm.update_execution_status(
+                create_dep_env.id, ExecutionState.TERMINATED, None)
 
         assert not exc.error
         assert exc.status == ExecutionState.PENDING
@@ -1139,7 +1143,9 @@ class ExecutionQueueingTests(BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        create_dep_env = dep.make_create_environment_execution()
+        with mock.patch('manager_rest.dsl_functions.get_storage_manager',
+                        return_value=self.sm):
+            create_dep_env = dep.make_create_environment_execution()
         exc = models.Execution(
             workflow_id='nonexistent1',
             parameters={
@@ -1150,9 +1156,10 @@ class ExecutionQueueingTests(BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-
-        self.rm.update_execution_status(
-            create_dep_env.id, ExecutionState.TERMINATED, None)
+        with mock.patch('manager_rest.dsl_functions.get_storage_manager',
+                        return_value=self.sm):
+            self.rm.update_execution_status(
+                create_dep_env.id, ExecutionState.TERMINATED, None)
 
         assert exc.error
         assert 'nonexistent1' in exc.error

--- a/tests/integration_tests/resources/dsl/custom_workflow_with_intrinsic_fn.yaml
+++ b/tests/integration_tests/resources/dsl/custom_workflow_with_intrinsic_fn.yaml
@@ -8,6 +8,8 @@ inputs:
     type: blueprint_id
   a_secret_key:
     type: secret_key
+  a_string:
+    type: string
 
 node_templates:
   test_node:
@@ -19,6 +21,7 @@ workflows:
     parameters:
       to_be_tested:
         type: list
+        default: [blueprint_id, secret, secret_key, some_string, list_of_strings]
       blueprint_id:
         description: A blueprint identifier
         type: blueprint_id
@@ -31,3 +34,9 @@ workflows:
         description: A secret value to be tested
         type: secret_key
         default: {get_input: a_secret_key}
+      some_string:
+        type: string
+        default: "lorem ipsum"
+      list_of_strings:
+        type: list
+        item_type: string

--- a/tests/integration_tests/resources/dsl/custom_workflow_with_intrinsic_fn.yaml
+++ b/tests/integration_tests/resources/dsl/custom_workflow_with_intrinsic_fn.yaml
@@ -1,0 +1,33 @@
+tosca_definitions_version: cloudify_dsl_1_5
+
+imports:
+  - cloudify/types/types.yaml
+
+inputs:
+  a_blueprint_id:
+    type: blueprint_id
+  a_secret_key:
+    type: secret_key
+
+node_templates:
+  test_node:
+    type: cloudify.nodes.Root
+
+workflows:
+  test_parameters:
+    mapping: scripts/workflows/test_deployment_id_parameters.py
+    parameters:
+      to_be_tested:
+        type: list
+      blueprint_id:
+        description: A blueprint identifier
+        type: blueprint_id
+        default: {get_input: a_blueprint_id}
+      secret:
+        description: A secret value to be tested
+        type: string
+        default: {get_secret: {get_input: a_secret_key}}
+      secret_key:
+        description: A secret value to be tested
+        type: secret_key
+        default: {get_input: a_secret_key}

--- a/tests/integration_tests/resources/dsl/scripts/workflows/test_deployment_id_parameters.py
+++ b/tests/integration_tests/resources/dsl/scripts/workflows/test_deployment_id_parameters.py
@@ -1,11 +1,28 @@
+import json
 import sys
 
-import json
+from cloudify.decorators import workflow
+from cloudify.manager import get_rest_client
+from cloudify.workflows import ctx
 
 
+@workflow
 def test_parameter(name, value):
     assert value is not None
     print("Tested parameter '{0}' is {1}".format(name, value))
+    client = get_rest_client()
+
+    node = ctx.get_node('test_node')
+    if not node:
+        return
+    for ni in client.node_instances.list(node_id=node.id):
+        rp = ni.runtime_properties
+        rp.update({'tested': True, name: value})
+        client.node_instances.update(
+            ni.id,
+            version=ni.version,
+            runtime_properties=rp
+        )
 
 
 if __name__ == '__main__':

--- a/tests/integration_tests/resources/dsl/scripts/workflows/test_deployment_id_parameters.py
+++ b/tests/integration_tests/resources/dsl/scripts/workflows/test_deployment_id_parameters.py
@@ -1,27 +1,23 @@
 import json
 import sys
 
-from cloudify.decorators import workflow
-from cloudify.manager import get_rest_client
 from cloudify.workflows import ctx
 
 
-@workflow
 def test_parameter(name, value):
     assert value is not None
     print("Tested parameter '{0}' is {1}".format(name, value))
-    client = get_rest_client()
 
     node = ctx.get_node('test_node')
     if not node:
         return
-    for ni in client.node_instances.list(node_id=node.id):
+    for ni in node.instances:
         rp = ni.runtime_properties
         rp.update({'tested': True, name: value})
-        client.node_instances.update(
+        ctx.update_node_instance(
             ni.id,
+            runtime_properties=rp,
             version=ni.version,
-            runtime_properties=rp
         )
 
 

--- a/tests/integration_tests/tests/agentless_tests/test_workflow.py
+++ b/tests/integration_tests/tests/agentless_tests/test_workflow.py
@@ -103,15 +103,17 @@ class BasicWorkflowsTest(AgentlessTestCase):
             dsl_path,
             blueprint_id=blueprint_id,
             inputs={'a_blueprint_id': blueprint_id,
-                    'a_secret_key': 'my_secret'},
+                    'a_secret_key': 'my_secret',
+                    'a_string': 'foobar'},
             timeout_seconds=30
         )
         self.execute_workflow(
             'test_parameters',
             deployment.id,
             parameters={
-                'to_be_tested': ['blueprint_id', 'secret', 'secret_key'],
-                'secret_key': 'your_secret'
+                'secret_key': 'your_secret',
+                'some_string': {'get_input': 'a_string'},
+                'list_of_strings': [{'get_input': 'a_string'}, 'foo', 'bar']
             }
         )
         instances = self.client.node_instances.list()
@@ -120,6 +122,8 @@ class BasicWorkflowsTest(AgentlessTestCase):
         assert rp.get('blueprint_id') == blueprint_id
         assert rp.get('secret') == 's3cr3t'
         assert rp.get('secret_key') == 'your_secret'
+        assert rp.get('some_string') == 'foobar'
+        assert set(rp.get('list_of_strings')) == {'foobar', 'foo', 'bar'}
 
     @pytest.mark.usefixtures('testmockoperations_plugin')
     def test_dependencies_order_with_two_nodes(self):


### PR DESCRIPTION
Allow (the default) values for the custom workflow parameters to be declared using intrinsic functions, e.g.

```yaml
tosca_definitions_version: cloudify_dsl_1_5

inputs:
  a_blueprint_id:
    type: blueprint_id
  b_blueprint_id:
    type: blueprint_id

workflows:
  test_parameters:
    mapping: scripts/workflows/test_deployment_id_parameters.py
    parameters:
      blueprint_id:
        type: blueprint_id
        default: {get_input: a_blueprint_id}
```

or

```python
client.executions.start(
    deployment_id='d1',
    workflow_id='test_parameters',
    parameters={'blueprint_id': {'get_input': 'b_blueprint_id'}},
)
```