### PR TITLE
RD-6789 Component: use async blueprint upload

### DIFF
--- a/cloudify_types/cloudify_types/polling.py
+++ b/cloudify_types/cloudify_types/polling.py
@@ -31,7 +31,11 @@ def poll_with_timeout(pollster,
 
 def verify_blueprint_uploaded(blueprint_id, client):
     blueprint = client.blueprints.get(blueprint_id)
-    return blueprint['state'] == BlueprintUploadState.UPLOADED
+    state = blueprint['state']
+    if state in BlueprintUploadState.FAILED_STATES:
+        raise NonRecoverableError(
+            f'Blueprint {blueprint_id} upload failed (state: {state})')
+    return state == BlueprintUploadState.UPLOADED
 
 
 def wait_for_blueprint_to_upload(

--- a/cloudify_types/cloudify_types/polling.py
+++ b/cloudify_types/cloudify_types/polling.py
@@ -35,7 +35,7 @@ def verify_blueprint_uploaded(blueprint_id, client):
     if state in BlueprintUploadState.FAILED_STATES:
         raise NonRecoverableError(
             f'Blueprint {blueprint_id} upload failed (state: {state})')
-    return state == BlueprintUploadState.UPLOADED
+    return state in BlueprintUploadState.END_STATES
 
 
 def wait_for_blueprint_to_upload(

--- a/cloudify_types/cloudify_types/utils.py
+++ b/cloudify_types/cloudify_types/utils.py
@@ -260,13 +260,17 @@ def do_upload_blueprint(client, blueprint):
                 entity_id=blueprint_id,
                 path=os.path.join(blueprint_archive, blueprint_file_name),
                 labels=labels,
-                skip_size_limit=True)
+                skip_size_limit=True,
+                async_upload=True,
+            )
         else:
             client.blueprints._upload(
                 blueprint_id=blueprint_id,
                 archive_location=blueprint_archive,
                 application_file_name=blueprint_file_name,
-                labels=labels)
+                labels=labels,
+                async_upload=True,
+            )
         wait_for_blueprint_to_upload(blueprint_id, client)
     except CloudifyClientError as ex:
         if 'already exists' not in str(ex):

--- a/tests/integration_tests/resources/dsl/component_with_not_existing_blueprint_package.yaml
+++ b/tests/integration_tests/resources/dsl/component_with_not_existing_blueprint_package.yaml
@@ -11,7 +11,7 @@ node_templates:
       resource_config:
         blueprint:
           id: basic
-          blueprint_archive: http://not-real.com/blueprint.zip
+          blueprint_archive: http://nonexistent.local/blueprint.zip
           main_file_name: blueprint.yaml
         deployment:
           id: component


### PR DESCRIPTION
Component's `upload_blueprint` operation already calls `wait_for_blueprint_to_upload()` so it can very easily use async_upload directly. Almost no changes required!

And deployment creation already uses async.