### PR TITLE
RD-7070 Make summary work with chained assoc-proxies

### DIFF
--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -291,6 +291,7 @@ class BaseServerTestCase(unittest.TestCase):
                             mock_http_client
                         client.secrets_providers.api = mock_http_client
                         client.resources.api = mock_http_client
+                        client.summary.node_instances.api = mock_http_client
 
         return client
 

--- a/rest-service/manager_rest/test/endpoints/test_nodes.py
+++ b/rest-service/manager_rest/test/endpoints/test_nodes.py
@@ -402,6 +402,24 @@ class NodesTest(_NodeSetupMixin, base_test.BaseServerTestCase):
         assert all(ni.deployment_id == dep2.id for ni in dep2_n4_instances)
         assert all(ni.node_id == node4.id for ni in dep2_n4_instances)
 
+    def test_summarize_instances(self):
+        summary = self.client.summary.node_instances.get(
+            'deployment_id', 'node_id')
+        assert not summary
+
+        dep = self._deployment('d2')
+        node1 = self._node('1', deployment=dep)
+        self._instance('11', node=node1)
+
+        summary = self.client.summary.node_instances.get(
+            'deployment_id', 'node_id')
+        assert len(summary) == 1
+        assert summary[0]['deployment_id'] == dep.id
+        assert summary[0]['node_instances'] == 1
+        assert len(summary[0]['by node_id']) == 1
+        assert summary[0]['by node_id'][0]['node_id'] == node1.id
+        assert summary[0]['by node_id'][0]['node_instances'] == 1
+
     def test_sort_node_instances_list(self):
         dep2 = self._deployment('d2')
         node1 = self._node('0', deployment=self.dep1)


### PR DESCRIPTION
1. deref the fields inside of `summarize` the same way we do elsewhere. Still looking for a better general approach. For right now, it's still this.
2. In get_base_query, follow chained assoc-proxies as well, building the joinpath as we go
3. Add a test for summaries at all...