### PR TITLE
RD-6477 create-dep-env: check blueprint requirements

### DIFF
--- a/mgmtworker/cloudify_system_workflows/deployment_environment.py
+++ b/mgmtworker/cloudify_system_workflows/deployment_environment.py
@@ -146,6 +146,7 @@ def _format_required_capabilities(capabilities):
         for cap in capabilities
     )
 
+
 def _get_deployment_parent(ctx, deployment):
     """Fetch the parent of the given deployment.
 

--- a/mgmtworker/cloudify_system_workflows/deployment_environment.py
+++ b/mgmtworker/cloudify_system_workflows/deployment_environment.py
@@ -131,6 +131,99 @@ def _evaluate_inputs(ctx, client, plan):
             plan['inputs'][inp_name]['constraints'] = inp_constraints
 
 
+def _format_required_capabilities(capabilities):
+    """Format the required capabilities into a human-readable format.
+
+    >>> _format_required_capabilities([])
+    ''
+    >>> _format_required_capabilities([["a"], ["b", 0]])
+    'a, b.0'
+    >>> _format_required_capabilities([["a", "b", "c", "d"]])
+    'a.b.c.d'
+    """
+    return ', '.join(
+        '.'.join(str(part) for part in cap)
+        for cap in capabilities
+    )
+
+def _get_deployment_parent(ctx, deployment):
+    """Fetch the parent of the given deployment.
+
+    Based on labels, look up the parent deployment.
+    If the given deployment has multiple csys-obj-parent labels attached,
+    only one parent is returned, and the order is undefined.
+    """
+    parent_id = None
+    for label in deployment.labels:
+        if label['key'] == 'csys-obj-parent':
+            parent_id = label['value']
+            break
+    if not parent_id:
+        return None
+    return ctx.get_deployment(parent_id)
+
+
+def _find_missing_capabilities(required_capabilities, parent_capabilities):
+    """Return which required capabilities are missing from the parent.
+
+    A capability is considered missing if it doesn't exist at all, or if
+    a key/index in it isn't available. For example, if available parent
+    capabilities are {"a": "b"}, then ["b"] would be missing, ["a", 0]
+    would be missing, but ["a"] would be not missing.
+    """
+    if not parent_capabilities:
+        return required_capabilities
+    missing_capabilities = []
+
+    for required_cap in required_capabilities:
+        name = required_cap[0]
+        if name not in parent_capabilities:
+            missing_capabilities.append(required_cap)
+            continue
+        value = parent_capabilities[name]['value']
+        for index in required_cap[1:]:
+            try:
+                value = value[index]
+            except (KeyError, IndexError, TypeError):
+                missing_capabilities.append(required_cap)
+                break
+    return missing_capabilities
+
+
+def _check_blueprint_requirements(ctx, deployment, blueprint):
+    """Check blueprint requirements, and possibly throw an error.
+
+    If the new deployment doesn't satisfy the blueprint requirements,
+    an error is raised.
+    """
+    requirements = blueprint.requirements
+    if not requirements:
+        return
+    required_parent_caps = requirements.get('parent_capabilities', [])
+    if required_parent_caps:
+        ctx.logger.debug(
+            'Required parent capabilities: %s',
+            required_parent_caps,
+        )
+        parent = _get_deployment_parent(ctx, deployment)
+        if not parent:
+            cap_message = _format_required_capabilities(required_parent_caps)
+            raise ValueError(
+                f'Environment not found, but environment capabilities are '
+                f'required: {cap_message}'
+            )
+        missing_capabilities = _find_missing_capabilities(
+            required_parent_caps,
+            parent.capabilities,
+        )
+        if missing_capabilities:
+            cap_message = _format_required_capabilities(missing_capabilities)
+            raise ValueError(
+                f'Environment {parent.id} does not have the required '
+                f'capabilities: {cap_message}'
+            )
+
+
 @workflow
 def create(ctx, labels=None, inputs=None, skip_plugins_validation=False,
            display_name=None, **_):
@@ -156,7 +249,7 @@ def create(ctx, labels=None, inputs=None, skip_plugins_validation=False,
         deployment_plan.get('labels', {}))
 
     ctx.logger.info('Setting deployment attributes')
-    client.deployments.set_attributes(
+    deployment = client.deployments.set_attributes(
         ctx.deployment.id,
         description=deployment_plan['description'],
         workflows=deployment_plan['workflows'],
@@ -170,6 +263,8 @@ def create(ctx, labels=None, inputs=None, skip_plugins_validation=False,
         labels=labels_to_create,
         resource_tags=deployment_plan.get('resource_tags'),
     )
+
+    _check_blueprint_requirements(ctx, deployment, bp)
 
     ctx.logger.info('Creating %d nodes', len(nodes))
     client.nodes.create_many(ctx.deployment.id, nodes)

--- a/mgmtworker/cloudify_system_workflows/tests/test_create_deployment.py
+++ b/mgmtworker/cloudify_system_workflows/tests/test_create_deployment.py
@@ -2,6 +2,8 @@ from unittest import mock
 
 import pytest
 
+from cloudify_rest_client.blueprints import Blueprint
+from cloudify_rest_client.deployments import Deployment
 from cloudify_rest_client.responses import ListResponse
 from cloudify_system_workflows.deployment_environment import create
 
@@ -44,9 +46,11 @@ def blueprint_plan(mock_ctx):
 @pytest.fixture
 def mock_client(blueprint_plan):
     client = mock.Mock()
-    client.blueprints.get = lambda bp: mock.Mock(
-        plan=blueprint_plan
-    )
+    bp = Blueprint({'plan': blueprint_plan})
+    dep = Deployment({})
+    client.blueprints.get.return_value = bp
+    client.deployments.set_attributes.return_value = dep
+
     client.node_instances.list = lambda node_id, _offset: ListResponse(
         [], {'pagination': {'total': 0, 'size': 1000}})
     client.evaluate.functions = lambda dep, ctx, obj: {'payload': obj}

--- a/rest-service/manager_rest/dsl_functions.py
+++ b/rest-service/manager_rest/dsl_functions.py
@@ -407,7 +407,8 @@ class FunctionEvaluationStorage(object):
         shared_dep_id, element_id = capability_path[0], capability_path[1]
 
         deployment = self.sm.get(Deployment, shared_dep_id)
-        capability = deployment.capabilities.get(element_id)
+        capabilities = deployment.capabilities or {}
+        capability = capabilities.get(element_id)
 
         if not capability:
             raise FunctionsEvaluationError(

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1747,7 +1747,7 @@ class ResourceManager(object):
         missing_parents = set(parent_ids) - {d.id for d in parents}
         if missing_parents:
             raise manager_exceptions.DeploymentParentNotFound(
-                f'Deployment(s) referenced by `csys-obj-parent` not found: '
+                f'Environment referenced by `csys-obj-parent` not found: '
                 f'{ ",".join(missing_parents) }'
             )
         all_ancestors = models.DeploymentLabelsDependencies\


### PR DESCRIPTION
- When creating a deployment, check requirements, and if there's some missing capabilities, throw an error.
- Change the "missing parent" message to say "environment", not "deployment". More specific, I guess.

New error messages:
```
# label referencing a nonexistent deployment
'create_deployment_environment' workflow execution failed: 404: Environment referenced by `csys-obj-parent` not found: env2
# no parent set, but capabilities are required
'create_deployment_environment' workflow execution failed: Environment not found, but environment capabilities are required: cap1
# parent doesn't have the required capabilities
'create_deployment_environment' workflow execution failed: Environment env does not have the required capabilities: cap2
# ...or sub-keys/indexes in the capability
'create_deployment_environment' workflow execution failed: Environment env does not have the required capabilities: cap1.key1.0
```
