### PR TITLE
RD-5946 Fix the "cyclic dependency" check for dep-update

### DIFF
--- a/resources/rest-service/cloudify/migrations/versions/edd6d829a209_6_4_to_7_0.py
+++ b/resources/rest-service/cloudify/migrations/versions/edd6d829a209_6_4_to_7_0.py
@@ -55,9 +55,9 @@ def downgrade():
     remove_p_from_pickle_columns()
     add_service_management_config()
     drop_users_created_at_index()
+    drop_secrets_provider_relationship()
     drop_secrets_providers_table()
     drop_secrets_schema()
-    drop_secrets_provider_relationship()
 
 
 # Upgrade functions

--- a/rest-service/manager_rest/dsl_functions.py
+++ b/rest-service/manager_rest/dsl_functions.py
@@ -61,9 +61,15 @@ def evaluate_node_instance(instance):
         raise FunctionsEvaluationError(str(e))
 
 
-def evaluate_intrinsic_functions(payload, deployment_id, context=None):
+def evaluate_intrinsic_functions(
+    payload,
+    deployment_id,
+    context=None,
+    sm=None,
+):
     context = context or {}
-    sm = get_storage_manager()
+    if sm is None:
+        sm = get_storage_manager()
     sm.get(Deployment, deployment_id, include=['id'])
     storage = FunctionEvaluationStorage(deployment_id, sm)
 
@@ -167,7 +173,8 @@ class FunctionEvaluationStorage(object):
         capability = evaluate_intrinsic_functions(
             payload=capability,
             deployment_id=shared_dep_id,
-            context={EVAL_FUNCS_PATH_PREFIX_KEY: CAPABILITIES}
+            context={EVAL_FUNCS_PATH_PREFIX_KEY: CAPABILITIES},
+            sm=self.sm,
         )['value']
         return self._get_capability_by_path(capability, capability_path)
 

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1747,41 +1747,6 @@ class ResourceManager(object):
         delete_types = self.get_object_types_from_labels(labels_to_delete)
         return created_types, delete_types
 
-    def get_missing_deployment_parents(self, parents):
-        if not parents:
-            return
-        result = self.sm.list(
-            models.Deployment,
-            include=['id'],
-            filters={'id': lambda col: col.in_(parents)},
-            get_all_results=True,
-        ).items
-        _existing_parents = [_parent.id for _parent in result]
-        missing_parents = set(parents) - set(_existing_parents)
-        return missing_parents
-
-    def verify_deployment_parents_existence(self, parents, resource_id,
-                                            resource_type):
-        missing_parents = self.get_missing_deployment_parents(parents)
-        if missing_parents:
-            raise manager_exceptions.DeploymentParentNotFound(
-                '{0} {1}: is referencing deployments'
-                ' using label `csys-obj-parent` that does not exist, '
-                'make sure that deployment(s) {2} exist before creating '
-                '{3}'.format(resource_type.capitalize(),
-                             resource_id,
-                             ','.join(missing_parents), resource_type)
-            )
-
-    def verify_attaching_deployment_to_parents(self, dep, parents):
-        self.verify_deployment_parents_existence(parents, dep, 'deployment')
-        dependent_ids = [d.id for d in dep.get_all_dependents()]
-        for parent_id in parents:
-            if parent_id in dependent_ids:
-                raise manager_exceptions.ConflictError(
-                    f'cyclic dependency between {dep.id} and {parent_id}'
-                )
-
     def add_deployment_to_labels_graph(self, deployments, parent_ids):
         if not deployments or not parent_ids:
             return

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2600,17 +2600,6 @@ class ResourceManager(object):
                 execution.workflow_id, execution.deployment.id,
                 formatted_dependencies)
             return
