### PR TITLE
RD-6908 dep-update: update plan with real instance counts

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_modification.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_modification.py
@@ -541,3 +541,44 @@ workflows:
         assert cm.exception.error_code == 'unavailable_workflow_error'
         self._do_update(deployment.id, BLUEPRINT_ID)
         self.execute_workflow('wf1', deployment.id)  # doesn't throw
+
+    def test_update_scaled(self):
+        """Updating a deployment that was scaled before, doesn't remove
+        instances added by the scale.
+        """
+        bp = """
+tosca_definitions_version: cloudify_dsl_1_5
+imports:
+  - cloudify/types/types.yaml
+inputs:
+    inp1: {}
+
+node_templates:
+  n1:
+    type: cloudify.nodes.Root
+    capabilities:
+      scalable:
+        properties:
+          default_instances: 0
+          max_instances: 1
+"""
+        self.upload_blueprint_resource(
+            self.make_yaml_file(bp),
+            blueprint_id='bp1',
+        )
+        dep1 = self.deploy(
+            blueprint_id='bp1',
+            deployment_id='d1',
+            inputs={'inp1': 'val1'}
+        )
+        self.execute_workflow('install', dep1.id)
+        instances = self.client.node_instances.list(deployment_id=dep1.id)
+        assert len(instances) == 0
+        self.execute_workflow('scale', dep1.id, parameters={
+            'scalable_entity_name': 'n1',
+        })
+        instances = self.client.node_instances.list(deployment_id=dep1.id)
+        assert len(instances) == 1
+        self._do_update(dep1.id, inputs={'inp1': 'val2'})
+        instances = self.client.node_instances.list(deployment_id=dep1.id)
+        assert len(instances) == 1

--- a/workflows/cloudify_system_workflows/deployment_update/workflow.py
+++ b/workflows/cloudify_system_workflows/deployment_update/workflow.py
@@ -20,6 +20,43 @@ from .update_instances import update_or_reinstall_instances
 from .utils import clear_graph
 
 
+def _update_plan_nodes(plan):
+    """Update nodes stored in the plan, to reflect the current instance counts
+
+    The plan will always scaling properties as written in the blueprint,
+    but in reality, the nodes could have been scaled, and there might now
+    be more instances. Update the plan to reflect the currently existing
+    amount of instances.
+    """
+    for node in plan['nodes']:
+        existing_node = workflow_ctx.get_node(node['id'])
+        if not existing_node:
+            continue
+
+        try:
+            scale_properties = node['capabilities']['scalable']['properties']
+        except KeyError:
+            continue
+
+        current_num = existing_node._node.get('number_of_instances')
+        current_planned = \
+            existing_node._node.get('planned_number_of_instances')
+
+        try:
+            # if the node has an `instances: deploy: {num}`, that overrides
+            # any other setting
+            force_deploy = node['instances']['deploy']
+            if force_deploy is not None:
+                current_planned = force_deploy
+        except KeyError:
+            pass
+
+        if current_num is not None:
+            scale_properties['current_instances'] = current_num
+        if current_planned is not None:
+            scale_properties['planned_instances'] = current_planned
+
+
 def prepare_plan(*, update_id):
     """Prepare the new deployment plan for a deployment update"""
     dep_up = workflow_ctx.get_deployment_update(update_id)
@@ -42,6 +79,8 @@ def prepare_plan(*, update_id):
     else:
         values_getter = None
         existing_ni_ids = None
+
+    _update_plan_nodes(bp.plan)
 
     deployment_plan = tasks.prepare_deployment_plan(
         bp.plan,


### PR DESCRIPTION
If nodes were scaled, those new instance counts are not reflected in the plan.
Before creating the new deployment plan, update the blueprint plan with the current real instance counts.