### PR TITLE
RD-6658 inte-tests: update expected plugin path

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_plugins.py
+++ b/tests/integration_tests/tests/agent_tests/test_plugins.py
@@ -48,7 +48,7 @@ class PluginInstallationTest(AgentTestCase):
         return os.path.join(
             self.execute_on_manager(['bash', '-c', 'echo ~cfyuser']).strip(),
             agent_id,
-            'env', 'plugins',
+            'plugins',
             plugin.tenant_name,
             plugin.package_name,
             plugin.package_version


### PR DESCRIPTION
After cloudify-cosmo/cloudify-agent#867 the plugins are put in the agent dir, rather than near the env.

Anyway, the env is usually going to be like /opt/cloudify-agent-7.0.0/ and the agent user won't necessarily going to have write privileges for that dir (indeed, it had better not have write rights there).

So the agent must store the plugins in a directory where it does have write rights, like right here.

(in the case of this test, basedir and agent dir just happen to be the same...)