### PR TITLE
Inte-tests: use dsl 1_3 for test_update_scaled

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_modification.py
+++ b/tests/integration_tests/tests/agentless_tests/deployment_update/test_deployment_update_modification.py
@@ -547,7 +547,7 @@ workflows:
         instances added by the scale.
         """
         bp = """
-tosca_definitions_version: cloudify_dsl_1_5
+tosca_definitions_version: cloudify_dsl_1_3
 imports:
   - cloudify/types/types.yaml
 inputs:


### PR DESCRIPTION
Obviously, 1_5 doesn't exist in 6.4.2