### PR TITLE
RD-5952 Add a multi-instance IDD test

### DIFF
--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -555,6 +555,13 @@ def _evaluate_target_func(target_dep_func, source_dep_id):
 def _get_deployment_from_target_func(sm, target_dep_func, source_dep_id):
     target_dep_id = _evaluate_target_func(target_dep_func, source_dep_id)
     if target_dep_id:
+        if not isinstance(target_dep_id, str):
+            # raise early so that we don't try to pass a non-str to the db,
+            # which would cause a completely unreadable db-side error
+            raise ValueError(
+                f'function {target_dep_func} must return a string, but it '
+                f'returned {target_dep_id} ({type(target_dep_id)})'
+            )
         return sm.get(models.Deployment, target_dep_id, fail_silently=True,
                       all_tenants=True)
 

--- a/tests/integration_tests/tests/agentless_tests/test_inter_deployment_dependencies.py
+++ b/tests/integration_tests/tests/agentless_tests/test_inter_deployment_dependencies.py
@@ -228,6 +228,138 @@ node_templates:
         assert nis[0].runtime_properties['rel_operation'] == \
             'capability value'
 
+    def test_idd_with_context_multiple_instances(self):
+        """Check that IDDs can come from functions in scaled instances.
+
+        A somewhat complex blueprint!
+        First, the node `rel_target` (two instances of it) each fetch a
+        different entry from the input list, and store it in their runtime
+        properties.
+        Then, two instances of node `n1` run a lifecycle operation, and a
+        relationship operation, fetching a capability from a deployment given
+        by their related `rel_target` instance, with the capability name
+        based on their own property.
+        Finally, we check that since we've had two instances of the scaling
+        group, we've seen capability values coming from BOTH related
+        deployments.
+        """
+        bp1_yaml = """
+tosca_definitions_version: cloudify_dsl_1_4
+imports:
+    - cloudify/types/types.yaml
+inputs:
+    value: {}
+capabilities:
+    cap1:
+        value: {get_input: value}
+"""
+        bp2_yaml = """
+tosca_definitions_version: cloudify_dsl_1_4
+imports:
+    - cloudify/types/types.yaml
+    - plugin:cloudmock
+node_types:
+    t1:
+        derived_from: cloudify.nodes.Root
+        properties:
+            cap_name:
+                default: ""
+inputs:
+    dep_id:
+        type: list
+        default:
+            - null   # index is 0-based
+            - d1
+            - d2
+
+node_templates:
+    rel_target:
+        type: t1
+        interfaces:
+            cloudify.interfaces.lifecycle:
+                create:
+                    implementation: cloudmock.cloudmock.tasks.store_inputs
+                    inputs:
+                        dep_id:
+                            get_input:
+                                - dep_id
+                                - {get_attribute: [SELF, node_instance_index]}
+    n1:
+        type: t1
+        properties:
+            cap_name: cap1
+        interfaces:
+            cloudify.interfaces.lifecycle:
+                create:
+                    implementation: cloudmock.cloudmock.tasks.store_inputs
+                    inputs:
+                        lifecycle_operation:
+                            get_capability:
+                                - {get_attribute: [rel_target, dep_id]}
+                                - {get_attribute: [SELF, cap_name]}
+        relationships:
+            - target: rel_target
+              type: cloudify.relationships.depends_on
+              source_interfaces:
+                cloudify.interfaces.relationship_lifecycle:
+                    establish:
+                        implementation: cloudmock.cloudmock.tasks.store_inputs
+                        inputs:
+                            rel_operation:
+                                get_capability:
+                                    - {get_attribute: [rel_target, dep_id]}
+                                    - {get_attribute: [SOURCE, cap_name]}
+groups:
+  group1:
+    members: [n1, rel_target]
+policies:
+  policy:
+    type: cloudify.policies.scaling
+    targets: [group1]
+    properties:
+      default_instances: 2
+"""
+        self.upload_blueprint_resource(
+            self.make_yaml_file(bp1_yaml),
+            blueprint_id='bp1',
+        )
+        self.upload_blueprint_resource(
+            self.make_yaml_file(bp2_yaml),
+            blueprint_id='bp2',
+        )
+        dep1 = self.deploy(
+            blueprint_id='bp1',
+            deployment_id='d1',
+            inputs={'value': 'value1'},
+        )
+        dep2 = self.deploy(
+            blueprint_id='bp1',
+            deployment_id='d2',
+            inputs={'value': 'value2'},
+        )
+        dep3 = self.deploy(
+            blueprint_id='bp2',
+            deployment_id='d3',
+            # I wish this wasn't required, but otherwise get_input is angry
+            # when it tries to be evaluated up-front, at the get_attribute
+            # call in its arguments
+            runtime_only_evaluation=True,
+        )
+        exc = self.client.executions.create(dep3.id, 'install')
+        self.wait_for_execution_to_end(exc)
+
+        idds = self.client.inter_deployment_dependencies.list(
+            source_deployment_id=dep3.id)
+        assert {idd.target_deployment_id for idd in idds} == {dep1.id, dep2.id}
+        nis = self.client.node_instances.list(
+            deployment_id=dep3.id,
+            node_id='n1',
+        )
+        assert {ni.runtime_properties['lifecycle_operation'] for ni in nis} ==\
+            {'value1', 'value2'}
+        assert {ni.runtime_properties['rel_operation'] for ni in nis} ==\
+            {'value1', 'value2'}
+
     def _test_dependencies_are_updated(self, skip_uninstall):
         self._assert_dependencies_count(0)
         self._prepare_dep_update_test_resources()


### PR DESCRIPTION
Well the test is pretty complex. But just read the docstring :)

Also, add a pre-check for a more readable error. This will happen when you do `{get_capability: {get_attribute: ..}}` in case the attribute returns a non-string. If we allowed the non-string to go into the db select, we'd get a psycopg2 db error, and that one was completely unreadable.