### PR TITLE
CYBL-2013 Delete dep-group: run workflows after the delete

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -1403,9 +1403,12 @@ class DeploymentGroupsId(SecuredResource):
                     )
                     delete_exc_group.executions.append(delete_exc)
                 messages = delete_exc_group.start_executions(sm, rm)
-            workflow_executor.execute_workflow(messages)
 
         sm.delete(group)
+
+        if args.delete_deployments:
+            workflow_executor.execute_workflow(messages)
+
         return None, 204
 
 


### PR DESCRIPTION
When deleting a group with deployments, delete the group first, and only then start the delete-dep-env executions.

Otherwise, there's a race between the executions and the group delete, and for large enough groups, it'll cause concurrent access and ultimately errors.