### PR TITLE
RD-6766 mgmtworker dockerfile: install the missing libs

### DIFF
--- a/mgmtworker/Dockerfile
+++ b/mgmtworker/Dockerfile
@@ -11,7 +11,10 @@ RUN --mount=type=cache,target=/root/.cache \
     && \
     apt-get install -y \
       libpq-dev \
-      gcc
+      gcc \
+      git \
+      libkrb5-dev \
+      libffi-dev
 
 WORKDIR /opt
 

--- a/rest-service/Dockerfile
+++ b/rest-service/Dockerfile
@@ -13,6 +13,8 @@ ENV POSTGRES_PASSWORD=cloudify
 # FILE_SERVER_TYPE=minio or local
 ENV FILE_SERVER_TYPE=s3
 
+ARG PREMIUM=true
+
 RUN --mount=type=cache,target=/root/.cache \
     apt-get update \
     && \
@@ -40,8 +42,7 @@ RUN --mount=type=cache,target=/root/.cache \
       -r requirements.txt
 
 RUN --mount=type=ssh \
-    pip install \
-    -r requirements_ssh.txt
+    if [ -n "${PREMIUM}" ]; then pip install -r requirements_ssh.txt; fi
 
 RUN mkdir /src
 COPY docker/cloudify.pth /usr/local/lib/python3.11/site-packages/cloudify.pth


### PR DESCRIPTION
Those are actually required to install reqs.txt - I think it was missed before due to all the caching I had going on, but now that I actually ran that clean, I noted that these are needed.

Additionally, I'll parametrize PREMIUM in the restservice dockerfile as well, in case I wanted to build a non-premium restservice image (which I currently do want)