### PR TITLE
RD-6613 A bugfix

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/manager.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/manager.py
@@ -354,4 +354,4 @@ def _resource_relative_path(uri=None):
         if not uri.startswith(RESOURCES_PATH):
             return None
 
-    return uri.replace(RESOURCES_PATH, '', 1)
+    return uri


### PR DESCRIPTION
Do not remove just any `/resources/` in FileServerProxy request path, but only the string that starts it.