### PR TITLE
RD-6082 mgmtworker rpm: include a python3.6 base venv

### DIFF
--- a/packaging/cloudify-mgmtworker.spec
+++ b/packaging/cloudify-mgmtworker.spec
@@ -29,6 +29,10 @@ BuildRequires:  postgresql-devel
 Requires:       postgresql-libs
 Requires(pre):  shadow-utils
 
+Requires:       python3 >= 3.6
+BuildRequires:  python3 >= 3.6
+
+
 Source0:        https://cloudify-cicd.s3.amazonaws.com/python-build-packages/cfy-python3.10-%{ARCHITECTURE}.tgz
 
 %description
@@ -49,11 +53,18 @@ sudo tar xf %{S:0} -C /
 
 %{PIP_INSTALL} --upgrade kerberos==1.3.1
 
+# create a python3.6 venv with common & requirements preinstalled, to be used
+# as a base virtualenv for python3.6 plugins
+python3.6 -m venv /opt/plugins-common-3.6
+/opt/plugins-common-3.6/bin/pip install --upgrade pip "setuptools<=63.2"
+/opt/plugins-common-3.6/bin/pip install -r "${RPM_SOURCE_DIR}/packaging/mgmtworker/requirements.txt"
+
 
 %install
 
 mkdir -p %{buildroot}/opt/mgmtworker
 mv /opt/mgmtworker/env %{buildroot}/opt/mgmtworker
+mv /opt/plugins-common-3.6 %{buildroot}/opt/plugins-common-3.6
 
 mkdir -p %{buildroot}/var/log/cloudify/mgmtworker
 mkdir -p %{buildroot}/opt/mgmtworker/config
@@ -82,4 +93,5 @@ groupadd -fr cfylogs
 %attr(750,cfyuser,cfyuser) /opt/mgmtworker/env/plugins
 %attr(750,cfyuser,cfyuser) /opt/mgmtworker/env/source_plugins
 /opt/mgmtworker
+/opt/plugins-common-3.6
 %attr(750,cfyuser,cfylogs) /var/log/cloudify/mgmtworker


### PR DESCRIPTION
This venv contains an upgraded version of pip (and also all our cloudify-common libs) as a base for plugin installations