### PR TITLE
RD-7054 Join rels when `_include` contains assoc_proxy

### DIFF
--- a/mgmtworker/cloudify_system_workflows/search_utils.py
+++ b/mgmtworker/cloudify_system_workflows/search_utils.py
@@ -174,7 +174,8 @@ def get_instance_ids_by_node_ids(client, node_ids):
     offset = 0
     ni_num = 0
     while True:
-        nis = client.node_instances.list(node_id=node_ids, _offset=offset)
+        nis = client.node_instances.list(
+            node_id=node_ids, _offset=offset, _include=['id', 'node_id'])
         for ni in nis:
             ni_ids[ni['node_id']].add(ni['id'])
         ni_num += len(nis)

--- a/mgmtworker/cloudify_system_workflows/tests/snapshots/test_restore.py
+++ b/mgmtworker/cloudify_system_workflows/tests/snapshots/test_restore.py
@@ -761,7 +761,7 @@ EXPECTED_CALLS = {
                             }
                         ],
                         graph_id='595734d3-1535-4894-b366-ae36e52ca27c'
-                    )
+                    ),
                 ],
             },
             'sort_key': '',

--- a/mgmtworker/cloudify_system_workflows/tests/test_create_deployment.py
+++ b/mgmtworker/cloudify_system_workflows/tests/test_create_deployment.py
@@ -51,8 +51,9 @@ def mock_client(blueprint_plan):
     client.blueprints.get.return_value = bp
     client.deployments.set_attributes.return_value = dep
 
-    client.node_instances.list = lambda node_id, _offset: ListResponse(
-        [], {'pagination': {'total': 0, 'size': 1000}})
+    client.node_instances.list = \
+        lambda node_id, _offset, **kwargs: ListResponse(
+            [], {'pagination': {'total': 0, 'size': 1000}})
     client.evaluate.functions = lambda dep, ctx, obj: {'payload': obj}
     with mock.patch(
         'cloudify_system_workflows.deployment_environment.get_rest_client',

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -203,7 +203,7 @@ class SQLStorageManager(object):
         if sort or distinct:
             if distinct:
                 query = query.order_by(*distinct)
-            for column, order in sort.items():
+            for column, order in sort:
                 while isinstance(column, AssociationProxyInstance):
                     # get the actual attribute to sort on
                     column = column.remote_attr
@@ -270,7 +270,7 @@ class SQLStorageManager(object):
         return query
 
     def _add_value_filter(self, query, filters):
-        for column, value in filters.items():
+        for column, value in filters:
             column, value = self._update_case_insensitive(column, value)
             if callable(value):
                 query = query.filter(value(column))
@@ -290,7 +290,7 @@ class SQLStorageManager(object):
 
     def _add_substr_filter(self, query, filters):
         substr_conditions = []
-        for column, value in filters.items():
+        for column, value in filters:
             column, value = self._update_case_insensitive(column, value, True)
             if isinstance(value, str):
                 substr_conditions.append(column.contains(value))

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -40,7 +40,7 @@ from manager_rest.utils import (is_administrator,
                                 all_tenants_authorization,
                                 validate_global_modification)
 
-from .utils import get_column, get_joins
+from .utils import get_joins
 from .filters import add_filter_rules_to_query
 
 from psycopg2 import DatabaseError as Psycopg2DBError

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -474,19 +474,26 @@ class SQLStorageManager(object):
         """Go over the optional parameters (include, filters, sort), and
         replace column names with actual SQLA column objects
         """
-        include = [get_column(model_class, c) for c in include]
-        include = [item for item in include if item is not None]
-        filters = {get_column(model_class, c): filters[c] for c in filters}
-        filters = {k: v for k, v in filters.items() if k is not None}
-        substr_filters = {get_column(model_class, c): substr_filters[c]
-                          for c in substr_filters}
-        substr_filters = {k: v for k, v in substr_filters.items()
-                          if k is not None}
-        sort = OrderedDict((get_column(model_class, c), sort[c]) for c in sort
-                           if get_column(model_class, c) is not None)
-        distinct = [get_column(model_class, c) for c in distinct]
-        distinct = [item for item in distinct if item if item is not None]
-
+        include = [
+            col for colname in include
+            if (col := getattr(model_class, colname, None))
+        ]
+        filters = [
+            (col, filters[colname]) for colname in filters
+            if (col := getattr(model_class, colname, None))
+        ]
+        substr_filters = [
+            (col, substr_filters[colname]) for colname in substr_filters
+            if (col := getattr(model_class, colname, None))
+        ]
+        sort = [
+            (col, sort[colname]) for colname in sort
+            if (col := getattr(model_class, colname, None))
+        ]
+        distinct = [
+            col for colname in distinct
+            if (col := getattr(model_class, colname, None))
+        ]
         return include, filters, substr_filters, sort, distinct
 
     @staticmethod

--- a/rest-service/manager_rest/storage/utils.py
+++ b/rest-service/manager_rest/storage/utils.py
@@ -3,29 +3,6 @@ from collections import OrderedDict
 from manager_rest.storage.models_base import is_orm_attribute
 
 
-def get_column(model_class, column_name):
-    """Return the column on which an action (filtering, sorting, etc.)
-    would need to be performed. Can be either an attribute of the class,
-    or an association proxy linked to a relationship the class has
-    """
-    column = getattr(model_class, column_name, None)
-    if column is None:
-        # This is some sort of derived thing like tenant_roles in User
-        return None
-    if is_orm_attribute(column):
-        return column
-    else:
-        if not hasattr(column, 'remote_attr'):
-            # This is a property or similar, not a real column
-            return None
-        # We need to get to the underlying attribute, so we move on to the
-        # next remote_attr until we reach one
-        while not is_orm_attribute(column.remote_attr):
-            column = column.remote_attr
-        # Put a label on the remote attribute with the name of the column
-        return column.remote_attr.label(column_name)
-
-
 def get_joins(model_class, columns):
     """Get a list of all the attributes on which we need to join
 

--- a/tests/integration_tests/resources/scripts/prepare_reset_storage.py
+++ b/tests/integration_tests/resources/scripts/prepare_reset_storage.py
@@ -3,6 +3,7 @@ import json
 import argparse
 
 from manager_rest import config
+from manager_rest.constants import BOOTSTRAP_ADMIN_ID, DEFAULT_TENANT_ID
 from manager_rest.storage import models
 from manager_rest.flask_utils import setup_flask_app
 
@@ -17,11 +18,11 @@ MANAGER_CONFIG = {
 
 
 def get_password_hash():
-    return models.User.query.one().password
+    return models.User.query.get(BOOTSTRAP_ADMIN_ID).password
 
 
 def get_tenant_password():
-    return models.Tenant.query.one().rabbitmq_password
+    return models.Tenant.query.get(DEFAULT_TENANT_ID).rabbitmq_password
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When `_include`-ing an attribute that is an `association_proxy`, we didn't join the actual relationship, which led to 1+N queries.

This was shown by a client call like the one in the `only include what we need` commit here:
```python
        nis = client.node_instances.list(
            node_id=node_ids, _offset=offset, _include=['id', 'node_id'])
```

This is because `get_column` returns... something... or None... and there's nothing to really join on for us, on the storage_manager level.

And so, it seems that `get_column` is the wrong abstraction here. And since it's wrong, and I don't immediately have a better one, I decided to just un-abstract it, and get columns everywhere via `getattr()`, and follow the assoc-proxy only where required.

Maybe someday we'll find the correct one, but for right now, I think that no abstraction is better than the wrong one...