### PR TITLE
RD-2798 Drop the DeploymentUpdate PUT method

### DIFF
--- a/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
+++ b/rest-service/manager_rest/rest/resources_v2_1/deployment_update.py
@@ -59,15 +59,6 @@ class DeploymentUpdate(SecuredResource):
             sm = get_storage_manager()
             return sm.get(models.DeploymentUpdate, id)
 
-    @authorize('deployment_update_create')
-    @rest_decorators.marshal_with(models.DeploymentUpdate)
-    def put(self, id, phase):
-        """DEPRECATED.
-
-        This method is implemented for backward-compatibility only.
-        """
-        return self._initiate(id)
-
     @rest_decorators.marshal_with(models.DeploymentUpdate)
     def _initiate(self, deployment_id):
         sm = get_storage_manager()


### PR DESCRIPTION
The method is deprecated for a long time and was kept for back-compat only.