### PR TITLE
RD-6885 Add /health endpoint in apiservice

### DIFF
--- a/api-service/cloudify_api/main.py
+++ b/api-service/cloudify_api/main.py
@@ -1,7 +1,7 @@
 import pkg_resources
 
 import cloudify_api
-from cloudify_api.routers import audit as audit_router
+from cloudify_api.routers import audit as audit_router, health as health_router
 
 DEBUG = False
 
@@ -15,6 +15,7 @@ def create_application() -> cloudify_api.CloudifyAPI:
     )
     application.configure()
     application.include_router(audit_router, prefix="/api/v3.1")
+    application.include_router(health_router)
     return application
 
 

--- a/api-service/cloudify_api/routers/__init__.py
+++ b/api-service/cloudify_api/routers/__init__.py
@@ -1,1 +1,2 @@
 from .audit import router as audit  # noqa
+from .health import router as health  # noqa

--- a/api-service/cloudify_api/routers/health.py
+++ b/api-service/cloudify_api/routers/health.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/health", tags=["Healthcheck"])
+
+
+@router.get("")
+async def healthcheck():
+    """Just a basic healthcheck endpoint"""
+    return 'ok'


### PR DESCRIPTION
The endpoint is going to be used solely for monitoring purposes, so it is not burried under /api/v3.1/ path prefix and will be used directly (http://:8081/health)