### PR TITLE
Allow all tenants in the auth of plugins.get_yaml

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/plugins.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/plugins.py
@@ -336,7 +336,7 @@ class PluginsYaml(SecuredResource):
         nickname="downloadPluginYaml",
         notes="download a plugin YAML according to the plugin ID. "
     )
-    @authorize('plugin_download')
+    @authorize('plugin_download', allow_all_tenants=True)
     def get(self, plugin_id, **kwargs):
         """
         Download plugin yaml


### PR DESCRIPTION
plugins.get_yaml is called from the import resolver in mgmtworker, which needs an all_tenants authorization, similarly to 
https://github.com/cloudify-cosmo/cloudify-manager/blob/master/rest-service/manager_rest/rest/resources_v2/plugins.py#L45