### PR TITLE
RD-6493 Replace no_external_authenticator with check_external_authenticator

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3/tenants.py
+++ b/rest-service/manager_rest/rest/resources_v3/tenants.py
@@ -151,7 +151,7 @@ class TenantsId(SecuredMultiTenancyResource):
 class TenantUsers(SecuredMultiTenancyResource):
     @authorize('tenant_add_user', get_tenant_from='data')
     @rest_decorators.marshal_with(TenantResponse)
-    @rest_decorators.no_external_authenticator('add user to tenant')
+    @rest_decorators.check_external_authenticator('add user to tenant')
     def put(self, multi_tenancy):
         """
         Add a user to a tenant
@@ -184,7 +184,7 @@ class TenantUsers(SecuredMultiTenancyResource):
 
     @authorize('tenant_update_user', get_tenant_from='data')
     @rest_decorators.marshal_with(TenantResponse)
-    @rest_decorators.no_external_authenticator('update user in tenant')
+    @rest_decorators.check_external_authenticator('update user in tenant')
     def patch(self, multi_tenancy):
         """Update role in user tenant association."""
         request_dict = rest_utils.get_json_and_verify_params(
@@ -210,7 +210,7 @@ class TenantUsers(SecuredMultiTenancyResource):
         )
 
     @authorize('tenant_remove_user', get_tenant_from='data')
-    @rest_decorators.no_external_authenticator('remove user from tenant')
+    @rest_decorators.check_external_authenticator('remove user from tenant')
     def delete(self, multi_tenancy):
         """
         Remove a user from a tenant

--- a/rest-service/manager_rest/rest/resources_v3/user_groups.py
+++ b/rest-service/manager_rest/rest/resources_v3/user_groups.py
@@ -115,7 +115,7 @@ class UserGroupsId(SecuredMultiTenancyResource):
 class UserGroupsUsers(SecuredMultiTenancyResource):
     @authorize('user_group_add_user')
     @rest_decorators.marshal_with(GroupResponse)
-    @rest_decorators.no_external_authenticator('add user to group')
+    @rest_decorators.check_external_authenticator('add user to group')
     def put(self, multi_tenancy):
         """
         Add a user to a group

--- a/rest-service/manager_rest/rest/resources_v3/users.py
+++ b/rest-service/manager_rest/rest/resources_v3/users.py
@@ -53,7 +53,7 @@ class Users(SecuredMultiTenancyResource):
 
     @authorize('user_create')
     @rest_decorators.marshal_with(UserResponse)
-    @rest_decorators.no_external_authenticator('create user')
+    @rest_decorators.check_external_authenticator('create user')
     def put(self, multi_tenancy):
         """
         Create a user


### PR DESCRIPTION
Now, those actions will be possibly allowed by the external auth! External auth handler can now return a "handler" for any of those actions.
If they don't (which is the default, authenticators need to opt-in), then the action is still disallowed.