### PR TITLE
RD-7052 configure_manager: make create-admin-token separate

### DIFF
--- a/rest-service/manager_rest/configure_manager.py
+++ b/rest-service/manager_rest/configure_manager.py
@@ -654,6 +654,7 @@ def _create_admin_token(target):
     db.session.commit()
     with open(target, 'w') as f:
         f.write(token.value)
+    return 0
 
 
 def _wait_for_db(address):
@@ -708,11 +709,12 @@ if __name__ == '__main__':
         sys.exit(_wait_for_db(args.db_wait))
     if args.rabbitmq_wait:
         sys.exit(_wait_for_rabbitmq(args.rabbitmq_wait))
+    if args.create_admin_token:
+        with setup_flask_app().app_context():
+            sys.exit(_create_admin_token(args.create_admin_token))
 
     config.instance.load_configuration(from_db=False)
     with setup_flask_app().app_context():
         user_config = _load_user_config(args.config_file_path)
         config.instance.load_from_db(session=db.session)
         configure(user_config)
-        if args.create_admin_token:
-            _create_admin_token(args.create_admin_token)


### PR DESCRIPTION
The "create-admin-token" part will now be a "subcommand" similar to db-wait and rabbitmq-wait.

The reason is, we want to be able to run create-admin-token, without running the actual "configure" parts.

And that is because normally create-admin-token runs in the mgmtworker initcontainer, while the configure parts run in the restservice one. So that's why we want them to be separate.