### PR TITLE
RD-6586 configure_manager: store internal_rest_port

### DIFF
--- a/rest-service/manager_rest/configure_manager.py
+++ b/rest-service/manager_rest/configure_manager.py
@@ -531,10 +531,13 @@ def _generate_db_config_entries(cfg):
     mgmtworker_cfg = cfg.get('mgmtworker', {})
     prometheus_cfg = cfg.get('prometheus', {})
     restservice_cfg = cfg.get('restservice', {})
+    internal_rest_port = (
+        manager_cfg.get('internal_rest_port') or DEFAULT_INTERNAL_REST_PORT
+    )
 
     manager_private_ip = manager_cfg.get('private_ip', 'localhost')
     default_file_server_url = f'https://{ipv6_url_compat(manager_private_ip)}'\
-                              f':{DEFAULT_INTERNAL_REST_PORT}/resources'
+                              f':{internal_rest_port}/resources'
     rest_cfg = build_dict(
         rest_service_log_path=os.path.join(
             REST_LOG_DIR, 'cloudify-rest-service.log'),
@@ -558,6 +561,7 @@ def _generate_db_config_entries(cfg):
             'credentials', {}).get('username'),
         log_fetch_password=prometheus_cfg.get(
             'credentials', {}).get('password'),
+        default_agent_port=internal_rest_port,
     )
     mgmtworker_cfg = build_dict(
         max_workers=mgmtworker_cfg.get('max_workers'),


### PR DESCRIPTION
internal_rest_port can now be passed in from the config, and it will be stored in the config table.

The config setting is already used by the workflow_executor, so all we need to do, is to store it!