### PR TITLE
RD-6789 Component: use async blueprint upload

### DIFF
--- a/cloudify_types/cloudify_types/polling.py
+++ b/cloudify_types/cloudify_types/polling.py
@@ -31,7 +31,11 @@ def poll_with_timeout(pollster,
 
 def verify_blueprint_uploaded(blueprint_id, client):
     blueprint = client.blueprints.get(blueprint_id)
-    return blueprint['state'] == BlueprintUploadState.UPLOADED
+    state = blueprint['state']
+    if state in BlueprintUploadState.FAILED_STATES:
+        raise NonRecoverableError(
+            f'Blueprint {blueprint_id} upload failed (state: {state})')
+    return state in BlueprintUploadState.END_STATES
 
 
 def wait_for_blueprint_to_upload(

--- a/cloudify_types/cloudify_types/utils.py
+++ b/cloudify_types/cloudify_types/utils.py
@@ -257,13 +257,17 @@ def do_upload_blueprint(client, blueprint):
                 entity_id=blueprint_id,
                 path=os.path.join(blueprint_archive, blueprint_file_name),
                 labels=labels,
-                skip_size_limit=True)
+                skip_size_limit=True,
+                async_upload=True,
+            )
         else:
             client.blueprints._upload(
                 blueprint_id=blueprint_id,
                 archive_location=blueprint_archive,
                 application_file_name=blueprint_file_name,
-                labels=labels)
+                labels=labels,
+                async_upload=True,
+            )
         wait_for_blueprint_to_upload(blueprint_id, client)
     except CloudifyClientError as ex:
         if 'already exists' not in str(ex):

--- a/tests/integration_tests/resources/dsl/component_with_not_existing_blueprint_package.yaml
+++ b/tests/integration_tests/resources/dsl/component_with_not_existing_blueprint_package.yaml
@@ -11,7 +11,7 @@ node_templates:
       resource_config:
         blueprint:
           id: basic
-          blueprint_archive: http://not-real.com/blueprint.zip
+          blueprint_archive: http://nonexistent.local/blueprint.zip
           main_file_name: blueprint.yaml
         deployment:
           id: component


### PR DESCRIPTION
This ports #4019 to 6.4.2.


* component tests: use a url that ACTUALLY doesn't exist

`not-real.com` does exist, funnily. The test passes because it returns 403, but... someday it might not. I mean, pretty much everything .com is going to exist, won't it.

* ServiceComponent: use async_upload for blueprints

This already calls `wait_for_blueprint_to_upload()` so it can very easily use async_upload directly

* verify_blueprint_uploaded: throw on failure

this used to wait for... just the uploaded state. But if the upload fails, the state never becomes uploaded, obviously. We then just wait until the timeout.

Instead, if it failed uploading, exit immediately

* verify_blueprint_uploaded: also exist on any END_STATE

END_STATES different than FAILED_STATES are just UPLOADED anyway, but in case we add more in the future...