### PR TITLE
RD-6635 Component check_drift: handle auto_inc_suffix

### DIFF
--- a/cloudify_types/cloudify_types/component/operations.py
+++ b/cloudify_types/cloudify_types/component/operations.py
@@ -399,9 +399,19 @@ def _diff_blueprint(blueprint_spec, blueprint):
         if spec_blueprint_id != blueprint.id:
             blueprint_drift.append('id')
 
-    spec_blueprint_labels = blueprint_spec.get('labels')
-    if blueprint.labels and spec_blueprint_labels:
-        blueprint_drift.append('labels')
+    if spec_labels := {
+        list(label.items())[0]
+        for label in blueprint_spec.get('labels', [])
+        if label
+    }:
+        blueprint_labels = blueprint.labels or []
+        current_labels = {
+            (label['key'], label['value'])
+            for label in blueprint_labels
+            if not label['key'].startswith('csys-')
+        }
+        if current_labels != spec_labels:
+            blueprint_drift.append('labels')
     return blueprint_drift
 
 

--- a/cloudify_types/cloudify_types/component/operations.py
+++ b/cloudify_types/cloudify_types/component/operations.py
@@ -351,6 +351,12 @@ def _diff_deployment(deployment_spec, deployment):
         return deployment_drift
 
     deployment_id = deployment.id
+    if deployment_spec.get('auto_inc_suffix'):
+        # if we created the deployment with auto_inc_suffix, the actual
+        # deployment id is going to be `<dep_id>-<number>`, while in
+        # node properties we only store the base "dep_id". Consider that
+        # not drifted.
+        deployment_id, _, _suffix = deployment_id.rpartition('-')
 
     if spec_deployment_id := deployment_spec.get('id'):
         if deployment_id != spec_deployment_id:

--- a/cloudify_types/cloudify_types/component/operations.py
+++ b/cloudify_types/cloudify_types/component/operations.py
@@ -338,6 +338,67 @@ def refresh(**kwargs):
     populate_runtime_with_wf_results(client, deployment_id)
 
 
+def _diff_deployment(deployment_spec, deployment):
+    """Return the names of attributes that drifted in the deployment
+
+    :param deployment_spec: the specification of the deployment as given in
+        node properties.resource_config
+    :param deployment: actual deployment
+    :return: list of attribute names, e.g. ["id", "labels"]
+    """
+    deployment_drift = []
+    if not deployment_spec:
+        return deployment_drift
+
+    deployment_id = deployment.id
+
+    if spec_deployment_id := deployment_spec.get('id'):
+        if deployment_id != spec_deployment_id:
+            deployment_drift.append('id')
+
+    if spec_labels := {
+        list(label.items())[0]
+        for label in deployment_spec.get('labels', [])
+        if label
+    }:
+        deployment_labels = deployment.labels or []
+        current_labels = {
+            (label['key'], label['value'])
+            for label in deployment_labels
+            if not label['key'].startswith('csys-')
+        }
+        if current_labels != spec_labels:
+            deployment_drift.append('labels')
+
+    if spec_inputs := deployment_spec.get('inputs'):
+        if spec_inputs != deployment.inputs:
+            deployment_drift.append('inputs')
+
+    return deployment_drift
+
+
+def _diff_blueprint(blueprint_spec, blueprint):
+    """Return the names of attributes that drifted in the blueprint
+
+    :param blueprint_spec: the specification of the blueprint as given in
+        node properties.resource_config
+    :param deployment: actual blueprint
+    :return: list of attribute names, e.g. ["id", "labels"]
+    """
+    blueprint_drift = []
+    if not blueprint_spec:
+        return blueprint_spec
+
+    if spec_blueprint_id := blueprint_spec.get('id'):
+        if spec_blueprint_id != blueprint.id:
+            blueprint_drift.append('id')
+
+    spec_blueprint_labels = blueprint_spec.get('labels')
+    if blueprint.labels and spec_blueprint_labels:
+        blueprint_drift.append('labels')
+    return blueprint_drift
+
+
 @operation(resumable=True)
 def check_drift(timeout=EXECUTIONS_TIMEOUT, **kwargs):
     deployment_id = current_deployment_id(**kwargs)
