### PR TITLE
Secrets update_provider_options: store a single value

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3/secrets.py
+++ b/rest-service/manager_rest/rest/resources_v3/secrets.py
@@ -316,7 +316,7 @@ class SecretsKey(SecuredResource):
             json.dumps(
                 provider_options,
             ),
-        ),
+        )
 
 
 class Secrets(SecuredResource):


### PR DESCRIPTION
We don't really want to store a tuple there :)
Sometimes a trailing comma is a comma too much!