### PR TITLE
RD-7061 dep-update inte-tests: use `get` in scripts

### DIFF
--- a/tests/integration_tests/resources/dsl/deployment_update/add_and_override_resource/base/morphing_resource.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_and_override_resource/base/morphing_resource.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_and_override_resource/base/stegnant_resource.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_and_override_resource/base/stegnant_resource.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_and_override_resource/modification/morphing_resource.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_and_override_resource/modification/morphing_resource.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_and_override_resource/modification/stegnant_resource.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_and_override_resource/modification/stegnant_resource.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_node/modification/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_node/modification/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_node/modification/remote_increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_node/modification/remote_increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-target_ops_counter=$(ctx target instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx target instance runtime_properties get 'target_ops_counter')
 else
-target_ops_counter=$(ctx instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx instance runtime_properties get 'target_ops_counter')
 fi
 target_ops_counter=${target_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_node_and_relationship/base/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_node_and_relationship/base/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_node_and_relationship/modification/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_node_and_relationship/modification/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_node_operation/modification/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_node_operation/modification/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_node_with_multiple_instances/modification/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_node_with_multiple_instances/modification/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_relationship/base/scripts/remote_increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_relationship/base/scripts/remote_increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-target_ops_counter=$(ctx target instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx target instance runtime_properties get 'target_ops_counter')
 else
-target_ops_counter=$(ctx instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx instance runtime_properties get 'target_ops_counter')
 fi
 target_ops_counter=${target_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_relationship/modification/additional_scripts/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_relationship/modification/additional_scripts/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_relationship/modification/scripts/remote_increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_relationship/modification/scripts/remote_increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-target_ops_counter=$(ctx target instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx target instance runtime_properties get 'target_ops_counter')
 else
-target_ops_counter=$(ctx instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx instance runtime_properties get 'target_ops_counter')
 fi
 target_ops_counter=${target_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_relationship_operation/modification/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_relationship_operation/modification/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/increment_a.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/increment_a.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # load current ops count (or default to 0)
-a_ops_counter=$(ctx instance runtime_properties 'a_ops_counter')
+a_ops_counter=$(ctx instance runtime_properties get 'a_ops_counter')
 a_ops_counter=${a_ops_counter:-0}
 # increment ops count
 a_ops_counter=$(expr $a_ops_counter + 1)

--- a/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/increment_b.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/increment_b.sh
@@ -2,7 +2,7 @@
 
 # load current ops count (or default to 0)
 
-b_ops_counter=$(ctx instance runtime_properties 'b_ops_counter')
+b_ops_counter=$(ctx instance runtime_properties get 'b_ops_counter')
 b_ops_counter=${b_ops_counter:-0}
 # increment ops count
 b_ops_counter=$(expr $b_ops_counter + 1)

--- a/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/increment_c.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/increment_c.sh
@@ -2,7 +2,7 @@
 
 # load current ops count (or default to 0)
 
-c_ops_counter=$(ctx instance runtime_properties 'c_ops_counter')
+c_ops_counter=$(ctx instance runtime_properties get 'c_ops_counter')
 c_ops_counter=${c_ops_counter:-0}
 # increment ops count
 c_ops_counter=$(expr $c_ops_counter + 1)

--- a/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/increment_d.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/increment_d.sh
@@ -2,7 +2,7 @@
 
 # load current ops count (or default to 0)
 
-d_ops_counter=$(ctx instance runtime_properties 'd_ops_counter')
+d_ops_counter=$(ctx instance runtime_properties get 'd_ops_counter')
 d_ops_counter=${d_ops_counter:-0}
 # increment ops count
 d_ops_counter=$(expr $d_ops_counter + 1)

--- a/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/increment_e.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/increment_e.sh
@@ -2,7 +2,7 @@
 
 # load current ops count (or default to 0)
 
-e_ops_counter=$(ctx instance runtime_properties 'e_ops_counter')
+e_ops_counter=$(ctx instance runtime_properties get 'e_ops_counter')
 e_ops_counter=${e_ops_counter:-0}
 # increment ops count
 e_ops_counter=$(expr $e_ops_counter + 1)

--- a/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/increment_f.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/increment_f.sh
@@ -2,7 +2,7 @@
 
 # load current ops count (or default to 0)
 
-f_ops_counter=$(ctx instance runtime_properties 'f_ops_counter')
+f_ops_counter=$(ctx instance runtime_properties get 'f_ops_counter')
 f_ops_counter=${f_ops_counter:-0}
 # increment ops count
 f_ops_counter=$(expr $f_ops_counter + 1)

--- a/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/remote_increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/remote_increment.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # load current ops count (or default to 0)
-target_ops_counter=$(ctx target instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx target instance runtime_properties get 'target_ops_counter')
 target_ops_counter=${target_ops_counter:-0}
 
 # increment ops count

--- a/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/source_increment_b.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/source_increment_b.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # load current ops count (or default to 0)
-source_ops_counter_b=$(ctx source instance runtime_properties 'source_ops_counter_b')
+source_ops_counter_b=$(ctx source instance runtime_properties get 'source_ops_counter_b')
 source_ops_counter_b=${source_ops_counter_b:-0}
 
 # increment ops count

--- a/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/source_increment_d.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_relationships_between_added_nodes/modification/source_increment_d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # load current ops count (or default to 0)
-source_ops_counter_d=$(ctx target instance runtime_properties 'target_ops_counter_de')
+source_ops_counter_d=$(ctx target instance runtime_properties get 'target_ops_counter_de')
 source_ops_counter_d=${source_ops_counter_d:-0}
 
 # increment ops count

--- a/tests/integration_tests/resources/dsl/deployment_update/add_remove_and_modify_relationship/base/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_remove_and_modify_relationship/base/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/add_remove_and_modify_relationship/modification/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/add_remove_and_modify_relationship/modification/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/modify_node_operation/base/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/modify_node_operation/base/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/modify_node_operation/modification/decrement.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/modify_node_operation/modification/decrement.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/modify_node_operation/modification/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/modify_node_operation/modification/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/modify_relationship/base/scripts/remote_increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/modify_relationship/base/scripts/remote_increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-target_ops_counter=$(ctx target instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx target instance runtime_properties get 'target_ops_counter')
 else
-target_ops_counter=$(ctx instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx instance runtime_properties get 'target_ops_counter')
 fi
 target_ops_counter=${target_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/modify_relationship/modification/scripts/remote_increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/modify_relationship/modification/scripts/remote_increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-target_ops_counter=$(ctx target instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx target instance runtime_properties get 'target_ops_counter')
 else
-target_ops_counter=$(ctx instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx instance runtime_properties get 'target_ops_counter')
 fi
 target_ops_counter=${target_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/modify_relationship_operation/base/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/modify_relationship_operation/base/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/modify_relationship_operation/modification/decrement.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/modify_relationship_operation/modification/decrement.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/modify_relationship_operation/modification/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/modify_relationship_operation/modification/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/remove_node/base/remote_increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/remove_node/base/remote_increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-target_ops_counter=$(ctx target instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx target instance runtime_properties get 'target_ops_counter')
 else
-target_ops_counter=$(ctx instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx instance runtime_properties get 'target_ops_counter')
 fi
 target_ops_counter=${target_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/remove_node/modification/remote_increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/remove_node/modification/remote_increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-target_ops_counter=$(ctx target instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx target instance runtime_properties get 'target_ops_counter')
 else
-target_ops_counter=$(ctx instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx instance runtime_properties get 'target_ops_counter')
 fi
 target_ops_counter=${target_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/remove_node_operation/base/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/remove_node_operation/base/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/remove_node_operation/modification/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/remove_node_operation/modification/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/remove_relationship/base/remote_increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/remove_relationship/base/remote_increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-target_ops_counter=$(ctx target instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx target instance runtime_properties get 'target_ops_counter')
 else
-target_ops_counter=$(ctx instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx instance runtime_properties get 'target_ops_counter')
 fi
 target_ops_counter=${target_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/remove_relationship/modification/remote_increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/remove_relationship/modification/remote_increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-target_ops_counter=$(ctx target instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx target instance runtime_properties get 'target_ops_counter')
 else
-target_ops_counter=$(ctx instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx instance runtime_properties get 'target_ops_counter')
 fi
 target_ops_counter=${target_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/remove_relationship_operation/base/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/remove_relationship_operation/base/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/remove_relationship_operation/modification/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/remove_relationship_operation/modification/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/scripts/decrease.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/scripts/decrease.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/scripts/decrement.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/scripts/decrement.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/scripts/increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/scripts/increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-source_ops_counter=$(ctx source instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx source instance runtime_properties get 'source_ops_counter')
 else
-source_ops_counter=$(ctx instance runtime_properties 'source_ops_counter')
+source_ops_counter=$(ctx instance runtime_properties get 'source_ops_counter')
 fi
 source_ops_counter=${source_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/scripts/remote_increment.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/scripts/remote_increment.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-target_ops_counter=$(ctx target instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx target instance runtime_properties get 'target_ops_counter')
 else
-target_ops_counter=$(ctx instance runtime_properties 'target_ops_counter')
+target_ops_counter=$(ctx instance runtime_properties get 'target_ops_counter')
 fi
 target_ops_counter=${target_ops_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/skip_install/base/remote_uninstall_inc.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/skip_install/base/remote_uninstall_inc.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-uninstall_op_counter=$(ctx target instance runtime_properties 'uninstall_op_counter')
+uninstall_op_counter=$(ctx target instance runtime_properties get 'uninstall_op_counter')
 else
-uninstall_op_counter=$(ctx instance runtime_properties 'uninstall_op_counter')
+uninstall_op_counter=$(ctx instance runtime_properties get 'uninstall_op_counter')
 fi
 uninstall_op_counter=${uninstall_op_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/skip_install/modification/remote_install_inc.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/skip_install/modification/remote_install_inc.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-install_op_counter=$(ctx target instance runtime_properties 'install_op_counter')
+install_op_counter=$(ctx target instance runtime_properties get 'install_op_counter')
 else
-install_op_counter=$(ctx instance runtime_properties 'install_op_counter')
+install_op_counter=$(ctx instance runtime_properties get 'install_op_counter')
 fi
 install_op_counter=${install_op_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/skip_install/modification/remote_uninstall_inc.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/skip_install/modification/remote_uninstall_inc.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-uninstall_op_counter=$(ctx target instance runtime_properties 'uninstall_op_counter')
+uninstall_op_counter=$(ctx target instance runtime_properties get 'uninstall_op_counter')
 else
-uninstall_op_counter=$(ctx instance runtime_properties 'uninstall_op_counter')
+uninstall_op_counter=$(ctx instance runtime_properties get 'uninstall_op_counter')
 fi
 uninstall_op_counter=${uninstall_op_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/skip_install_and_uninstall/base/target_install_inc.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/skip_install_and_uninstall/base/target_install_inc.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-install_op_counter=$(ctx target instance runtime_properties 'install_op_counter')
+install_op_counter=$(ctx target instance runtime_properties get 'install_op_counter')
 else
-install_op_counter=$(ctx instance runtime_properties 'install_op_counter')
+install_op_counter=$(ctx instance runtime_properties get 'install_op_counter')
 fi
 install_op_counter=${install_op_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/skip_install_and_uninstall/base/target_uninstall_inc.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/skip_install_and_uninstall/base/target_uninstall_inc.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-uninstall_op_counter=$(ctx target instance runtime_properties 'uninstall_op_counter')
+uninstall_op_counter=$(ctx target instance runtime_properties get 'uninstall_op_counter')
 else
-uninstall_op_counter=$(ctx instance runtime_properties 'uninstall_op_counter')
+uninstall_op_counter=$(ctx instance runtime_properties get 'uninstall_op_counter')
 fi
 uninstall_op_counter=${uninstall_op_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/skip_install_and_uninstall/modification/target_install_inc.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/skip_install_and_uninstall/modification/target_install_inc.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-install_op_counter=$(ctx target instance runtime_properties 'install_op_counter')
+install_op_counter=$(ctx target instance runtime_properties get 'install_op_counter')
 else
-install_op_counter=$(ctx instance runtime_properties 'install_op_counter')
+install_op_counter=$(ctx instance runtime_properties get 'install_op_counter')
 fi
 install_op_counter=${install_op_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/skip_install_and_uninstall/modification/target_uninstall_inc.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/skip_install_and_uninstall/modification/target_uninstall_inc.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-uninstall_op_counter=$(ctx target instance runtime_properties 'uninstall_op_counter')
+uninstall_op_counter=$(ctx target instance runtime_properties get 'uninstall_op_counter')
 else
-uninstall_op_counter=$(ctx instance runtime_properties 'uninstall_op_counter')
+uninstall_op_counter=$(ctx instance runtime_properties get 'uninstall_op_counter')
 fi
 uninstall_op_counter=${uninstall_op_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/skip_uninstall/base/remote_uninstall_inc.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/skip_uninstall/base/remote_uninstall_inc.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-uninstall_op_counter=$(ctx target instance runtime_properties 'uninstall_op_counter')
+uninstall_op_counter=$(ctx target instance runtime_properties get 'uninstall_op_counter')
 else
-uninstall_op_counter=$(ctx instance runtime_properties 'uninstall_op_counter')
+uninstall_op_counter=$(ctx instance runtime_properties get 'uninstall_op_counter')
 fi
 uninstall_op_counter=${uninstall_op_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/skip_uninstall/modification/remote_install_inc.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/skip_uninstall/modification/remote_install_inc.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-install_op_counter=$(ctx target instance runtime_properties 'install_op_counter')
+install_op_counter=$(ctx target instance runtime_properties get 'install_op_counter')
 else
-install_op_counter=$(ctx instance runtime_properties 'install_op_counter')
+install_op_counter=$(ctx instance runtime_properties get 'install_op_counter')
 fi
 install_op_counter=${install_op_counter:-0}
 

--- a/tests/integration_tests/resources/dsl/deployment_update/skip_uninstall/modification/remote_uninstall_inc.sh
+++ b/tests/integration_tests/resources/dsl/deployment_update/skip_uninstall/modification/remote_uninstall_inc.sh
@@ -3,9 +3,9 @@
 # load current ops count (or default to 0)
 if [[ "$(ctx type)" == 'relationship-instance' ]]
 then
-uninstall_op_counter=$(ctx target instance runtime_properties 'uninstall_op_counter')
+uninstall_op_counter=$(ctx target instance runtime_properties get 'uninstall_op_counter')
 else
-uninstall_op_counter=$(ctx instance runtime_properties 'uninstall_op_counter')
+uninstall_op_counter=$(ctx instance runtime_properties get 'uninstall_op_counter')
 fi
 uninstall_op_counter=${uninstall_op_counter:-0}
 


### PR DESCRIPTION
All the scripts used something like:
```bash
a_ops_counter=$(ctx instance runtime_properties 'a_ops_counter')
```
On the first run of the script, that errors out, spewing an error message into the logs - because that is a KeyError, the property doesn't exist.

The script continues anyway, because there's no `set -e`, and the test can pass.

This commit replaces it with a `get` in all the scripts, so that there's no unnecessary error printout.

(and now the scripts COULD use `set -e` if we wanted to)