### PR TITLE
RD-6639 Remove /set-global endpoints

### DIFF
--- a/rest-service/manager_rest/rest/endpoint_mapper.py
+++ b/rest-service/manager_rest/rest/endpoint_mapper.py
@@ -101,7 +101,6 @@ def setup_resources(api):
         'SecretsExport': 'secrets/share/export',
         'SecretsImport': 'secrets/share/import',
         'SecretsKey': 'secrets/<string:key>',
-        'SecretsSetGlobal': 'secrets/<string:key>/set-global',
         'SecretsSetVisibility': 'secrets/<string:key>/set-visibility',
         'ManagerConfig': 'config',
         'ManagerConfigId': 'config/<string:name>',

--- a/rest-service/manager_rest/rest/endpoint_mapper.py
+++ b/rest-service/manager_rest/rest/endpoint_mapper.py
@@ -67,7 +67,6 @@ def setup_resources(api):
         'PluginsUpdateId': 'plugins-updates/<string:update_id>',
         'PluginsUpdates': 'plugins-updates',
         'PluginsArchive': 'plugins/<string:plugin_id>/archive',
-        'PluginsSetGlobal': 'plugins/<string:plugin_id>/set-global',
         'PluginsSetVisibility': 'plugins/<string:plugin_id>/set-visibility',
         'PluginsYaml': 'plugins/<string:plugin_id>/yaml',
         'MaintenanceMode': 'maintenance',

--- a/rest-service/manager_rest/rest/endpoint_mapper.py
+++ b/rest-service/manager_rest/rest/endpoint_mapper.py
@@ -14,7 +14,6 @@ def setup_resources(api):
         'BlueprintsId': 'blueprints/<string:blueprint_id>',
         'BlueprintsIdValidate': 'blueprints/<string:blueprint_id>/validate',
         'BlueprintsIdArchive': 'blueprints/<string:blueprint_id>/archive',
-        'BlueprintsSetGlobal': 'blueprints/<string:blueprint_id>/set-global',
         'BlueprintsSetVisibility': 'blueprints/<string:blueprint_id>/'
                                    'set-visibility',
         'BlueprintsIcon': 'blueprints/<string:blueprint_id>/icon',

--- a/rest-service/manager_rest/rest/resources_v3/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v3/__init__.py
@@ -30,7 +30,6 @@ from .secrets import (          # NOQA
     SecretsKey,
     SecretsExport,
     SecretsImport,
-    SecretsSetGlobal,
     SecretsSetVisibility,
 )
 

--- a/rest-service/manager_rest/rest/resources_v3/secrets.py
+++ b/rest-service/manager_rest/rest/resources_v3/secrets.py
@@ -346,21 +346,6 @@ class Secrets(SecuredResource):
         )
 
 
-class SecretsSetGlobal(SecuredResource):
-
-    @authorize('resource_set_global')
-    @rest_decorators.marshal_with(models.Secret)
-    def patch(self, key):
-        """
-        Set the secret's visibility to global
-        """
-        return get_resource_manager().set_global_visibility(
-            models.Secret,
-            key,
-            VisibilityState.GLOBAL
-        )
-
-
 class SecretsSetVisibility(SecuredResource):
 
     @authorize('secret_update')

--- a/rest-service/manager_rest/rest/resources_v3_1/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/__init__.py
@@ -42,7 +42,6 @@ from .plugins import (                           # NOQA
     PluginsUpdates,
     PluginsUpdateId,
     PluginsId,
-    PluginsSetGlobal,
     PluginsSetVisibility,
     PluginsYaml,
 )

--- a/rest-service/manager_rest/rest/resources_v3_1/__init__.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/__init__.py
@@ -61,7 +61,6 @@ from .blueprints import (                        # NOQA
     BlueprintsId,
     BlueprintsIdArchive,
     BlueprintsIdValidate,
-    BlueprintsSetGlobal,
     BlueprintsSetVisibility,
     BlueprintsIcon,
 )

