### PR TITLE
RD-6613 List files relative to request path

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/manager.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/manager.py
@@ -215,7 +215,7 @@ class FileServerProxy(SecuredResource):
         if not _is_resource_path_directory(rel_path):
             return self.storage_handler.proxy(rel_path)
         elif not as_archive:
-            files_list = [os.path.join(RESOURCES_PATH, file_name)
+            files_list = [os.path.relpath(file_name, rel_path)
                           for file_name in self.storage_handler.list(rel_path)]
             return {'files': files_list}, 200
         else:


### PR DESCRIPTION
This is a fix for broken integration tests:
* `integration_tests/tests/agentless_tests/test_deployment_resource.py::DeploymentResourceTest::test_get_and_download_deployment_resource`,
* `integration_tests/tests/agentless_tests/component/test_component_basics.py::ComponentTypeTest::test_component_creation_with_blueprint_in_internal_directory`.

e.g. `GET /resources/blueprints/default_tenant/` will now produce something like
```yaml
{
    "files": [
        "bp/blueprint.yaml",
        "bp/scripts/workflows/workflow.py"
    ]
}
```