@@ -373,39 +434,16 @@ def check_drift(timeout=EXECUTIONS_TIMEOUT, **kwargs):
     if modified_keys:
         drift['capabilities'] = modified_keys
 
-    # Discover the properties drift - the deployment
-    new_deployment_properties = node_properties.get('deployment', {})
-    modified_keys = list(dict_sum_diff(
-        {
-            'id': deployment_id,
-            'inputs': deployment.inputs,
-            'labels': [{label['key']: label['value']}
-                       for label in deployment.labels
-                       if not label['key'].startswith('csys-')],
-        },
-        {
-            'id': new_deployment_properties.get('id', deployment_id),
-            'inputs': new_deployment_properties.get('inputs', {}),
-            'labels': new_deployment_properties.get('labels', []),
-        },
-    ))
-    if modified_keys:
-        drift['deployment'] = modified_keys
-
-    # Discover the properties drift, starting with blueprint
-    new_blueprint_properties = node_properties.get('blueprint', {})
-    modified_keys = list(dict_sum_diff(
-        {
-            'id': blueprint.id,
-            'labels': blueprint.labels,
-        },
-        {
-            'id': new_blueprint_properties.get('id', blueprint.id),
-            'labels': new_blueprint_properties.get('labels', []),
-        },
-    ))
-    if modified_keys:
-        drift['blueprint'] = modified_keys
+    if deployment_drift := _diff_deployment(
+        node_properties.get('deployment', {}),
+        deployment,
+    ):
+        drift['deployment'] = deployment_drift
+    if blueprint_drift := _diff_blueprint(
+        node_properties.get('blueprint', {}),
+        blueprint,
+    ):
+        drift['blueprint'] = blueprint_drift
 
     return drift or None
 

--- a/cloudify_types/cloudify_types/component/tests/base_test_suite.py
+++ b/cloudify_types/cloudify_types/component/tests/base_test_suite.py
@@ -45,10 +45,7 @@ class ComponentTestBase(TestCase):
 
     def setUp(self, context_data=COMPONENT_PROPS):
         super(ComponentTestBase, self).setUp()
-        self._ctx = self.get_mock_ctx('test', COMPONENT_PROPS)
-        self._ctx.logger.log = mock.MagicMock(return_value=None)
-        self._ctx.logger.info = mock.MagicMock(return_value=None)
-        current_ctx.set(self._ctx)
+        self._ctx = self.get_mock_ctx('test', context_data)
         self.cfy_mock_client = MockCloudifyRestClient()
 
     def tearDown(self):
@@ -70,4 +67,7 @@ class ComponentTestBase(TestCase):
         )
         ctx.operation._operation_context = {'name': 'some.test'}
 
+        ctx.logger.log = mock.MagicMock(return_value=None)
+        ctx.logger.info = mock.MagicMock(return_value=None)
+        current_ctx.set(ctx)
         return ctx

--- a/cloudify_types/cloudify_types/component/tests/client_mock.py
+++ b/cloudify_types/cloudify_types/component/tests/client_mock.py
@@ -16,10 +16,15 @@ import datetime
 
 from unittest.mock import MagicMock, Mock
 
+from cloudify_rest_client.blueprints import Blueprint
+from cloudify_rest_client.deployments import Deployment
+from cloudify_rest_client.executions import Execution
+from cloudify_rest_client.secrets import Secret
 from cloudify_rest_client.responses import ListResponse
 
 
 class BaseMockClient(object):
+    item_cls = dict
     existing_objects = []
 
     def set_existing_objects(self, existing_objects):
@@ -38,22 +43,21 @@ class BaseMockClient(object):
     def get(self, object_id, **kwargs):
         for obj in self.existing_objects:
             if obj['id'] == object_id:
-                return obj
+                return self.item_cls(obj)
 
     def delete(self, *_, **__):
         return None
 
 
 class MockBlueprintsClient(BaseMockClient):
+    item_cls = Blueprint
 
     def _upload(self, *_, **__):
         return MagicMock(return_value={'id': 'test'})
 
-    def get(self, *_, **__):
-        return {'state': 'uploaded'}
-
 
 class MockDeploymentsClient(BaseMockClient):
