### PR TITLE
RD-6717 MonitoringAuth: use stage login page

### DIFF
--- a/rest-service/manager_rest/manager_exceptions.py
+++ b/rest-service/manager_rest/manager_exceptions.py
@@ -153,13 +153,6 @@ class UnauthorizedError(ManagerException):
 
 class NoAuthProvided(UnauthorizedError):
     """Not authorized, because authentication was not provided."""
-
-    additional_headers: typing.ClassVar[dict[str, str]] = {
-        # if the user received this error in a browser, they'll be greeted
-        # with the basic auth prompt, rather than just an error page
-        'WWW-Authenticate': 'Basic',
-    }
-
     def __init__(self, *args, **kwargs):
         super().__init__('No authentication info provided', *args, **kwargs)
 


### PR DESCRIPTION
Instead of relying on the browser http basic auth popup, rely on stage's cookies. Much nicer UX.

This goes with cloudify-cosmo/cloudify-manager-install#1458