### PR TITLE
RD-6586 Make the default agents/REST port configurable

### DIFF
--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -152,6 +152,7 @@ class Config(object):
     insecure_endpoints_disabled = Setting('insecure_endpoints_disabled')
     default_page_size = Setting('default_page_size', default=1000)
     min_available_memory_mb = Setting('min_available_memory_mb', default=0)
+    default_agent_port = Setting('default_agent_port', default=53333)
 
     # security settings
     security_hash_salt = Setting('security_hash_salt', from_db=False)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -31,7 +31,7 @@ from dsl_parser.constants import (WORKFLOW_PLUGINS_TO_INSTALL,
 from dsl_parser.constraints import extract_constraints, validate_input_value
 from dsl_parser import exceptions as dsl_exceptions
 
-from manager_rest import manager_exceptions
+from manager_rest import config, manager_exceptions
 from manager_rest.rest.responses import Workflow, Label
 from manager_rest.utils import (get_rrule,
                                 classproperty)
@@ -1458,7 +1458,7 @@ class Execution(CreatedAtMixin, SQLResourceBase):
             'rest_host': [
                 mgr.private_ip for mgr in session.query(Manager).all()
             ],
-            'rest_port': 53333,
+            'rest_port': config.instance.default_agent_port,
         }
         if self.deployment is not None:
             context['deployment_id'] = self.deployment.id

--- a/rest-service/manager_rest/workflow_executor.py
+++ b/rest-service/manager_rest/workflow_executor.py
@@ -8,6 +8,7 @@ from cloudify.amqp_client import SendHandler
 from cloudify.models_states import PluginInstallationState
 from cloudify.constants import MGMTWORKER_QUEUE, EVENTS_EXCHANGE_NAME
 
+from manager_rest import config
 from manager_rest.storage import get_storage_manager, models
 from manager_rest.utils import current_tenant, get_amqp_client
 
@@ -94,7 +95,7 @@ def cancel_execution(executions):
             'task_name': 'cancel-workflow',
             'kwargs': {
                 'rest_host': [manager.private_ip for manager in managers],
-                'rest_port': 53333,
+                'rest_port': config.instance.default_agent_port,
                 'executions': executions,
                 'tenant': _get_tenant_dict(),
             }
@@ -117,7 +118,7 @@ def _get_plugin_message(plugin, task='install-plugin', target_names=None):
             'kwargs': {
                 'plugin': plugin.to_dict(),
                 'rest_host': [manager.private_ip for manager in managers],
-                'rest_port': 53333,
+                'rest_port': config.instance.default_agent_port,
                 'rest_token': current_user.get_auth_token(
                     description=f'Plugins task {task} rest token.',
                 ),

--- a/rest-service/migrations/versions/edd6d829a209_6_4_to_7_0.py
+++ b/rest-service/migrations/versions/edd6d829a209_6_4_to_7_0.py
@@ -49,11 +49,13 @@ def upgrade():
     add_secrets_provider_relationship()
     add_s3_client_config()
     add_file_server_type_config()
+    add_default_agents_rest_port_config()
     add_blueprint_requirements_column()
 
 
 def downgrade():
     drop_blueprint_requirements_column()
+    drop_default_agents_rest_port_config()
     drop_file_server_type_config()
     drop_s3_client_config()
     downgrade_users_roles_constraints()
@@ -721,6 +723,30 @@ def drop_secrets_provider_relationship():
     op.drop_column(
         'secrets',
         '_secrets_provider_fk',
+    )
+
+
+def add_default_agents_rest_port_config():
+    op.bulk_insert(
+        config_table,
+        [
+            {
+                'name': 'default_agent_port',
+                'value': 53333,
+                'scope': 'rest',
+                'schema': {"type": "number", "minimum": 1, "maximum": 65535},
+                'is_editable': True,
+            },
+        ]
+    )
+
+
+def drop_default_agents_rest_port_config():
+    op.execute(
+        config_table.delete().where(
+            (config_table.c.name == op.inline_literal('default_agent_port'))
+            & (config_table.c.scope == op.inline_literal('rest'))
+        )
     )
 
 


### PR DESCRIPTION
This is the port that the mgmtworker is going to connect to, and then, pass it through to the agents.

Further work will involve making it different per-network