### PR TITLE
RD-6634 Update: run reinstalls before new installs

### DIFF
--- a/mgmtworker/cloudify_system_workflows/deployment_update/workflow.py
+++ b/mgmtworker/cloudify_system_workflows/deployment_update/workflow.py
@@ -368,7 +368,7 @@ def update_deployment_node_instances(*, update_id):
         ]
         workflow_ctx.create_node_instances(
             dep_up.deployment_id,
-            added_instances
+            added_instances,
         )
     if update_instances.get('extended_and_related'):
         for ni in update_instances['extended_and_related']:
@@ -869,6 +869,14 @@ def _execute_deployment_update(ctx, update_id, install_params):
             node_instances=install_params.removed_instances,
             related_nodes=install_params.removed_target_instances,
         )
+
+    update_or_reinstall_instances(
+        ctx,
+        graph,
+        dep_up,
+        install_params,
+    )
+
     if install_params.added and not install_params.skip_install:
         clear_graph(graph)
         lifecycle.install_node_instances(
@@ -879,13 +887,6 @@ def _execute_deployment_update(ctx, update_id, install_params):
     if install_params.extended and not install_params.skip_install:
         clear_graph(graph)
         _establish_relationships(ctx, graph, install_params)
-
-    update_or_reinstall_instances(
-        ctx,
-        graph,
-        dep_up,
-        install_params,
-    )
 
 
 def _execute_custom_workflow(dep_up, workflow_id, install_params,

--- a/mgmtworker/cloudify_system_workflows/tests/deployment_update/blueprints/single_node.yaml
+++ b/mgmtworker/cloudify_system_workflows/tests/deployment_update/blueprints/single_node.yaml
@@ -1,0 +1,19 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - minimal_types.yaml
+
+node_types:
+  t1: {}
+
+node_templates:
+  n1:
+    type: t1
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+        check_drift:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
+          inputs:
+            return_value: {"drift": true}

--- a/mgmtworker/cloudify_system_workflows/tests/deployment_update/blueprints/single_relationship.yaml
+++ b/mgmtworker/cloudify_system_workflows/tests/deployment_update/blueprints/single_relationship.yaml
@@ -20,6 +20,10 @@ node_templates:
 
   n2:
     type: t1
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: builtin.cloudify_system_workflows.tests.deployment_update.test_workflow.op
     relationships:
       - target: n1
         type: cloudify.relationships.depends_on

--- a/mgmtworker/cloudify_system_workflows/tests/deployment_update/test_workflow.py
+++ b/mgmtworker/cloudify_system_workflows/tests/deployment_update/test_workflow.py
@@ -199,7 +199,52 @@ def test_establish_operation():
         'check_drift', 'create', 'target_establish',  # from this update
     ]
     assert n2_instance.runtime_properties['invocations'] == [
-        'source_establish'
+        'source_establish',
+    ]
+
+
+def test_establish_once():
+    """When adding a node, the establish is ran after reinstalls.
+
+    It wouldn't make sense to establish relationships with the newly-added
+    instance, and then reinstall a dependency only to establish them
+    again. Instead, make sure we reinstall existing instances before
+    installing new instances, and so establish only needs to run once.
+    """
+    storage = deploy('single_node.yaml', resource_id='d1')
+    storage.create_blueprint(
+        'bp2',
+        os.path.join(dsl_path_base(), 'single_relationship.yaml'),
+    )
+    dep_env = local.load_env('d1', storage)
+
+    dep_env.execute('install')
+
+    n1_instances = dep_env.storage.get_node_instances(node_id='n1')
+    n2_instances = dep_env.storage.get_node_instances(node_id='n2')
+    assert len(n1_instances) == 1
+    assert len(n2_instances) == 0
+    n1_instance = n1_instances[0]
+    assert n1_instance.state == 'started'
+
+    storage.create_deployment_update('d1', 'update1', {
+        'new_blueprint_id': 'bp2',
+    })
+    dep_env.execute('update', parameters={'update_id': 'update1'})
+
+    n1_instance = dep_env.storage.get_node_instance(n1_instance.id)
+    n2_instances = dep_env.storage.get_node_instances(node_id='n2')
+    assert len(n2_instances) == 1
+    n2_instance = n2_instances[0]
+    assert n2_instance.state == 'started'
+
+    assert n1_instance.runtime_properties['invocations'] == [
+        # establish is AFTER the (re)create
+        'check_drift', 'create', 'target_establish'
+    ]
+    assert n2_instance.runtime_properties['invocations'] == [
+        # establish is AFTER the create
+        'create', 'source_establish'
     ]
 
 


### PR DESCRIPTION
Before, update handled instances in the order of:
1. Uninstall removed instances
1. Install added instances
1. Reinstall/update changed instances

That means if we add an instance, and also change an instance that the added one depends on, we need to run relationship operations twice: once after adding the new instance, and then after reinstalling the dependency.

With this change, we reinstall/update BEFORE installing new instances.
Thanks to this, we only need to run relationship operations once.