### PR TITLE
RD-6395 REST: set sqlalchemy client_encoding to utf-8

### DIFF
--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -205,7 +205,8 @@ class CloudifyFlaskApp(Flask):
         the tables if necessary
         """
         self.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
-            'pool_size': 1
+            'pool_size': 1,
+            'client_encoding': 'utf-8',
         }
         self.update_db_uri()
         self.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False


### PR DESCRIPTION
We don't ever want anything but utf-8 here.

If this is not set, it might default to ascii, and then saving non-ascii strings into the db, is going to cause UnicodeEncodeErrors.