### PR TITLE
default value for Users.created_at

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/edd6d829a209_6_4_to_7_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/edd6d829a209_6_4_to_7_0.py
@@ -477,9 +477,11 @@ def add_users_created_at_index():
         .where(users_table.c.created_at.is_(None))
         .values(created_at=datetime.utcnow())
     )
-    op.alter_column('users', 'created_at',
-               existing_type=postgresql.TIMESTAMP(),
-               nullable=False)
+    op.alter_column(
+        'users', 'created_at',
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=False,
+    )
     op.create_index(
         op.f('users_created_at_idx'),
         'users',
@@ -487,8 +489,11 @@ def add_users_created_at_index():
         unique=False,
     )
 
+
 def drop_users_created_at_index():
     op.drop_index(op.f('users_created_at_idx'), table_name='users')
-    op.alter_column('users', 'created_at',
-               existing_type=postgresql.TIMESTAMP(),
-               nullable=True)
+    op.alter_column(
+        'users', 'created_at',
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+    )

--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -286,14 +286,13 @@ class GroupTenantAssoc(SQLModelBase):
         return 'group_id'
 
 
-class User(SQLModelBase, UserMixin):
+class User(CreatedAtMixin, SQLModelBase, UserMixin):
     __tablename__ = 'users'
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     username = CIColumn(db.String(255), index=True, unique=True)
 
     active = db.Column(db.Boolean)
-    created_at = db.Column(UTCDateTime)
     email = db.Column(db.String(255))
     first_name = db.Column(db.String(255))
     first_login_at = db.Column(UTCDateTime)


### PR DESCRIPTION
When creating a user, default their created_at to now. Note: this also makes created_at be the default_sort_column.

Also, this causes a migration, because now, created_at is not nullable. That means we must default the value to something, and well, the something has to be the migration time.