### PR TITLE
RD-6284 types.yaml: new workflow parameters

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -751,6 +751,19 @@ workflows:
     is_cascading: false
     availability_rules:
       node_instances_active: ['none', 'partial']
+    parameters:
+      type_names:
+        type: list
+        item_type: node_type
+        default: []
+      node_ids:
+        type: list
+        item_type: node_id
+        default: []
+      node_instance_ids:
+        type: list
+        item_type: node_instance
+        default: []
 
   check_status:
     mapping: default_workflows.cloudify.plugins.workflows.check_status
@@ -803,6 +816,40 @@ workflows:
       ignore_failure:
         default: false
         type: boolean
+      type_names:
+        type: list
+        item_type: node_type
+        default: []
+      node_ids:
+        type: list
+        item_type: node_id
+        default: []
+      node_instance_ids:
+        type: list
+        item_type: node_instance
+        default: []
+
+  reinstall:
+    mapping: default_workflows.cloudify.plugins.workflows.reinstall
+    is_cascading: false
+    availability_rules:
+      node_instances_active: [ 'all', 'partial' ]
+    parameters:
+      ignore_failure:
+        default: false
+        type: boolean
+      type_names:
+        type: list
+        item_type: node_type
+        default: []
+      node_ids:
+        type: list
+        item_type: node_id
+        default: []
+      node_instance_ids:
+        type: list
+        item_type: node_instance
+        default: []
 
   start:
     mapping: default_workflows.cloudify.plugins.workflows.start

--- a/resources/rest-service/cloudify/types/types_1_3.yaml
+++ b/resources/rest-service/cloudify/types/types_1_3.yaml
@@ -687,6 +687,13 @@ workflows:
   install:
     mapping: default_workflows.cloudify.plugins.workflows.install
     is_cascading: false
+    parameters:
+      type_names:
+        default: []
+      node_ids:
+        default: []
+      node_instance_ids:
+        default: []
 
   check_status:
     mapping: default_workflows.cloudify.plugins.workflows.check_status
@@ -721,6 +728,26 @@ workflows:
       ignore_failure:
         default: false
         type: boolean
+      type_names:
+        default: []
+      node_ids:
+        default: []
+      node_instance_ids:
+        default: []
+
+  reinstall:
+    mapping: default_workflows.cloudify.plugins.workflows.reinstall
+    is_cascading: false
+    parameters:
+      ignore_failure:
+        default: false
+        type: boolean
+      type_names:
+        default: []
+      node_ids:
+        default: []
+      node_instance_ids:
+        default: []
 
   start:
     mapping: default_workflows.cloudify.plugins.workflows.start

--- a/resources/rest-service/cloudify/types/types_1_4.yaml
+++ b/resources/rest-service/cloudify/types/types_1_4.yaml
@@ -751,6 +751,19 @@ workflows:
     is_cascading: false
     availability_rules:
       node_instances_active: ['none', 'partial']
+    parameters:
+      type_names:
+        type: list
+        item_type: node_type
+        default: []
+      node_ids:
+        type: list
+        item_type: node_id
+        default: []
+      node_instance_ids:
+        type: list
+        item_type: node_instance
+        default: []
 
   check_status:
     mapping: default_workflows.cloudify.plugins.workflows.check_status
@@ -803,6 +816,18 @@ workflows:
       ignore_failure:
         default: false
         type: boolean
+      type_names:
+        type: list
+        item_type: node_type
+        default: []
+      node_ids:
+        type: list
+        item_type: node_id
+        default: []
+      node_instance_ids:
+        type: list
+        item_type: node_instance
+        default: []
 
   start:
     mapping: default_workflows.cloudify.plugins.workflows.start
@@ -814,6 +839,28 @@ workflows:
         default: {}
       run_by_dependency_order:
         default: true
+      type_names:
+        type: list
+        item_type: node_type
+        default: []
+      node_ids:
+        type: list
+        item_type: node_id
+        default: []
+      node_instance_ids:
+        type: list
+        item_type: node_instance
+        default: []
+
+  reinstall:
+    mapping: default_workflows.cloudify.plugins.workflows.reinstall
+    is_cascading: false
+    availability_rules:
+      node_instances_active: [ 'all', 'partial' ]
+    parameters:
+      ignore_failure:
+        default: false
+        type: boolean
       type_names:
         type: list
         item_type: node_type

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -808,7 +808,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
 
         resource_path = '/deployments/{0}'.format(deployment_id)
         workflows = self.get(resource_path).json['workflows']
-        self.assertEqual(15, len(workflows))
+        self.assertEqual(16, len(workflows))
         workflow: Optional[Dict] = next(
             (
                 workflow for workflow in workflows


### PR DESCRIPTION
- Add filtering parameters to `install`
- Add filtering parameters to `uninstall`
- Declare the `reinstall` workflow

This is done in all types (1_5, 1_4, 1_3), because the parameters don't depend on dsl version (only on the manager version). However 1_3 of course doesn't get 1_4+ dsl features, ie. availability_rules and item_type