### PR TITLE
RD-5953 Use the new dep-plan IDD format

### DIFF
--- a/mgmtworker/cloudify_system_workflows/idd.py
+++ b/mgmtworker/cloudify_system_workflows/idd.py
@@ -108,8 +108,16 @@ def _prepare(deployment_plan: dsl_models.Plan,
     local_tenant_name = tenant_name if ext_client else None
 
     local_dependencies, external_dependencies = [], []
-    for func_id, deployment_id_func in new_dependencies.items():
-        target_deployment_id, target_deployment_func = deployment_id_func
+    for dependency in new_dependencies:
+        func_id = dependency['function_identifier']
+
+        target_deployment_id, target_deployment_func = \
+            dependency['target_deployment']
+        if target_deployment_func:
+            target_deployment_func = {
+                'function': target_deployment_func,
+                'context': dependency.get('context', {}),
+            }
         if ext_client:
             local_dependencies += [
                 create_deployment_dependency(

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -511,9 +511,20 @@ def _add_new_consumer_labels(sm, source_id, consumer_labels_to_add):
 
 
 def _evaluate_target_func(target_dep_func, source_dep_id):
+    if not target_dep_func:
+        return target_dep_func
+    context = None
+    # 7.0.0+ IDDs are of the form {'function': func, 'context': {}},
+    # but pre-7.0.0 (un-migrated snapshots?) there's only func
+    if 'function' in target_dep_func and 'context' in target_dep_func:
+        context = target_dep_func['context']
+        target_dep_func = target_dep_func['function']
     if get_function(target_dep_func):
         evaluated_func = evaluate_intrinsic_functions(
-            {'target_deployment': target_dep_func}, source_dep_id)
+            {'target_deployment': target_dep_func},
+            source_dep_id,
+            context=context,
+        )
         return evaluated_func.get('target_deployment')
 
     return target_dep_func

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -373,6 +373,35 @@ def get_deployment_plan(parsed_deployment,
             str(e))
 
 
+def _normalize_plan_dependencies(dependencies, dep_plan_filter_func):
+    """Normalize the dependencies coming from deployment plan to be a list.
+
+    Before 7.0.0, plan dependencies were a dict and didn't contain context.
+    This function returns the 7.0.0+ format, either directly, or
+    based on the old format.
+    """
+    idds = []
+    if not dependencies:
+        return idds
+    if isinstance(dependencies, list):
+        idds = dependencies
+    elif isinstance(dependencies, dict):
+        for dependency_creator, target_deployment_attr in dependencies.items():
+            idd = {
+                'function_identifier': dependency_creator,
+                'target_deployment': target_deployment_attr,
+                'context': {},
+            }
+            idds.append(idd)
+    else:
+        raise TypeError(
+            f'IDDs must be a list or a dict, but got {type(dependencies)}')
+    return [
+        idd for idd in idds
+        if dep_plan_filter_func(idd['function_identifier'])
+    ]
+
+
 def update_deployment_dependencies_from_plan(deployment_id,
                                              deployment_plan,
                                              storage_manager,
@@ -381,20 +410,14 @@ def update_deployment_dependencies_from_plan(deployment_id,
     curr_dependencies = {} if curr_dependencies is None else curr_dependencies
 
     new_dependencies = deployment_plan.setdefault(
-        INTER_DEPLOYMENT_FUNCTIONS, {})
-    new_dependencies_dict = {
-        creator: (target[0], target[1])
-        for creator, target in new_dependencies.items()
-        if dep_plan_filter_func(creator)
-    }
+        INTER_DEPLOYMENT_FUNCTIONS, [])
     source_deployment = storage_manager.get(models.Deployment,
                                             deployment_id,
                                             all_tenants=True)
     dependents = source_deployment.get_all_dependents()
-    for dependency_creator, target_deployment_attr \
-            in new_dependencies_dict.items():
-        target_deployment_id = target_deployment_attr[0]
-        target_deployment_func = target_deployment_attr[1]
+    for idd in new_dependencies:
+        dependency_creator = idd['function_identifier']
+        target_deployment_id, target_deployment_func = idd['target_deployment']
         target_deployment = storage_manager.get(
             models.Deployment, target_deployment_id, all_tenants=True) \
             if target_deployment_id else None
@@ -431,7 +454,6 @@ def update_deployment_dependencies_from_plan(deployment_id,
             raise manager_exceptions.ConflictError(
                 f'cyclic dependency between {source_deployment.id} '
                 f'and {target_deployment.id}')
-    return new_dependencies_dict
 
 
 def update_inter_deployment_dependencies(sm, deployment):

--- a/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
@@ -678,8 +678,10 @@ class InterDeploymentDependenciesTest(BaseServerTestCase):
         self._assert_dependency_values(static_dependency,
                                        static_target_deployment,
                                        resource_id)
-        self.assertEqual(target_deployment_func,
-                         {'get_secret': 'shared2_key'})
+        self.assertEqual(
+            target_deployment_func['function'],
+            {'get_secret': 'shared2_key'},
+        )
 
     @staticmethod
     def _get_target_deployment_func(dependencies_list):

--- a/tests/integration_tests/tests/agentless_tests/test_inter_deployment_dependencies.py
+++ b/tests/integration_tests/tests/agentless_tests/test_inter_deployment_dependencies.py
@@ -126,6 +126,108 @@ class TestInterDeploymentDependenciesInfrastructure(AgentlessTestCase):
         with self.assertRaises(RuntimeError):
             self.wait_for_execution_to_end(exc)
 
+    def test_dependency_func_with_context(self):
+        """Check that IDD-creating-functions can use context
+
+        Specifically, get_capability must be able to fetch things from
+        SELF and TARGET.
+        """
+        bp1_yaml = """
+tosca_definitions_version: cloudify_dsl_1_4
+imports:
+    - cloudify/types/types.yaml
+capabilities:
+    cap1:
+        value: capability value
+"""
+        bp2_yaml = """
+tosca_definitions_version: cloudify_dsl_1_4
+imports:
+    - cloudify/types/types.yaml
+    - plugin:cloudmock
+node_types:
+    t1:
+        derived_from: cloudify.nodes.Root
+        properties:
+            prop1: {}
+            x: {}
+node_templates:
+    rel_target:
+        type: t1
+        properties:
+            x: ""
+            prop1: cap1
+    n1:
+        type: t1
+        properties:
+            prop1: d1
+            x:
+                get_capability:
+                    - {get_attribute: [SELF, prop1]}
+                    - cap1
+        interfaces:
+            cloudify.interfaces.lifecycle:
+                create:
+                    implementation: cloudmock.cloudmock.tasks.store_inputs
+                    inputs:
+                        lifecycle_operation:
+                            get_capability:
+                                - {get_attribute: [SELF, prop1]}
+                                - {get_attribute: [rel_target, prop1]}
+        relationships:
+            - target: rel_target
+              type: cloudify.relationships.depends_on
+              source_interfaces:
+                cloudify.interfaces.relationship_lifecycle:
+                    establish:
+                        implementation: cloudmock.cloudmock.tasks.store_inputs
+                        inputs:
+                            rel_operation:
+                                get_capability:
+                                    - {get_attribute: [SOURCE, prop1]}
+                                    - {get_attribute: [TARGET, prop1]}
+"""
+        self.upload_blueprint_resource(
+            self.make_yaml_file(bp1_yaml),
+            blueprint_id='bp1',
+        )
+        self.upload_blueprint_resource(
+            self.make_yaml_file(bp2_yaml),
+            blueprint_id='bp2',
+        )
+        dep1 = self.deploy(blueprint_id='bp1', deployment_id='d1')
+        dep2 = self.deploy(blueprint_id='bp2', deployment_id='d2')
+        exc = self.client.executions.create(dep2.id, 'install')
+        self.wait_for_execution_to_end(exc)
+
+        idds = self.client.inter_deployment_dependencies.list(
+            source_deployment_id=dep2.id)
+        for idd in idds:
+            # we have declared IDDs using several ways, but they all point
+            # to dep1 in the end
+            assert idd.target_deployment_id == dep1.id
+            # ...they all come from a function...
+            assert idd.target_deployment_func.get('function')
+            # ...and they all declare some context
+            assert idd.target_deployment_func.get('context')
+
+        nodes = self.client.nodes.list(
+            deployment_id=dep2.id,
+            id='n1',
+            evaluate_functions=True,
+        )
+        assert len(nodes) == 1
+        assert nodes[0].properties['x'] == 'capability value'
+        nis = self.client.node_instances.list(
+            deployment_id=dep2.id,
+            node_id='n1',
+        )
+        assert len(nis) == 1
+        assert nis[0].runtime_properties['lifecycle_operation'] == \
+            'capability value'
+        assert nis[0].runtime_properties['rel_operation'] == \
+            'capability value'
+
     def _test_dependencies_are_updated(self, skip_uninstall):
         self._assert_dependencies_count(0)
         self._prepare_dep_update_test_resources()

--- a/tests/integration_tests/tests/agentless_tests/test_inter_deployment_dependencies.py
+++ b/tests/integration_tests/tests/agentless_tests/test_inter_deployment_dependencies.py
@@ -251,8 +251,10 @@ class TestInterDeploymentDependenciesInfrastructure(AgentlessTestCase):
                 self.assertEqual(dependency.target_deployment_id,
                                  SR_DEPLOYMENT)
                 secret_func = {'get_secret': 'shared_resource_deployment_key'}
-                self.assertEqual(dependency['target_deployment_func'],
-                                 secret_func)
+                self.assertEqual(
+                    dependency['target_deployment_func']['function'],
+                    secret_func,
+                )
             else:
                 self.fail('Unexpected dependency creator "{0}"'
                           ''.format(dependency.dependency_creator))

--- a/tests/integration_tests_plugins/cloudmock/cloudmock/tasks.py
+++ b/tests/integration_tests_plugins/cloudmock/cloudmock/tasks.py
@@ -18,7 +18,7 @@ import time
 from cloudify.decorators import operation, workflow
 from cloudify.exceptions import NonRecoverableError
 from cloudify.manager import get_rest_client
-from cloudify import ctx
+from cloudify import ctx, constants
 
 
 RUNNING = 'running'
@@ -230,3 +230,13 @@ def maybe_failing(ctx, **kwargs):
     """Fail only if the fail flag is set"""
     if ctx.instance.runtime_properties.get('fail'):
         raise NonRecoverableError('Error')
+
+
+@operation
+def store_inputs(ctx, **kwargs):
+    """Store inputs of this operation in the instance's runtime properties"""
+    if ctx.type == constants.RELATIONSHIP_INSTANCE:
+        instance = ctx.source.instance
+    else:
+        instance = ctx.instance
+    instance.runtime_properties.update(kwargs)


### PR DESCRIPTION
In cloudify-cosmo/cloudify-common#1186 we introduce a new format of returned IDDs, that also includes the "context" (also see commit messages).
This makes sure that the manager is able to work with this new format.