--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -41,19 +41,6 @@ from manager_rest import config
 from manager_rest.constants import FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER
 
 
-class BlueprintsSetGlobal(SecuredResource):
-
-    @authorize('resource_set_global')
-    @rest_decorators.marshal_with(models.Blueprint)
-    def patch(self, blueprint_id):
-        """
-        Set the blueprint's visibility to global
-        """
-        blueprint = get_storage_manager().get(models.Blueprint, blueprint_id)
-        return get_resource_manager().set_visibility(blueprint,
-                                                     VisibilityState.GLOBAL)
-
-
 class BlueprintsSetVisibility(SecuredResource):
 
     @authorize('resource_set_visibility')

--- a/rest-service/manager_rest/rest/resources_v3_1/plugins.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/plugins.py
@@ -28,19 +28,6 @@ from manager_rest.rest import (resources_v2,
                                rest_utils)
 
 
-class PluginsSetGlobal(SecuredResource):
-
-    @authorize('resource_set_global')
-    @rest_decorators.marshal_with(models.Plugin)
-    def patch(self, plugin_id):
-        """
-        Set the plugin's visibility to global
-        """
-        plugin = get_storage_manager().get(models.Plugin, plugin_id)
-        return get_resource_manager().set_visibility(plugin,
-                                                     VisibilityState.GLOBAL)
-
-
 class PluginsSetVisibility(SecuredResource):
 
     @authorize('resource_set_visibility')

--- a/rest-service/manager_rest/test/endpoints/test_blueprints.py
+++ b/rest-service/manager_rest/test/endpoints/test_blueprints.py
@@ -21,14 +21,18 @@ from unittest import mock
 
 import pytest
 
+from cloudify.exceptions import WorkflowFailed, InvalidBlueprintImport
+from cloudify.models_states import VisibilityState
+from cloudify_rest_client.exceptions import (
+    BlueprintInUseError,
+    CloudifyClientError,
+)
+
 from manager_rest import archiving
 from manager_rest.test import base_test
+from manager_rest.storage import models
 from manager_rest.storage.resource_models import Blueprint, db
-
-from cloudify_rest_client import exceptions
-from cloudify.exceptions import WorkflowFailed, InvalidBlueprintImport
-
-from .test_utils import generate_progress_func
+from manager_rest.test.endpoints.test_utils import generate_progress_func
 
 try:
     import bz2
@@ -54,19 +58,19 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
         self.assertEqual(0, len(result))
 
     def test_get_nonexistent_blueprint(self):
-        with self.assertRaises(exceptions.CloudifyClientError) as context:
+        with self.assertRaises(CloudifyClientError) as context:
             self.client.blueprints.get('15')
         self.assertEqual(404, context.exception.status_code)
 
     def test_upload_blueprint_illegal_id(self):
         # try id with whitespace
