### PR TITLE
Python 3.11 compat

### DIFF
--- a/rest-service/manager_rest/constants.py
+++ b/rest-service/manager_rest/constants.py
@@ -14,8 +14,18 @@
 #  * limitations under the License.
 
 from collections import namedtuple
-from enum import Enum
 from typing import List, Union, Tuple
+
+
+try:
+    from enum import StrEnum
+except ImportError:
+    from enum import Enum
+    # before python 3.11, StrEnum didn't exist. Trivial reimplementation:
+
+    class StrEnum(str, Enum):
+        def __str__(self):
+            return self.value
 
 
 CONVENTION_APPLICATION_BLUEPRINT_FILE = 'blueprint.yaml'
@@ -102,7 +112,7 @@ RESERVED_LABELS = {'csys-obj-name',
 RESERVED_PREFIX = 'csys-'
 
 
-class LabelsOperator(str, Enum):
+class LabelsOperator(StrEnum):
     ANY_OF = 'any_of'
     NOT_ANY_OF = 'not_any_of'
     IS_NULL = 'is_null'
@@ -110,7 +120,7 @@ class LabelsOperator(str, Enum):
     IS_NOT = 'is_not'
 
 
-class AttrsOperator(str, Enum):
+class AttrsOperator(StrEnum):
     ANY_OF = 'any_of'
     NOT_ANY_OF = 'not_any_of'
     CONTAINS = 'contains'
@@ -120,7 +130,7 @@ class AttrsOperator(str, Enum):
     IS_NOT_EMPTY = 'is_not_empty'
 
 
-class FilterRuleType(str, Enum):
+class FilterRuleType(StrEnum):
     LABEL = 'label'
     ATTRIBUTE = 'attribute'
 

--- a/rest-service/manager_rest/test/endpoints/test_community_contacts.py
+++ b/rest-service/manager_rest/test/endpoints/test_community_contacts.py
@@ -1,13 +1,18 @@
 import mock
+import pytest
 from json import JSONDecodeError
 from typing import Dict, Any
 
+from manager_rest import premium_enabled
 from manager_rest.test import base_test
 from cloudify_rest_client.exceptions import CloudifyClientError
 
 
-@mock.patch('manager_rest.rest.resources_v3_1.'
-            'community_contacts.premium_enabled', False)
+@pytest.mark.skipif(
+    premium_enabled,
+    reason='Community tests cannot be run when cloudify-premium is '
+           'installed. Premium tests are in cloudify-premium.'
+)
 class TestCommunityContacts(base_test.BaseServerTestCase):
     data = {"first_name": "John",
             "last_name": "Smith",

--- a/rest-service/manager_rest/test/endpoints/test_tenants.py
+++ b/rest-service/manager_rest/test/endpoints/test_tenants.py
@@ -13,9 +13,11 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
+import pytest
+
 from mock import patch
 
-from manager_rest import constants
+from manager_rest import constants, premium_enabled
 from manager_rest.storage import models
 
 from cloudify.cryptography_utils import encrypt
@@ -23,11 +25,14 @@ from cloudify_rest_client.exceptions import CloudifyClientError
 
 from manager_rest.test import base_test
 
-
 CREDENTIALS_PERMISSION = 'tenant_rabbitmq_credentials'
 
 
-@patch('manager_rest.security.secured_resource.premium_enabled', False)
+@pytest.mark.skipif(
+    premium_enabled,
+    reason='Community tests cannot be run when cloudify-premium is '
+           'installed. Premium tests are in cloudify-premium.'
+)
 class TenantsCommunityTestCase(base_test.BaseServerTestCase):
     def test_list_tenants(self):
         """Listing tenants is allowed on community."""


### PR DESCRIPTION
Turns out, there's only very few (really - one) changes required to make the restservice compatible with Python 3.11 - and it makes the tests faster indeed!

The cloudify-premium thing is to some degree unrelated, but that's how I ended up running the tests, so I'm cleaning that up too.