### PR TITLE
RD-6802 rabbitmq: disable consumer_timeout

### DIFF
--- a/service_containers/rabbitmq/config/rabbitmq.config
+++ b/service_containers/rabbitmq/config/rabbitmq.config
@@ -1,6 +1,7 @@
 [
  {ssl, [{versions, ['tlsv1.2', 'tlsv1.1']}]},
  {rabbit, [
+           {consumer_timeout, undefined},
            {heartbeat, 0},  % clients can override this
            {loopback_users, []},
            {ssl_listeners, [5671]},


### PR DESCRIPTION
This ports cloudify-cosmo/cloudify-manager-install#1465 to the split-services deployment