-        self.assertRaisesRegex(exceptions.CloudifyClientError,
+        self.assertRaisesRegex(CloudifyClientError,
                                'contains illegal characters',
                                self.client.blueprints.upload,
                                'path',
                                'illegal id')
         # try id that starts with a number
-        self.assertRaisesRegex(exceptions.CloudifyClientError,
+        self.assertRaisesRegex(CloudifyClientError,
                                'must begin with a letter',
                                self.client.blueprints.upload,
                                'path',
@@ -83,7 +87,7 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
     def test_post_blueprint_already_exists(self):
         self.put_blueprint()
         self.assertRaisesRegex(
-            exceptions.CloudifyClientError,
+            CloudifyClientError,
             '409: blueprint with id=blueprint already exists',
             self.put_blueprint)
 
@@ -317,11 +321,11 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
                            'blueprint_with_2_layer_blueprint_import.yaml',
                            app_blueprint_id)
 
-        self.assertRaises(exceptions.BlueprintInUseError,
+        self.assertRaises(BlueprintInUseError,
                           self.client.blueprints.delete,
                           first_blueprint_id)
 
-        self.assertRaises(exceptions.BlueprintInUseError,
+        self.assertRaises(BlueprintInUseError,
                           self.client.blueprints.delete,
                           second_blueprint_id)
 
@@ -343,7 +347,7 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
                            'blueprint_with_blueprint_import.yaml',
                            app_blueprint_id)
 
-        self.assertRaises(exceptions.BlueprintInUseError,
+        self.assertRaises(BlueprintInUseError,
                           self.client.blueprints.delete,
                           first_blueprint_id)
 
@@ -373,7 +377,7 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
         blueprint_path = os.path.join(
             self.get_blueprint_path('mock_blueprint'),
             blueprint_file)
-        with self.assertRaises(exceptions.CloudifyClientError) as context:
+        with self.assertRaises(CloudifyClientError) as context:
             self.client.blueprints.validate(blueprint_path, blueprint_id)
         self.assertEqual(400, context.exception.status_code)
         self.assertIn(
@@ -413,7 +417,7 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
                            'blueprint_with_inputs.yaml',
                            blueprint_id)
         self.assertRaisesRegex(
-            exceptions.CloudifyClientError,
+            CloudifyClientError,
             'Invalid state: `{0}`'.format(new_state),
             self.client.blueprints.update,
             blueprint_id,
@@ -426,7 +430,7 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
                            'blueprint_with_inputs.yaml',
                            blueprint_id)
         self.assertRaisesRegex(
-            exceptions.CloudifyClientError,
+            CloudifyClientError,
             'Unknown parameters: abc',
             self.client.blueprints.update,
             blueprint_id,
@@ -439,7 +443,7 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
                            'blueprint_with_inputs.yaml',
                            blueprint_id)
         self.assertRaisesRegex(
-            exceptions.CloudifyClientError,
+            CloudifyClientError,
             'visibility parameter is expected to be of type {}'.format(
                 str.__name__),
             self.client.blueprints.update,
@@ -447,7 +451,7 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
             {'visibility': 123}
         )
         self.assertRaisesRegex(
-            exceptions.CloudifyClientError,
+            CloudifyClientError,
             'plan parameter is expected to be of type dict',
             self.client.blueprints.update,
             blueprint_id,
@@ -479,3 +483,28 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
         self.assertEqual(len(blueprints), 1)
         self.assertEqual(blueprints[0], bp2)
         self.assert_metadata_filtered(blueprints, 1)
+
+    def test_update_blueprint_set_visibility(self):
+        bp = models.Blueprint(
+            id='bp1',
+            visibility=VisibilityState.PRIVATE,
+            tenant=self.tenant,
+            creator=self.user,
+        )
+        with self.assertRaisesRegex(CloudifyClientError, 'visibility'):
+            # already private, can't set again
+            self.client.blueprints.set_visibility(
+                bp.id, VisibilityState.PRIVATE)
+        assert bp.visibility == VisibilityState.PRIVATE
+
+        self.client.blueprints.set_visibility(bp.id, VisibilityState.TENANT)
+        assert bp.visibility == VisibilityState.TENANT
+
+        self.client.blueprints.set_visibility(bp.id, VisibilityState.GLOBAL)
+        assert bp.visibility == VisibilityState.GLOBAL
+
+        with self.assertRaisesRegex(CloudifyClientError, 'wider'):
+            # already has wider visibility, can't move back from global!
+            self.client.blueprints.set_visibility(
+                bp.id, VisibilityState.TENANT)
+        assert bp.visibility == VisibilityState.GLOBAL


### PR DESCRIPTION
set-visibility is available instead; the rest-client already uses set-visibility for its .set_global methods.

Set-global has been mentioned to be deprecated in the rest-docs since like 4.3, and we note that set-global was broken for some time already.

This is relevant for plugins, blueprints, secrets.

Also add a test for set-visibility, for each of the resources mentioned.