### PR TITLE
RD-5507 Pop id-s from search constraints

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/searches.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/searches.py
@@ -569,10 +569,10 @@ def retrieve_constraints(id_required=False):
         raise manager_exceptions.BadParametersError(
             "You should provide either a valid 'blueprint_id' parameter "
             "or have a 'blueprint_id' key in the constraints, not both.")
-    deployment_id = args.get('deployment_id') \
-        or constraints.get('deployment_id')
-    blueprint_id = args.get('blueprint_id') \
-        or constraints.get('blueprint_id')
+    deployment_id = \
+        args.get('deployment_id') or constraints.pop('deployment_id', None)
+    blueprint_id = \
+        args.get('blueprint_id') or constraints.pop('blueprint_id', None)
     if (constraints or id_required) \
             and not deployment_id and not blueprint_id:
         raise manager_exceptions.BadParametersError(


### PR DESCRIPTION
This will prevent having both `deployment_id` set and having a `deployment_id` key in `constraints` (which led to problems later in `scaling_group_name_matches()` function).