### PR TITLE
inte-tests: correct path to migrations mount

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -93,7 +93,7 @@ sources = [
 # directory directly.
 sources_static = [
     (
-        'cloudify-manager/resources/rest-service/cloudify/migrations',
+        'cloudify-manager/rest-service/migrations',
         ['/opt/manager/resources/cloudify/migrations']
     ),
     (


### PR DESCRIPTION
After #4031 this path has changed