### PR TITLE
RD-6633 Update: don't `establish` non-installed relationships

### DIFF
--- a/mgmtworker/cloudify_system_workflows/deployment_update/update_instances.py
+++ b/mgmtworker/cloudify_system_workflows/deployment_update/update_instances.py
@@ -230,7 +230,11 @@ def update_or_reinstall_instances(ctx, graph, dep_up, install_params):
         instances_to_update = set()
 
     if instances_to_update:
-        intact_nodes = set(workflow_ctx.node_instances) - instances_to_update
+        intact_nodes = (
+            set(workflow_ctx.node_instances)
+            - instances_to_update
+            - to_skip
+        )
         clear_graph(graph)
         if not install_params.skip_heal:
             # TODO factor healing out, to make this function shorter
@@ -287,6 +291,7 @@ def update_or_reinstall_instances(ctx, graph, dep_up, install_params):
             set(workflow_ctx.node_instances)
             - must_reinstall
             - set(install_params.removed_instances)
+            - to_skip
         )
         uninstall_ids = {ni.id for ni in install_params.removed_instances}
         for n in must_reinstall:

--- a/mgmtworker/cloudify_system_workflows/tests/deployment_update/blueprints/minimal_types.yaml
+++ b/mgmtworker/cloudify_system_workflows/tests/deployment_update/blueprints/minimal_types.yaml
@@ -5,6 +5,10 @@ plugins:
 workflows:
   install:
     mapping: builtin.cloudify.plugins.workflows.install
+    parameters:
+      node_ids:
+        type: list
+        default: null
   update:
     mapping: builtin.cloudify_system_workflows.deployment_update.workflow.update_deployment
     parameters:
@@ -22,3 +26,30 @@ workflows:
       reinstall_list:
         type: list
         default: []
+relationships:
+  cloudify.relationships.depends_on:
+    source_interfaces:
+      cloudify.interfaces.relationship_lifecycle:
+        # install
+        preconfigure: {}
+        postconfigure: {}
+        establish: {}
+        # uninstall
+        unlink: {}
+        # misc
+        update: {}
+        check_drift: {}
+    target_interfaces:
+      cloudify.interfaces.relationship_lifecycle:
+        # install
+        preconfigure: {}
+        postconfigure: {}
+        establish: {}
+        # uninstall
+        unlink: {}
+        # misc
+        update: {}
+        check_drift: {}
+    properties:
+      connection_type:
+        default: all_to_all

--- a/mgmtworker/cloudify_system_workflows/tests/deployment_update/blueprints/single_relationship.yaml
+++ b/mgmtworker/cloudify_system_workflows/tests/deployment_update/blueprints/single_relationship.yaml
@@ -1,0 +1,31 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - minimal_types.yaml
+
+node_types:
+  t1: {}
+
+node_templates:
+  n1:
+    type: t1
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+        check_drift:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+          inputs:
+            return_value: {"drift": true}
+
+  n2:
+    type: t1
+    relationships:
+      - target: n1
+        type: cloudify.relationships.depends_on
+        source_interfaces:
+          cloudify.interfaces.relationship_lifecycle:
+            establish: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+        target_interfaces:
+          cloudify.interfaces.relationship_lifecycle:
+            establish: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op


### PR DESCRIPTION
When reinstalling a node instance during update, it used to be the case that we would `establish` ALL of its relationships... even if the other side of the relationship was not installed!

That doesn't make sense. Establish a relationships to an uninstalled node?

Instead, when calculating `intact_nodes`, skip ones that aren't ready.