### PR TITLE
Blueprint upload: on skip_execution, still store the files

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -176,9 +176,10 @@ class BlueprintsId(resources_v2.BlueprintsId):
                     blueprint_id,
                     application_file_name,
                     blueprint_url,
-                    config.instance.file_server_root,     # for the import resolver
-                    config.instance.marketplace_api_url,  # for the import resolver
                     labels=labels,
+                    # for the import resolver
+                    file_server_root=config.instance.file_server_root,
+                    marketplace_api_url=config.instance.marketplace_api_url,
                 )
             else:
                 messages = []

--- a/rest-service/manager_rest/rest/resources_v3_1/operations.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/operations.py
@@ -433,7 +433,7 @@ class TasksGraphsId(SecuredResource):
             'graph_id': {'optional': True},
         })
         created_at = params.get('created_at')
-        operations = params.get('operations', [])
+        operations = params.get('operations') or []
         if params.get('graph_id'):
             check_user_action_allowed('set_execution_details')
         if created_at or any(op.get('created_at') for op in operations):

--- a/rest-service/manager_rest/test/endpoints/test_blueprints.py
+++ b/rest-service/manager_rest/test/endpoints/test_blueprints.py
@@ -216,6 +216,21 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
         self.assertEqual('b1', blueprints[0].id)
         self.assertEqual('b0', blueprints[1].id)
 
+    def test_upload_skip_execution(self):
+        bp_path = os.path.join(
+            self.get_blueprint_path('mock_blueprint'),
+            'blueprint_with_inputs.yaml',
+        )
+        self.client.blueprints.upload(bp_path, 'b0', skip_execution=True)
+
+        bp = self.client.blueprints.get('b0')
+        assert not self.client.executions.list(workflow_id='upload_blueprint')
+
+        outfile = os.path.join(self.tmpdir, 'skip-execution-blueprint')
+        self.addCleanup(self.quiet_delete, outfile)
+        self.client.blueprints.download('b0', output_file=outfile)
+        assert os.path.exists(outfile)
+
     def test_blueprint_download_progress(self):
         tmp_dir = '/tmp/tmp_upload_blueprint'
         tmp_local_path = '/tmp/blueprint.bl'

--- a/rest-service/manager_rest/test/endpoints/test_blueprints.py
+++ b/rest-service/manager_rest/test/endpoints/test_blueprints.py
@@ -223,7 +223,6 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
         )
         self.client.blueprints.upload(bp_path, 'b0', skip_execution=True)
 
-        bp = self.client.blueprints.get('b0')
         assert not self.client.executions.list(workflow_id='upload_blueprint')
 
         outfile = os.path.join(self.tmpdir, 'skip-execution-blueprint')


### PR DESCRIPTION
Even when skip_execution is passed, we still want to call the upload_blueprint_archive_to_file_server function.

And then, we won't have any messages to send. And that also implies async_upload, as in, there's nothing to wait _for_.