-        # If part of a deployment update - mark the update as failed
-        if execution.workflow_id in ('update', 'csys_new_deployment_update'):
-            dep_update = self.sm.get(
-                models.DeploymentUpdate,
-                None,
-                filters={'deployment_id': execution.deployment.id,
-                         'state': UpdateStates.UPDATING}
-            )
-            if dep_update:
-                dep_update.state = UpdateStates.FAILED
-                self.sm.update(dep_update)
         raise manager_exceptions.DependentExistsError(
             f"Can't execute workflow `{execution.workflow_id}` on deployment "
             f"{execution.deployment.id} - existing installations depend "

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -305,7 +305,7 @@ class ResourceManager(object):
 
         except Exception as e:
             execution.status = ExecutionState.FAILED
-            execution.error = str(e)
+            execution.error = f'Error dequeueing execution: {e}'
             return False, []
         else:
             flag_modified(execution, 'parameters')
@@ -1170,7 +1170,7 @@ class ResourceManager(object):
             except Exception as e:
                 errors.append(e)
                 exc.status = ExecutionState.FAILED
-                exc.error = str(e)
+                exc.error = f'Error preparing execution: {e}'
                 self.sm.update(exc)
                 continue
 

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -1412,7 +1412,7 @@ class DeploymentGroupsId(SecuredResource):
 
 def _create_inter_deployment_dependency(
         source_deployment: Optional[models.Deployment],
-        dependency: models.InterDeploymentDependencies,
+        dependency: dict,
         sm) -> models.InterDeploymentDependencies:
     now = utils.get_formatted_timestamp()
 
@@ -1426,7 +1426,8 @@ def _create_inter_deployment_dependency(
         target_deployment = None
 
     if target_deployment and source_deployment:
-        if target_deployment in source_deployment.get_ancestors(locking=False)\
+        target_dependencies = target_deployment.get_dependencies(locking=False)
+        if source_deployment in target_dependencies\
                 or target_deployment == source_deployment:
             raise manager_exceptions.ConflictError(
                 f'Cyclic dependency between {source_deployment} and '

--- a/rest-service/manager_rest/rest/rest_utils.py
+++ b/rest-service/manager_rest/rest/rest_utils.py
@@ -411,10 +411,11 @@ def update_deployment_dependencies_from_plan(deployment_id,
 
     new_dependencies = deployment_plan.setdefault(
         INTER_DEPLOYMENT_FUNCTIONS, [])
+    new_dependencies = _normalize_plan_dependencies(
+        new_dependencies, dep_plan_filter_func)
     source_deployment = storage_manager.get(models.Deployment,
                                             deployment_id,
                                             all_tenants=True)
-    dependents = source_deployment.get_all_dependents()
     for idd in new_dependencies:
         dependency_creator = idd['function_identifier']
         target_deployment_id, target_deployment_func = idd['target_deployment']
@@ -450,10 +451,6 @@ def update_deployment_dependencies_from_plan(deployment_id,
                 or not hasattr(curr_target_deployment, 'id')):
             continue
             # upcoming: handle the case of external dependencies
-        if target_deployment._storage_id in dependents:
-            raise manager_exceptions.ConflictError(
-                f'cyclic dependency between {source_deployment.id} '
-                f'and {target_deployment.id}')
 
 
 def update_inter_deployment_dependencies(sm, deployment):

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -56,6 +56,17 @@ def no_autoflush(f):
     return wrapper
 
 
+class _Transaction(object):
+    """A transaction controller yielded by `sm.transaction()`
+
+    This allows the in-transaction code to force the transaction to commit,
+    even if the block throws an exception (which would cause a rollback
+    instead otherwise).
+    """
+    def __init__(self):
+        self.force_commit = False
+
+
 class SQLStorageManager(object):
     def __init__(self, user=None, tenant=None):
         self._user = user
@@ -101,12 +112,16 @@ class SQLStorageManager(object):
         self._safe_commit()
 
         self._in_transaction = True
+        tx = _Transaction()
         try:
             with db.session.no_autoflush:
-                yield
+                yield tx
         except Exception:
             self._in_transaction = False
-            db.session.rollback()
+            if tx.force_commit:
+                self._safe_commit()
+            else:
+                db.session.rollback()
             raise
         else:
             self._in_transaction = False

--- a/rest-service/manager_rest/test/endpoints/test_permissions.py
+++ b/rest-service/manager_rest/test/endpoints/test_permissions.py
@@ -51,12 +51,17 @@ class TestPermissions(base_test.BaseServerTestCase):
         assert permission_name not in {p['permission'] for p in retrieved}
 
     def test_put_already_existing(self):
-        role = models.Role.query.first()
-        permission = role.permissions[0]
+        role = models.Role(
+            name='test-role',
+            type='tenant_role',
+        )
+        test_permission = 'test-permission'
+        role.permissions.append(models.Permission(name=test_permission))
+        db.session.add(role)
         with pytest.raises(CloudifyClientError) as cm:
             self.client.permissions.add(
                 role=role.name,
-                permission=permission.name,
+                permission=test_permission,
             )
         assert cm.value.status_code == 409
 

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_modification.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_modification.py
@@ -541,3 +541,126 @@ workflows:
         assert cm.exception.error_code == 'unavailable_workflow_error'
         self._do_update(deployment.id, BLUEPRINT_ID)
         self.execute_workflow('wf1', deployment.id)  # doesn't throw
+
+    def test_parent_child(self):
+        env_bp = """
+tosca_definitions_version: cloudify_dsl_1_5
+imports:
+    - cloudify/types/types.yaml
+inputs:
+    inp1: {}
+capabilities:
+    cap1:
+        value: {get_input: inp1}
+    cap2:
+        value: other value
+"""
+        srv_bp = """
+tosca_definitions_version: cloudify_dsl_1_5
+imports:
+    - cloudify/types/types.yaml
+inputs:
+    inp1: {}
+outputs:
+    out1:
+        value:
+            get_capability:
+                - {get_label: [csys-obj-parent, 0]}
+                - {get_input: inp1}
+"""
+        self.upload_blueprint_resource(
+            self.make_yaml_file(env_bp),
+            blueprint_id='bp1',
+        )
+        self.upload_blueprint_resource(
+            self.make_yaml_file(srv_bp),
+            blueprint_id='bp2',
+        )
+        dep1 = self.deploy(
+            blueprint_id='bp1',
+            deployment_id='d1',
+            deployment_labels=[{'csys-obj-type': 'environment'}],
+            inputs={'inp1': 'capability value'},
+        )
+        dep2 = self.deploy(
+            blueprint_id='bp2',
+            deployment_id='d2',
+            deployment_labels=[{'csys-obj-parent': 'd1'}],
+            inputs={'inp1': 'cap1'},
+            runtime_only_evaluation=True,
+        )
+        outs = self.client.deployments.outputs.get(dep2.id).outputs
+        assert outs['out1'] == 'capability value'
+
+        new_inputs = {'inp1': 'capability2 value'}
+        with self.assertRaisesRegex(
+            CloudifyClientError,
+            'existing installations'
+        ):
+            self._do_update(dep1.id, inputs=new_inputs)
+        self._do_update(dep1.id, inputs=new_inputs, force=True)
+        outs = self.client.deployments.outputs.get(dep2.id).outputs
+        assert outs['out1'] == 'capability2 value'
+        self._do_update(dep2.id, inputs={'inp1': 'cap2'})
+        outs = self.client.deployments.outputs.get(dep2.id).outputs
+        assert outs['out1'] == 'other value'
+
+    def test_environment_sharedresource(self):
+        env_bp = """
+tosca_definitions_version: cloudify_dsl_1_5
+imports:
+  - cloudify/types/types.yaml
+capabilities:
+  cap1:
+    value: value1
+  cap2:
+    value: value2
+"""
+        srv_bp = """
+tosca_definitions_version: cloudify_dsl_1_5
+imports:
+  - cloudify/types/types.yaml
+inputs:
+    inp1: {}
+
+node_templates:
+  env:
+    type: cloudify.nodes.SharedResource
+    properties:
+      resource_config:
+        deployment:
+          id: { get_label: [csys-obj-parent, 0] }
+outputs:
+    out1:
+        value: {get_capability: [d1, {get_input: inp1} ]}
+"""
+        self.upload_blueprint_resource(
+            self.make_yaml_file(env_bp),
+            blueprint_id='bp1',
+        )
+        self.upload_blueprint_resource(
+            self.make_yaml_file(srv_bp),
+            blueprint_id='bp2',
+        )
+        dep1 = self.deploy(
+            blueprint_id='bp1',
+            deployment_id='d1',
+            deployment_labels=[{'csys-obj-type': 'environment'}],
+        )
+        self.execute_workflow('install', dep1.id)
+        dep2 = self.deploy(
+            blueprint_id='bp2',
+            deployment_id='d2',
+            deployment_labels=[{'csys-obj-parent': 'd1'}],
+            inputs={'inp1': 'cap1'},
+            runtime_only_evaluation=True,
+        )
+        self.execute_workflow('install', dep2.id)
+
+        outs = self.client.deployments.outputs.get(dep2.id).outputs
+        assert outs['out1'] == 'value1'
+
+        self._do_update(dep2.id, inputs={'inp1': 'cap2'})
+
+        outs = self.client.deployments.outputs.get(dep2.id).outputs
+        assert outs['out1'] == 'value2'

--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_modification.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_modification.py
@@ -459,14 +459,14 @@ class TestDeploymentUpdateModification(DeploymentUpdateBase):
         deployment, modified_bp_path = \
             self._deploy_and_get_modified_bp_path('modify_description')
 
-        self.assertRegexpMatches(deployment['description'], 'old description')
+        assert deployment['description'].strip() == 'old description'
 
         self.client.blueprints.upload(modified_bp_path, BLUEPRINT_ID)
         wait_for_blueprint_upload(BLUEPRINT_ID, self.client)
         self._do_update(deployment.id, BLUEPRINT_ID)
 
         deployment = self.client.deployments.get(deployment.id)
-        self.assertRegexpMatches(deployment['description'], 'new description')
+        assert deployment['description'].strip() == 'new description'
 
     def test_modify_inputs_ops_order(self):
         """Verify that update workflow executes uninstall and install."""

--- a/tests/integration_tests/tests/agentless_tests/test_deployment_workflows.py
+++ b/tests/integration_tests/tests/agentless_tests/test_deployment_workflows.py
@@ -40,10 +40,11 @@ class TestDeploymentWorkflows(AgentlessTestCase):
         deployment, _ = self.deploy_application(dsl_path)
         deployment_id = deployment.id
         workflows = self.client.deployments.get(deployment_id).workflows
-        self.assertEqual(15, len(workflows))
+        self.assertEqual(16, len(workflows))
         wf_ids = [x.name for x in workflows]
         self.assertIn('uninstall', wf_ids)
         self.assertIn('install', wf_ids)
+        self.assertIn('reinstall', wf_ids)
         self.assertIn('execute_operation', wf_ids)
         self.assertIn('custom', wf_ids)
         self.assertIn('scale', wf_ids)

--- a/tests/integration_tests/tests/test_cases.py
+++ b/tests/integration_tests/tests/test_cases.py
@@ -162,16 +162,19 @@ class BaseTestCase(unittest.TestCase):
                 timeout_seconds=timeout_seconds)
         return execution
 
-    def deploy(self,
-               dsl_path=None,
-               blueprint_id=None,
-               deployment_id=None,
-               inputs=None,
-               wait=True,
-               client=None,
-               runtime_only_evaluation=False,
-               blueprint_visibility=None,
-               deployment_visibility=None):
+    def deploy(
+        self,
+        dsl_path=None,
+        blueprint_id=None,
+        deployment_id=None,
+        inputs=None,
+        wait=True,
+        client=None,
+        runtime_only_evaluation=False,
+        blueprint_visibility=None,
+        deployment_visibility=None,
+        deployment_labels=None,
+    ):
         if not (dsl_path or blueprint_id):
             raise RuntimeWarning('Please supply blueprint path '
                                  'or blueprint id for deploying')
@@ -199,7 +202,8 @@ class BaseTestCase(unittest.TestCase):
             'deployment_id': deployment_id,
             'inputs': inputs,
             'skip_plugins_validation': True,
-            'runtime_only_evaluation': runtime_only_evaluation
+            'runtime_only_evaluation': runtime_only_evaluation,
+            'labels': deployment_labels,
         }
         # If not provided, use the client's default
         if deployment_visibility:


### PR DESCRIPTION
The first commit message explains most of it. It's still ugly/wrong, but it's better than before, and it does fix the specific case...

Please do read commit and commit messages separately, there's quite several things here:
- the cyclic check itself
- some tests
- better error reporting for the dep-update failure (due to dependency errors)
- another IDD fixup (snap-restore-related)
- some cleanups
- also at the end, fixups to tests that are... well, unrelated, but I want to have the tests green already :P