### PR TITLE
RD-6766 Drop the fileserver container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,8 +91,10 @@ services:
     restart: unless-stopped
 
   fileserver:
-    container_name: fileserver
-    build: service_containers/fileserver
+    image: minio/minio
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: admin123
     volumes:
       - ./fileserver/minio/data:/data
     ports:

--- a/service_containers/fileserver/Dockerfile
+++ b/service_containers/fileserver/Dockerfile
@@ -1,6 +1,0 @@
-FROM minio/minio
-
-ENV MINIO_ROOT_USER=admin
-ENV MINIO_ROOT_PASSWORD=admin123
-
-CMD ["minio", "server", "/data", "--console-address", ":9090"]


### PR DESCRIPTION
After cloudify-cosmo/cloudify-helm#77 we can just use the base image directly, and this is not required anymore.