### PR TITLE
RD-6586 Pass through rest_port when sending workflow messages

### DIFF
--- a/mgmtworker/mgmtworker/worker.py
+++ b/mgmtworker/mgmtworker/worker.py
@@ -236,7 +236,8 @@ class MgmtworkerServiceTaskConsumer(ServiceTaskConsumer):
                                tenant_name, deployment_id)
         shutil.rmtree(dep_dir, ignore_errors=True)
 
-    def cancel_workflow_task(self, executions, tenant, rest_host):
+    def cancel_workflow_task(
+            self, executions, tenant, rest_host, rest_port=53333):
         logger.info('Cancelling workflows %s',
                     [exc['id'] for exc in executions])
 
@@ -245,6 +246,7 @@ class MgmtworkerServiceTaskConsumer(ServiceTaskConsumer):
             """
             def __init__(self, execution_token):
                 self.rest_host = rest_host
+                self.rest_port = rest_port
                 self.tenant_name = tenant['name']
                 self.rest_token = execution_token
                 self.execution_token = execution_token

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -1458,6 +1458,7 @@ class Execution(CreatedAtMixin, SQLResourceBase):
             'rest_host': [
                 mgr.private_ip for mgr in session.query(Manager).all()
             ],
+            'rest_port': 53333,
         }
         if self.deployment is not None:
             context['deployment_id'] = self.deployment.id

--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -94,6 +94,7 @@ def cancel_execution(executions):
             'task_name': 'cancel-workflow',
             'kwargs': {
                 'rest_host': [manager.private_ip for manager in managers],
+                'rest_port': 53333,
                 'executions': executions,
                 'tenant': _get_tenant_dict(),
             }
@@ -116,6 +117,7 @@ def _get_plugin_message(plugin, task='install-plugin', target_names=None):
             'kwargs': {
                 'plugin': plugin.to_dict(),
                 'rest_host': [manager.private_ip for manager in managers],
+                'rest_port': 53333,
                 'rest_token': current_user.get_auth_token(
                     description=f'Plugins task {task} rest token.',
                 ),


### PR DESCRIPTION
Similar to passing rest_host, we'll also let the worker know what port to connect to us on.

For now, this is 53333, but being able to parametrize it, is the first step to be able to change it!