### PR TITLE
RD-6290 Implement MonitoringAuth

### DIFF
--- a/rest-service/manager_rest/manager_exceptions.py
+++ b/rest-service/manager_rest/manager_exceptions.py
@@ -153,6 +153,13 @@ class UnauthorizedError(ManagerException):
 
 class NoAuthProvided(UnauthorizedError):
     """Not authorized, because authentication was not provided."""
+
+    additional_headers: typing.ClassVar[dict[str, str]] = {
+        # if the user received this error in a browser, they'll be greeted
+        # with the basic auth prompt, rather than just an error page
+        'WWW-Authenticate': 'Basic',
+    }
+
     def __init__(self, *args, **kwargs):
         super().__init__('No authentication info provided', *args, **kwargs)
 

--- a/rest-service/manager_rest/manager_exceptions.py
+++ b/rest-service/manager_rest/manager_exceptions.py
@@ -13,12 +13,15 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
+import typing
+
 from flask import jsonify
 
 INTERNAL_SERVER_ERROR_CODE = 'internal_server_error'
 
 
 class ManagerException(Exception):
+    additional_headers: typing.ClassVar[dict[str, str]] = {}
     error_code = INTERNAL_SERVER_ERROR_CODE
     status_code = 500
 

--- a/rest-service/manager_rest/rest/endpoint_mapper.py
+++ b/rest-service/manager_rest/rest/endpoint_mapper.py
@@ -90,6 +90,7 @@ def setup_resources(api):
         'UsersActive': 'users/active/<string:username>',
         'UsersUnlock': 'users/unlock/<string:username>',
         'FileServerAuth': 'file-server-auth',
+        'MonitoringAuth': 'monitoring-auth',
         'FileServerProxy': [
             'file-server-proxy/',
             'file-server-proxy/<path:uri>',

--- a/rest-service/manager_rest/rest/resources_v3_1/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/__init__.py
@@ -28,6 +28,7 @@ from .manager import (                           # NOQA
     DBNodes,
     FileServerIndex,
     FileServerProxy,
+    MonitoringAuth,
 )
 
 from .manager_config import (                    # NOQA

--- a/rest-service/manager_rest/rest/resources_v3_1/manager.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/manager.py
@@ -28,13 +28,13 @@ from manager_rest.rest import rest_utils
 from manager_rest.storage import get_storage_manager, models
 from manager_rest.security.authorization import (
     authorize,
-    is_user_action_allowed
+    is_user_action_allowed,
+    check_user_action_allowed,
 )
 from manager_rest.rest.rest_decorators import (
     marshal_with,
     paginate
 )
-
 try:
     from cloudify_premium import manager as manager_premium
 except ImportError:
@@ -310,3 +310,15 @@ class FileServerProxy(SecuredResource):
             return self._get_local_fileserver_response(original_uri)
 
         return {}, 404
+
+
+class MonitoringAuth(SecuredResource):
+    """Auth endpoint for monitoring.
+
+    Users who access /monitoring need to first pass through auth_request
+    proxying to here. If this returns 200, the user has full access
+    to local prometheus.
+    """
+    def get(self, **_):
+        check_user_action_allowed("monitoring")
+        return "", 200

--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -50,7 +50,7 @@ def manager_exception(error):
         current_app.logger.debug(error)
     else:
         current_app.logger.error(error)
-    return error.to_response(), error.status_code
+    return error.to_response(), error.status_code, error.additional_headers
 
 
 @app_errors.app_errorhandler(InternalServerError)


### PR DESCRIPTION
When the user hits /monitoring, they'll be presented with a http basic auth prompt in their browser, and then they can access prometheus, if they log in as admin.

This is the other part of cloudify-cosmo/cloudify-manager-install#1444