+    item_cls = Deployment
 
     def __init__(self):
         super(MockDeploymentsClient, self).__init__()
@@ -68,6 +72,7 @@ class MockDeploymentsClient(BaseMockClient):
 
 
 class MockExecutionsClient(BaseMockClient):
+    item_cls = Execution
 
     def start(self, *_, **__):
         _return_value = {
@@ -90,7 +95,7 @@ class MockEventsClient(BaseMockClient):
 
 
 class MockSecretsClient(BaseMockClient):
-    pass
+    item_cls = Secret
 
 
 class MockDeploymentCapabilitiesClient(BaseMockClient):
@@ -109,3 +114,4 @@ class MockCloudifyRestClient(object):
         self.secrets = MockSecretsClient()
         self.plugins = MagicMock()
         self.inter_deployment_dependencies = Mock()
+        self.node_instances = Mock()

--- a/cloudify_types/cloudify_types/component/tests/test_blueprint_handling.py
+++ b/cloudify_types/cloudify_types/component/tests/test_blueprint_handling.py
@@ -67,19 +67,6 @@ class TestBlueprint(ComponentTestBase):
             output = upload_blueprint(**self.resource_config)
             self.assertTrue(output)
 
-    def test_upload_blueprint_success(self):
-        with mock.patch('cloudify.manager.get_rest_client') as mock_client:
-            mock_client.return_value = self.cfy_mock_client
-
-            blueprint_params = dict()
-            blueprint_params['blueprint'] = {}
-            blueprint_params['blueprint']['id'] = 'blu_name'
-            blueprint_params['blueprint']['blueprint_archive'] = self.archive
-            self.resource_config['resource_config'] = blueprint_params
-
-            output = upload_blueprint(**self.resource_config)
-            self.assertTrue(output)
-
     def test_upload_blueprint_fail_missing_archive(self):
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:
             mock_client.return_value = self.cfy_mock_client
@@ -156,17 +143,18 @@ class TestBlueprint(ComponentTestBase):
                 upload_blueprint(**self.resource_config)
 
     def test_upload_blueprint(self):
+        blueprint = {
+            'id': 'test',
+            EXTERNAL_RESOURCE: False,
+            'labels': [{'foo': 'bar'}],
+            'blueprint_archive': self.archive,
+        }
+
+        self.cfy_mock_client.blueprints.set_existing_objects([blueprint])
         with mock.patch('cloudify.manager.get_rest_client') as mock_client:
-            labels = [{'foo': 'bar'}]
-            blueprint_params = dict()
-            blueprint_params['blueprint'] = {}
-            blueprint_params['blueprint']['id'] = 'test'
-            blueprint_params['blueprint'][EXTERNAL_RESOURCE] = False
-            blueprint_params['blueprint']['labels'] = labels
-            blueprint_params['blueprint']['blueprint_archive'] = self.archive
-
-            self.resource_config['resource_config'] = blueprint_params
-
+            self.resource_config['resource_config'] = {
+                'blueprint': blueprint,
+            }
             mock_client.return_value = self.cfy_mock_client
 
             output = upload_blueprint(**self.resource_config)

--- a/cloudify_types/cloudify_types/component/tests/test_check_drift.py
+++ b/cloudify_types/cloudify_types/component/tests/test_check_drift.py
@@ -1,0 +1,93 @@
+from unittest import mock
+
+from cloudify_rest_client.blueprints import Blueprint
+from cloudify_rest_client.deployments import Deployment
+
+from cloudify_types.component.operations import check_drift
+from cloudify_types.component.tests.base_test_suite import ComponentTestBase
+
+
+class TestCheckDrift(ComponentTestBase):
+    def setUp(self):
+        super().setUp()
+        self._client_patch = mock.patch(
+            'cloudify.manager.get_rest_client',
+            return_value=self.cfy_mock_client,
+        )
+        self._client_patch.start()
+
+    def tearDown(self):
+        self._client_patch.stop()
+        super().tearDown()
+
+    def test_no_drift(self):
+        ctx = self.get_mock_ctx('test', {
+            'resource_config': {
+                'blueprint': {
+                    'id': 'test',
+                }
+            },
+        })
+        self.cfy_mock_client.deployments.set_existing_objects([
+            Deployment({'id': 'test', 'labels': [], 'blueprint_id': 'test'})
+        ])
+        self.cfy_mock_client.blueprints.set_existing_objects([
+            Blueprint({'id': 'test'})
+        ])
+        drift = check_drift(ctx=ctx)
+        assert not drift
+
+    def test_blueprint_id_drift(self):
+        ctx = self.get_mock_ctx('test', {
+            'resource_config': {
+                'blueprint': {
+                    'id': 'test',
+                }
+            },
+        })
+        self.cfy_mock_client.deployments.set_existing_objects([
+            Deployment({'id': 'test', 'labels': [], 'blueprint_id': 'test2'})
+        ])
+        self.cfy_mock_client.blueprints.set_existing_objects([
+            Blueprint({'id': 'test2'})
+        ])
+        drift = check_drift(ctx=ctx)
+        assert drift == {'blueprint': ['id']}
+
+    def test_blueprint_labels_drift(self):
+        ctx = self.get_mock_ctx('test', {
+            'resource_config': {
+                'blueprint': {
+                    'id': 'test',
+                    'labels': [{'key': 'a', 'value': 'c'}],
+                }
+            },
+        })
+        self.cfy_mock_client.deployments.set_existing_objects([
+            Deployment({'id': 'test', 'labels': [], 'blueprint_id': 'test'})
+        ])
+        self.cfy_mock_client.blueprints.set_existing_objects([
+            Blueprint({'id': 'test', 'labels': [{'key': 'a', 'value': 'b'}]})
+        ])
+        drift = check_drift(ctx=ctx)
+        assert drift == {'blueprint': ['labels']}
+
+    def test_deployment_id_drift(self):
+        ctx = self.get_mock_ctx('test2', {
+            'resource_config': {
+                'deployment': {
+                    'id': 'test',
+                }
+            },
+        })
+        ctx.instance.runtime_properties.update({
+            'deployment': {'id': 'test2'}
+        })
+        self.cfy_mock_client.deployments.set_existing_objects([
+            Deployment({'id': 'test2', 'blueprint_id': 'test'}),
+        ])
+        self.cfy_mock_client.blueprints.set_existing_objects([
+            Blueprint({'id': 'test'})
+        ])
+        drift = check_drift(ctx=ctx)
+        assert drift == {'deployment': ['id']}

--- a/cloudify_types/cloudify_types/component/tests/test_check_drift.py
+++ b/cloudify_types/cloudify_types/component/tests/test_check_drift.py
@@ -91,3 +91,27 @@ class TestCheckDrift(ComponentTestBase):
         ])
         drift = check_drift(ctx=ctx)
         assert drift == {'deployment': ['id']}
