### PR TITLE
RD-6288 dep-update: bring back `reinstall_list`

### DIFF
--- a/mgmtworker/cloudify_system_workflows/deployment_update/update_instances.py
+++ b/mgmtworker/cloudify_system_workflows/deployment_update/update_instances.py
@@ -281,7 +281,7 @@ def update_or_reinstall_instances(ctx, graph, dep_up, install_params):
 
     must_reinstall -= to_skip
     if install_params.skip_reinstall:
-       must_reinstall = force_reinstall_instances
+        must_reinstall = force_reinstall_instances
     if must_reinstall:
         intact_nodes = (
             set(workflow_ctx.node_instances)

--- a/mgmtworker/cloudify_system_workflows/deployment_update/update_instances.py
+++ b/mgmtworker/cloudify_system_workflows/deployment_update/update_instances.py
@@ -177,7 +177,7 @@ def _clean_drift(ctx, instance):
 
 def update_or_reinstall_instances(ctx, graph, dep_up, install_params):
     to_skip = set(install_params.added_instances) \
-              | set(install_params.removed_instances)
+        | set(install_params.removed_instances)
     # update must not touch instances that weren't installed previously
     to_skip |= {
         ni for ni in workflow_ctx.node_instances
@@ -186,7 +186,12 @@ def update_or_reinstall_instances(ctx, graph, dep_up, install_params):
     consider_for_update = set(workflow_ctx.node_instances) - to_skip
     changed_instances = _find_changed_instances(dep_up.steps) - to_skip
 
-    must_reinstall = set()
+    force_reinstall_instances = {
+        inst for inst in consider_for_update
+        if inst.id in install_params.force_reinstall_ids
+    }
+    must_reinstall = set(force_reinstall_instances)
+    consider_for_update -= force_reinstall_instances
     instances_with_drift = set()
 
     if not install_params.skip_drift_check:
@@ -275,7 +280,9 @@ def update_or_reinstall_instances(ctx, graph, dep_up, install_params):
         must_reinstall |= failed_update
 
     must_reinstall -= to_skip
-    if must_reinstall and not install_params.skip_reinstall:
+    if install_params.skip_reinstall:
+       must_reinstall = force_reinstall_instances
+    if must_reinstall:
         intact_nodes = (
             set(workflow_ctx.node_instances)
             - must_reinstall

--- a/mgmtworker/cloudify_system_workflows/deployment_update/workflow.py
+++ b/mgmtworker/cloudify_system_workflows/deployment_update/workflow.py
@@ -745,11 +745,13 @@ class InstallParameters:
     skip_drift_check: bool
     force_reinstall: bool
     skip_heal: bool
+    force_reinstall_ids: list
 
     def __init__(self, ctx, update_params, dep_update):
         self._update_instances = dep_update['deployment_update_node_instances']
         self.update_id = dep_update.id
         self.steps = dep_update.steps
+        self.force_reinstall_ids = update_params.get('reinstall_list') or set()
 
         for kind in ['added', 'removed', 'extended', 'reduced']:
             changed, related = self._split_by_modification(

--- a/mgmtworker/cloudify_system_workflows/tests/deployment_update/blueprints/minimal_types.yaml
+++ b/mgmtworker/cloudify_system_workflows/tests/deployment_update/blueprints/minimal_types.yaml
@@ -16,3 +16,9 @@ workflows:
       force_reinstall:
         type: boolean
         default: false
+      skip_reinstall:
+        type: boolean
+        default: false
+      reinstall_list:
+        type: list
+        default: []

--- a/mgmtworker/cloudify_system_workflows/tests/deployment_update/test_workflow.py
+++ b/mgmtworker/cloudify_system_workflows/tests/deployment_update/test_workflow.py
@@ -111,6 +111,39 @@ def test_update_operation(subtests, blueprint_filename, parameters, install):
             assert actual_calls == expected_calls
 
 
+def test_reinstall_list():
+    storage = deploy('force_reinstall.yaml', resource_id='d1', inputs={
+        'inp1': 'value1',
+    })
+    dep_env = local.load_env('d1', storage)
+    dep_env.execute('install')
+
+    instances = dep_env.storage.get_node_instances()
+    assert len(instances) == 1
+    ni_id = instances[0].id
+
+    storage.create_deployment_update('d1', 'update1', {
+        'new_inputs': {'inp1': 'value1'},  # unchanged
+    })
+
+    # updating with reinstall_list, reinstalls that instance, even though
+    # nothing has changed
+    dep_env.execute('update', parameters={
+        'update_id': 'update1',
+        'reinstall_list': [ni_id]
+    })
+    inst = dep_env.storage.get_node_instance(ni_id)
+    assert inst.runtime_properties['invocations'] == ['create']
+
+    # reinstall_list overrides even skip_reinstall!
+    dep_env.execute('update', parameters={
+        'update_id': 'update1',
+        'reinstall_list': [ni_id],
+        'skip_reinstall': True,
+    })
+    inst = dep_env.storage.get_node_instance(ni_id)
+    assert inst.runtime_properties['invocations'] == ['create', 'create']
+
 def op(ctx, return_value=None, fail=False):
     """Operation used in the update-operation test.
 

--- a/mgmtworker/cloudify_system_workflows/tests/deployment_update/test_workflow.py
+++ b/mgmtworker/cloudify_system_workflows/tests/deployment_update/test_workflow.py
@@ -144,6 +144,7 @@ def test_reinstall_list():
     inst = dep_env.storage.get_node_instance(ni_id)
     assert inst.runtime_properties['invocations'] == ['create', 'create']
 
+
 def op(ctx, return_value=None, fail=False):
     """Operation used in the update-operation test.
 

--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -105,6 +105,7 @@ class DeploymentUpdate(SecuredResource):
                 'runtime_only_evaluation': runtime_eval,
                 'force': force,
                 'workflow_id': request.json.get('workflow_id', None),
+                'reinstall_list': reinstall_list,
             }
             # boolean params
             for name, default in [


### PR DESCRIPTION
CLI says:
```
  -r, --reinstall-list TEXT      Node instances ids to be reinstalled as part
                                 of deployment update. They will be
                                 reinstalled even if the flag --skip-reinstall
                                 has been supplied
```

But that was somehow missing from the dep-update. Heh. Now it's back, and now it has a test, too.