### PR TITLE
inte-tests: use `provider_name` argument in secrets.create

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_secrets_providers.py
+++ b/tests/integration_tests/tests/agentless_tests/test_secrets_providers.py
@@ -26,7 +26,7 @@ class SecretsProvidersTest(AgentlessTestCase):
         self.client.secrets.create(
             'port',
             '8080',
-            provider='local_provider',
+            provider_name='local_provider',
         )
         deployment, _ = self.deploy_application(dsl_path)
 


### PR DESCRIPTION
This updates the tests to work with the api change after cloudify-cosmo/cloudify-common#1234