+
+    def test_auto_inc_suffix(self):
+        ctx = self.get_mock_ctx('test-2', {
+            'resource_config': {
+                'deployment': {
+                    'id': 'test',
+                    'auto_inc_suffix': True,
+                },
+            },
+        })
+        ctx.instance.runtime_properties.update({
+            'deployment': {'id': 'test-2'}
+        })
+        self.cfy_mock_client.deployments.set_existing_objects([
+            Deployment({'id': 'test-2', 'blueprint_id': 'test'}),
+        ])
+        self.cfy_mock_client.blueprints.set_existing_objects([
+            Blueprint({'id': 'test'})
+        ])
+        drift = check_drift(ctx=ctx)
+        # even though the resource_config deployment id is "test",
+        # and the actual deployment id is "test-2" - that was generated
+        # by auto_inc_suffix, so there's no drift
+        assert not drift

--- a/cloudify_types/cloudify_types/component/tests/test_check_drift.py
+++ b/cloudify_types/cloudify_types/component/tests/test_check_drift.py
@@ -42,6 +42,7 @@ class TestCheckDrift(ComponentTestBase):
             'resource_config': {
                 'blueprint': {
                     'id': 'test',
+                    'labels': [{'a': 'b'}, {'c': 'd'}],
                 }
             },
         })
