### PR TITLE
RD-6881 Component: don't break on zip blueprint_archive

### DIFF
--- a/cloudify_types/cloudify_types/utils.py
+++ b/cloudify_types/cloudify_types/utils.py
@@ -247,7 +247,9 @@ def do_upload_blueprint(client, blueprint):
             res_dict = json.loads(res)
             if isinstance(res_dict, dict):
                 is_directory = True
-        except json.JSONDecodeError:
+        except ValueError:
+            # The downloaded blueprint isn't a json (it might be a zip!)
+            # Either json.loads failed, or unicode decode failed.
             pass
         if is_directory:
             blueprint_archive = ctx.download_directory(blueprint_archive)


### PR DESCRIPTION
In here, we can throw more than just a JSONDecodeError: we can also throw a UnicodeDecodeError, and that commonly happens when `res` is a binary blob - which is common when the blueprint is a zip.