### PR TITLE
RD-7069 Don't attempt to join "object" assoc-proxies

### DIFF
--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -145,11 +145,14 @@ class SQLStorageManager(object):
                 if isinstance(field, AssociationProxyInstance):
                     # specialcase if there is an assoc proxy in includes:
                     # join the proxied-to relationship, but only load
-                    # the proxied attribute
-                    rels.add(
-                        db.joinedload(field.parent.target_collection)
-                        .load_only(field.remote_attr)
-                    )
+                    # the proxied attribute.
+                    # But only do it for scalar attributes; if the remote
+                    # field is a whole object, we can't do much about that.
+                    if field.scalar:
+                        rels.add(
+                            db.joinedload(field.parent.target_collection)
+                            .load_only(field.remote_attr)
+                        )
                     continue
 
                 if not hasattr(field, 'prop'):


### PR DESCRIPTION
Only join assoc proxies when they're proxying to a single attribute. When they're proxying to a whole object, this join cannot work.

Notably, listing user-groups with include=tenants, fails when trying to join this way, because of the usergroup -> usertenantassoc -> tenant relationship structure there...

Yes that means "object" proxies like usergroups->tenants will still emit 1+N. We still need a better solution for that.