### PR TITLE
RD-6739 Workflow searches: cope with None workflows

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -639,7 +639,7 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
 
     def _list_workflows(self):
         if self.workflows is None:
-            return None
+            return []
 
         return [Workflow(name=wf_name,
                          created_at=None,


### PR DESCRIPTION
For failed deployments, workflows cna be None, and in that case, let's not throw a typerror.