### PR TITLE
Several test cleanups: drop server.reset_app

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/status.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/status.py
@@ -186,7 +186,7 @@ def _lookup_supervisor_service_status(service_name):
 def _check_rabbitmq(services):
     name = 'RabbitMQ'
     try:
-        with get_amqp_client():
+        with get_amqp_client(connect_timeout=3):
             extra_info = {'connection_check': ServiceStatus.HEALTHY}
             _add_or_update_service(services,
                                    name,

--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -243,12 +243,6 @@ class CloudifyFlaskApp(Flask):
 app: CloudifyFlaskApp
 
 
-def reset_app(configuration=None):
-    global app
-    config.reset(configuration)
-    app = CloudifyFlaskApp(False)
-
-
 def _detect_debug_environment():
     """
     Detect whether server is running in a debug environment

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -1036,36 +1036,3 @@ class BaseServerTestCase(unittest.TestCase):
         self.client.users.create(username, password, role='default')
         self.client.tenants.add_user(username, tenant, role=role)
         return self.create_client_with_tenant(username, password)
-
-    def _put_mock_blueprint(self):
-        blueprint_id = str(uuid.uuid4())
-        now = utils.get_formatted_timestamp()
-        return self.sm.put(
-            models.Blueprint(
-                id=blueprint_id,
-                created_at=now,
-                updated_at=now,
-                main_file_name='abcd',
-                plan={})
-        )
-
-    @staticmethod
-    def _get_mock_deployment(deployment_id, blueprint):
-        now = utils.get_formatted_timestamp()
-        deployment = models.Deployment(
-            id=deployment_id,
-            display_name=deployment_id,
-            created_at=now,
-            updated_at=now,
-        )
-        deployment.blueprint = blueprint
-        return deployment
-
-    def put_mock_deployments(self, source_deployment, target_deployment):
-        blueprint = self._put_mock_blueprint()
-        source_deployment = self._get_mock_deployment(source_deployment,
-                                                      blueprint)
-        self.sm.put(source_deployment)
-        target_deployment = self._get_mock_deployment(target_deployment,
-                                                      blueprint)
-        self.sm.put(target_deployment)

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -136,6 +136,24 @@ class TestClient(FlaskClient):
         return super(TestClient, self).open(*args, **kwargs)
 
 
+
+def copy_resources(file_server_root):
+    resources_path = os.path.normpath(os.path.join(
+        # rest-service/manager-rest/tests/
+        os.path.dirname(os.path.abspath(__file__)),
+        '..',  # rest-service/manager-rest/
+        '..',  # rest-service/
+        '..',  # repo root
+        'resources',
+        'rest-service',
+        'cloudify',
+    ))
+    shutil.copytree(
+        resources_path,
+        os.path.join(file_server_root, 'cloudify'),
+    )
+
+
 class BaseServerTestCase(unittest.TestCase):
     client: CloudifyClient
     app: server.CloudifyFlaskApp

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -292,7 +292,8 @@ class BaseServerTestCase(unittest.TestCase):
         for patcher in cls._patchers:
             patcher.start()
 
-        cls._reset_app()
+        copy_resources(cls.server_configuration.file_server_root)
+        server.app = server.CloudifyFlaskApp(False)
         cls._handle_flask_app_and_db()
         cls.client = cls.create_client()
 
@@ -405,13 +406,6 @@ class BaseServerTestCase(unittest.TestCase):
         cls.maintenance_mode_dir = tempfile.mkdtemp(prefix='maintenance-')
         fd, cls.tmp_conf_file = tempfile.mkstemp(prefix='conf-file-')
         os.close(fd)
-
-    @classmethod
-    def _reset_app(cls):
-        utils.copy_resources(cls.server_configuration.file_server_root)
-        server.reset_app(cls.server_configuration)
-
-        cls._set_hash_mechanism_to_plaintext()
 
     @staticmethod
     def _set_hash_mechanism_to_plaintext():

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -136,7 +136,6 @@ class TestClient(FlaskClient):
         return super(TestClient, self).open(*args, **kwargs)
 
 
-
 def copy_resources(file_server_root):
     resources_path = os.path.normpath(os.path.join(
         # rest-service/manager-rest/tests/

--- a/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
@@ -599,6 +599,26 @@ class TestUpdateIDDs(_DependencyTestUtils, BaseServerTestCase):
 
 
 class InterDeploymentDependenciesTest(BaseServerTestCase):
+    def _blueprint(self, **kwargs):
+        blueprint_params = {
+            'id': str(uuid.uuid4()),
+            'plan': {},
+            'creator': self.user,
+            'tenant': self.tenant,
+        }
+        blueprint_params.update(kwargs)
+        return models.Blueprint(**blueprint_params)
+
+    def _deployment(self, **kwargs):
+        deployment_params = {
+            'id': str(uuid.uuid4()),
+            'blueprint': self.bp,
+            'creator': self.user,
+            'tenant': self.tenant,
+        }
+        deployment_params.update(kwargs)
+        return models.Deployment(**deployment_params)
+
     def setUp(self):
         super(InterDeploymentDependenciesTest, self).setUp()
         self.dependency_creator = 'dependency_creator'
@@ -619,8 +639,9 @@ class InterDeploymentDependenciesTest(BaseServerTestCase):
             self.source_deployment,
             self.source_deployment,
         )
-        self.put_mock_deployments(self.source_deployment,
-                                  self.target_deployment)
+        self.bp = self._blueprint()
+        self._deployment(id=self.source_deployment)
+        self._deployment(id=self.target_deployment)
 
     def test_adds_dependency_and_retrieves_it(self):
         dependency = self.client.inter_deployment_dependencies.create(
@@ -756,9 +777,8 @@ class InterDeploymentDependenciesTest(BaseServerTestCase):
                                            'infra'))
 
     def _populate_dependencies_table(self):
-        self.put_mock_deployments('0', '1')
-        self.put_mock_deployments('2', '3')
-        self.put_mock_deployments('4', '5')
+        for mock_dep_id in ('0', '1', '2', '3', '4', '5'):
+            self._deployment(id=mock_dep_id)
         self.client.inter_deployment_dependencies.create(
             **create_deployment_dependency('sample.vm', '1', '0'))
         self.client.inter_deployment_dependencies.create(

--- a/rest-service/manager_rest/upload_manager/manager.py
+++ b/rest-service/manager_rest/upload_manager/manager.py
@@ -19,11 +19,7 @@ from manager_rest.dsl_back_compat import create_bc_plugin_yaml
 from manager_rest.archiving import get_archive_type
 from manager_rest.storage.models import Blueprint
 from manager_rest import config, manager_exceptions
-from manager_rest.utils import (mkdirs,
-                                current_tenant,
-                                unzip,
-                                files_in_folder,
-                                remove)
+from manager_rest.utils import current_tenant, unzip, files_in_folder, remove
 from manager_rest.resource_manager import get_resource_manager
 from manager_rest.constants import (SUPPORTED_ARCHIVE_TYPES)
 from manager_rest.upload_manager.storage import storage_client
@@ -181,7 +177,10 @@ def _update_blueprint_archive(tenant_name, blueprint_id):
             with storage_client().get(src_file_path) as tmp_file_name:
                 dst_dir_path = os.path.dirname(file_rel_path)
                 if dst_dir_path:
-                    mkdirs(os.path.join(tmpdir, 'blueprint', dst_dir_path))
+                    os.makedirs(
+                        os.path.join(tmpdir, 'blueprint', dst_dir_path),
+                        exist_ok=True,
+                    )
                 shutil.copy2(tmp_file_name, dst_file_path)
 
         with tempfile.NamedTemporaryFile(dir=file_server_root) as fh:

--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -61,17 +61,6 @@ def is_sanity_mode():
     return os.path.isfile(constants.SANITY_MODE_FILE_PATH)
 
 
-
-def mkdirs(folder_path):
-    try:
-        makedirs(folder_path)
-    except OSError as exc:
-        if exc.errno == errno.EEXIST and path.isdir(folder_path):
-            pass
-        else:
-            raise
-
-
 def create_filter_params_list_description(parameters, list_type):
     return [{'name': filter_val,
              'description': 'List {type} matching the \'{filter}\' '

--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -1,14 +1,12 @@
 import os
 import re
 import glob
-import errno
 import shutil
 import zipfile
 import tempfile
 from dateutil import rrule
 from base64 import b64encode
 from datetime import datetime
-from os import path, makedirs
 from dateutil import parser as date_parser
 
 from flask import g

--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -268,16 +268,17 @@ def extract_host_agent_plugins_from_plan(plan):
     return host_agent_plugins_to_install
 
 
-def get_amqp_client():
+def get_amqp_client(tenant=None, connect_timeout=None):
+    vhost = '/' if tenant is None else tenant.rabbitmq_vhost
     return get_client(
         amqp_host=config.instance.amqp_host,
         amqp_user=config.instance.amqp_username,
         amqp_pass=config.instance.amqp_password,
         amqp_port=BROKER_PORT_SSL,
-        amqp_vhost='/',
+        amqp_vhost=vhost,
         ssl_enabled=True,
         ssl_cert_data=config.instance.amqp_ca,
-        connect_timeout=3,
+        connect_timeout=connect_timeout,
     )
 
 

--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -61,18 +61,6 @@ def is_sanity_mode():
     return os.path.isfile(constants.SANITY_MODE_FILE_PATH)
 
 
-def copy_resources(file_server_root, resources_path=None):
-    if resources_path is None:
-        resources_path = path.abspath(__file__)
-        for i in range(3):
-            resources_path = path.dirname(resources_path)
-        resources_path = path.join(resources_path, 'resources')
-    cloudify_resources = path.join(resources_path,
-                                   'rest-service',
-                                   'cloudify')
-    shutil.copytree(cloudify_resources, path.join(file_server_root,
-                                                  'cloudify'))
-
 
 def mkdirs(folder_path):
     try:

--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -12,8 +12,9 @@ from cloudify.constants import (
     EVENTS_EXCHANGE_NAME,
 )
 
-from manager_rest import config, utils
+from manager_rest import config
 from manager_rest.storage import get_storage_manager, models
+from manager_rest.utils import current_tenant, get_amqp_client
 
 
 def get_amqp_handler(kind):
@@ -58,22 +59,7 @@ def send_hook(event):
 
 
 def _get_tenant_dict():
-    return {'name': utils.current_tenant.name}
-
-
-def get_amqp_client(tenant=None):
-    vhost = '/' if tenant is None else tenant.rabbitmq_vhost
-    client = get_client(
-        amqp_host=config.instance.amqp_host,
-        amqp_user=config.instance.amqp_username,
-        amqp_pass=config.instance.amqp_password,
-        amqp_port=BROKER_PORT_SSL,
-        amqp_vhost=vhost,
-        ssl_enabled=True,
-        ssl_cert_data=config.instance.amqp_ca,
-        connect_timeout=None,
-    )
-    return client
+    return {'name': current_tenant.name}
 
 
 def workflow_sendhandler() -> SendHandler:
@@ -232,7 +218,7 @@ def delete_source_plugins(deployment_id):
                 'task_name': 'delete-source-plugins',
                 'kwargs': {
                     'deployment_id': deployment_id,
-                    'tenant_name': utils.current_tenant.name
+                    'tenant_name': current_tenant.name
                 }
             }
         })

--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -4,15 +4,10 @@ from flask import current_app
 from flask_security import current_user
 
 from cloudify import logs
-from cloudify.amqp_client import get_client, SendHandler
+from cloudify.amqp_client import SendHandler
 from cloudify.models_states import PluginInstallationState
-from cloudify.constants import (
-    MGMTWORKER_QUEUE,
-    BROKER_PORT_SSL,
-    EVENTS_EXCHANGE_NAME,
-)
+from cloudify.constants import MGMTWORKER_QUEUE, EVENTS_EXCHANGE_NAME
 
-from manager_rest import config
 from manager_rest.storage import get_storage_manager, models
 from manager_rest.utils import current_tenant, get_amqp_client
 


### PR DESCRIPTION
Some cleanups, mainly around the tests (commits describe each change):
- drop reset_app
- simplify copy_resources
- drop put_mock_deployments
- drop utils.mkdirs
- deduplicate get_amqp_client