@@ -49,7 +50,16 @@ class TestCheckDrift(ComponentTestBase):
             Deployment({'id': 'test', 'labels': [], 'blueprint_id': 'test2'})
         ])
         self.cfy_mock_client.blueprints.set_existing_objects([
-            Blueprint({'id': 'test2'})
+            Blueprint({
+                'id': 'test2',
+                'labels': [
+                    # same labels as in resource config, but different order,
+                    # and different structure ({a:b} vs {key:a,value:b})
+                    # still no drift on labels!
+                    {'key': 'c', 'value': 'd'},
+                    {'key': 'a', 'value': 'b'},
+                ],
+            })
         ])
         drift = check_drift(ctx=ctx)
         assert drift == {'blueprint': ['id']}
@@ -59,7 +69,7 @@ class TestCheckDrift(ComponentTestBase):
             'resource_config': {
                 'blueprint': {
                     'id': 'test',
-                    'labels': [{'key': 'a', 'value': 'c'}],
+                    'labels': [{'a': 'c'}],
                 }
             },
         })

--- a/tests/integration_tests/tests/agentless_tests/component/test_component_auto_inc_suffix.py
+++ b/tests/integration_tests/tests/agentless_tests/component/test_component_auto_inc_suffix.py
@@ -158,8 +158,11 @@ node_templates:
 
     def test_drift(self):
         basic_blueprint_path = resource('dsl/empty_blueprint.yaml')
-        self.client.blueprints.upload(basic_blueprint_path,
-                                      entity_id=self.basic_blueprint_id)
+        self.client.blueprints.upload(
+            basic_blueprint_path,
+            entity_id=self.basic_blueprint_id,
+            labels=[{'a': 'b'}],
+        )
         wait_for_blueprint_upload(self.basic_blueprint_id, self.client, True)
 
         deployment_id = 'd{0}'.format(uuid.uuid4())
@@ -178,6 +181,8 @@ node_templates:
         blueprint:
           external_resource: true
           id: basic
+          labels:
+            - a: b
         deployment:
           id: component
           auto_inc_suffix: true

--- a/tests/integration_tests/tests/agentless_tests/component/test_component_auto_inc_suffix.py
+++ b/tests/integration_tests/tests/agentless_tests/component/test_component_auto_inc_suffix.py
@@ -155,3 +155,45 @@ node_templates:
                                                  _include=['id', 'status'])
         self.assertEqual(1, len(executions))
         self.assertEqual(executions[0].status, Execution.FAILED)
+
+    def test_drift(self):
+        basic_blueprint_path = resource('dsl/empty_blueprint.yaml')
+        self.client.blueprints.upload(basic_blueprint_path,
+                                      entity_id=self.basic_blueprint_id)
+        wait_for_blueprint_upload(self.basic_blueprint_id, self.client, True)
+
+        deployment_id = 'd{0}'.format(uuid.uuid4())
+        main_blueprint = """
+tosca_definitions_version: cloudify_dsl_1_4
+
+imports:
+  - cloudify/types/types.yaml
+
+node_templates:
+
+  component_node:
+    type: cloudify.nodes.Component
+    properties:
+      resource_config:
+        blueprint:
+          external_resource: true
+          id: basic
+        deployment:
+          id: component
+          auto_inc_suffix: true
+"""
+        blueprint_path = self.make_yaml_file(main_blueprint)
+        self.deploy_application(blueprint_path, deployment_id=deployment_id)
+        instances = self.client.node_instances.list(
+            deployment_id=deployment_id)
+        assert len(instances) == 1
+        assert not instances[0].has_configuration_drift
+
+        # even though the actual deployment id is different than the one in
+        # resource_config, that is only due to auto_inc_suffix, and that's
+        # not considered drift
+        self.execute_workflow('check_drift', deployment_id)
+        instances = self.client.node_instances.list(
+            deployment_id=deployment_id)
+        assert len(instances) == 1
+        assert not instances[0].has_configuration_drift


### PR DESCRIPTION
I ended up rewriting check_drift almost entirely. Heh. I do suggest viewing commits separately.

But anyway, the point of this change, is so that when auto_inc_suffix is set, don't consider deployment IDs drifted, if the specified deployment id was e.g. "dep", but the actual deployment id is "dep-42" (i.e. with the suffix)