### PR TITLE
RD-6589 Snapshot utils: calculate blueprint requirements

### DIFF
--- a/mgmtworker/cloudify_system_workflows/snapshots/compute_blueprint_requirements.py
+++ b/mgmtworker/cloudify_system_workflows/snapshots/compute_blueprint_requirements.py
@@ -1,0 +1,16 @@
+import os
+from manager_rest import config
+from manager_rest.flask_utils import setup_flask_app
+from manager_rest.constants import SECURITY_FILE_LOCATION
+from manager_rest.snapshot_utils import set_blueprint_requirements
+from manager_rest.storage import db
+
+
+os.environ['MANAGER_REST_CONFIG_PATH'] = '/opt/manager/cloudify-rest.conf'
+os.environ['MANAGER_REST_SECURITY_CONFIG_PATH'] = SECURITY_FILE_LOCATION
+
+if __name__ == '__main__':
+    with setup_flask_app().app_context():
+        config.instance.load_configuration()
+        set_blueprint_requirements()
+        db.session.commit()

--- a/mgmtworker/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/mgmtworker/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -664,6 +664,7 @@ class SnapshotRestore(object):
                         composer_revision
                     )
                 self._migrate_pickle_to_json()
+                self._compute_blueprint_requirements()
                 self._restore_hash_salt()
                 self._encrypt_secrets(postgres)
                 self._encrypt_rabbitmq_passwords(postgres)
@@ -1267,6 +1268,15 @@ class SnapshotRestore(object):
         scrip_path = os.path.join(
             dir_path,
             'migrate_pickle_to_json.py'
+        )
+        command = [MANAGER_PYTHON, scrip_path, self._tempdir]
+        utils.run(command)
+
+    def _compute_blueprint_requirements(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        scrip_path = os.path.join(
+            dir_path,
+            'compute_blueprint_requirements.py'
         )
         command = [MANAGER_PYTHON, scrip_path, self._tempdir]
         utils.run(command)

--- a/rest-service/manager_rest/snapshot_utils.py
+++ b/rest-service/manager_rest/snapshot_utils.py
@@ -222,7 +222,7 @@ def migrate_pickle_to_json(batch_size=PICKLE_TO_JSON_MIGRATION_BATCH_SIZE):
         migrate_model(db.session, model, attributes, batch_size)
 
 
-def set_blueprint_requirements(batch_size: int=1000):
+def set_blueprint_requirements(batch_size=1000):
     stmt = (
         select(models.Blueprint)
         .where(_json_column_null(models.Blueprint.requirements))

--- a/rest-service/manager_rest/snapshot_utils.py
+++ b/rest-service/manager_rest/snapshot_utils.py
@@ -10,6 +10,8 @@ import operator
 from typing import Dict, List
 
 from cloudify.models_states import DeploymentState
+from dsl_parser.functions import find_requirements
+from dsl_parser.models import Plan
 from sqlalchemy import select, exists, and_, or_
 from sqlalchemy.sql.expression import text as sql_text
 from sqlalchemy.orm import Session
@@ -161,21 +163,26 @@ pickle_migrations = {
 }
 
 
+def _json_column_null(json_column):
+    """Condition of checking whether the json column is null
+
+    We consider the json column empty in both the case of a SQL null,
+    and the JSON null.
+    The value will be a SQL null when the row is inserted directly via
+    SQL (eg. in snapshot-restore), and it will be a JSON null when
+    inserted using the ORM.
+    note: db.JSON.NULL doesn't work here, but I don't know why.
+    """
+    return json_column.is_(None) | (json_column == sql_text("'null'"))
+
+
 def _column_migrate_condition(model_cls, attr):
     """The SQL condition to check if the column needs to be migrated"""
     pickle_column = getattr(model_cls, f'{attr}_p')
     json_column = getattr(model_cls, attr)
     pickle_not_empty = pickle_column.isnot(None)
 
-    # We consider the json column empty in both the case of a SQL null,
-    # and the JSON null.
-    # The value will be a SQL null when the row is inserted directly via
-    # SQL (eg. in snapshot-restore), and it will be a JSON null when
-    # inserted using the ORM.
-    # note: db.JSON.NULL doesn't work here, but I don't know why.
-    json_empty = json_column.is_(None) | (json_column == sql_text("'null'"))
-
-    return pickle_not_empty & json_empty
+    return pickle_not_empty & _json_column_null(json_column)
 
 
 def migrate_model(session: Session, model_cls, attributes, batch_size: int):
@@ -213,3 +220,26 @@ def migrate_pickle_to_json(batch_size=PICKLE_TO_JSON_MIGRATION_BATCH_SIZE):
     """Migrate the fields which were pickled to their JSON counterparts"""
     for model, attributes in pickle_migrations.items():
         migrate_model(db.session, model, attributes, batch_size)
+
+
+def set_blueprint_requirements(batch_size: int=1000):
+    stmt = (
+        select(models.Blueprint)
+        .where(_json_column_null(models.Blueprint.requirements))
+        .limit(batch_size)
+        .with_for_update()
+    )
+    while True:
+        results = db.session.execute(stmt).scalars().all()
+        for bp in results:
+            try:
+                plan = Plan(bp.plan)
+                reqs = find_requirements(plan)
+            except Exception:
+                reqs = {}
+            bp.requirements = reqs
+            db.session.add(bp)
+        db.session.flush()
+
+        if len(results) < batch_size:
+            break

--- a/rest-service/manager_rest/test/infrastructure/test_snapshot_utils.py
+++ b/rest-service/manager_rest/test/infrastructure/test_snapshot_utils.py
@@ -7,15 +7,15 @@ from manager_rest.snapshot_utils import (populate_deployment_statuses,
                                          migrate_pickle_to_json)
 
 
-class TestSnapshotDeploymentStatus(base_test.BaseServerTestCase):
+class SnapshotUtilsTestBase(base_test.BaseServerTestCase):
     def setUp(self):
-        super(TestSnapshotDeploymentStatus, self).setUp()
+        super().setUp()
         self._tenant = models.Tenant()
         self._user = models.User()
 
     def tearDown(self):
         db.session.rollback()
-        super(TestSnapshotDeploymentStatus, self).tearDown()
+        super().tearDown()
 
     def _make_blueprint(self, **kw):
         bp = models.Blueprint(tenant=self._tenant, creator=self._user, **kw)
@@ -124,6 +124,8 @@ class TestSnapshotDeploymentStatus(base_test.BaseServerTestCase):
         db.session.flush()
         return plugins_update
 
+
+class TestSnapshotDeploymentStatus(SnapshotUtilsTestBase):
     def test_latest_execution_empty(self):
         dep = self._make_deployment()
         populate_deployment_statuses()
@@ -236,6 +238,8 @@ class TestSnapshotDeploymentStatus(base_test.BaseServerTestCase):
         db.session.refresh(dep)
         assert dep.deployment_status == DeploymentState.REQUIRE_ATTENTION
 
+
+class TestPickleToJSON(SnapshotUtilsTestBase):
     def test_pickle_to_json_blueprints(self):
         silly_plan = {'first': 'foo', 'then': ['bar', 'baz', 3.14, True, -1]}
         bp1 = self._make_blueprint(id='bp1', plan_p=silly_plan)


### PR DESCRIPTION
In snapshot-utils, calculate blueprint requirements, for old blueprints that don't have had their requirements computed yet.

In case anything breaks, maybe the plan isn't quite the format that we expected, just give up and set empty requirements...