### PR TITLE
RD-6001 Alias sort by labels to avoid autocorrelation with filters

### DIFF
--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -199,7 +199,7 @@ class SQLStorageManager(object):
                 else:
                     query = query.order_by(column)
         if sort_labels:
-            labels_model = model_class.labels_model
+            labels_model = aliased(model_class.labels_model)
             for key, order in sort_labels.items():
                 ordering = (
                     db.select(


### PR DESCRIPTION
This fixes `Select statement '<sqlalchemy.sql.selectable.Select object at ....>' returned no FROM clauses due to auto-correlation` when there's both filtering and sorting by labels