### PR TITLE
RD-7078 Replace the user.role property with a relationship

### DIFF
--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -441,9 +441,21 @@ class User(CreatedAtMixin, SQLModelBase, UserMixin):
 
         return user_dict
 
-    @property
-    def role(self):
-        return self.roles[0].name
+    @declared_attr
+    def first_role(cls):
+        # The "first", oldest, role that the user has. This is only useful
+        # for user.role, which then is a string role name.
+        # In principle, it's a bad idea to use this, because it would be better
+        # to always consider all of the user's roles, not just the first one.
+        return db.relationship(
+            Role,
+            uselist=False,
+            viewonly=True,
+            order_by=db.asc(Role.id),
+            secondary=cls.roles.secondary,
+        )
+
+    role = association_proxy('first_role', 'name')
 
     @property
     def group_system_roles(self):

--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -264,6 +264,23 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         retrieved = self.sm.list(models.Secret, filters={'_storage_id': []})
         assert len(retrieved) == 0
 
+    def test_users_filter_role(self):
+        abc_role = models.Role(name='abc', type='system_role')
+
+        other_admin = models.User(username='other_admin')
+        other_admin.roles = [
+            abc_role
+        ] + self.user.roles
+        db.session.add(other_admin)
+
+        other_user = models.User(username='abcd')
+        other_user.roles = [
+            abc_role,
+            models.Role(name='def', type='system_role'),
+        ]
+        db.session.add(other_user)
+        users = self.sm.list(models.User, filters={'role': 'sys_admin'})
+        assert set(users) == {self.user, other_admin}
 
 class TestTransactions(base_test.BaseServerTestCase):
     def _make_secret(self, id, value):

--- a/rest-service/manager_rest/test/endpoints/test_storage_manager.py
+++ b/rest-service/manager_rest/test/endpoints/test_storage_manager.py
@@ -282,6 +282,7 @@ class StorageManagerTests(base_test.BaseServerTestCase):
         users = self.sm.list(models.User, filters={'role': 'sys_admin'})
         assert set(users) == {self.user, other_admin}
 
+
 class TestTransactions(base_test.BaseServerTestCase):
     def _make_secret(self, id, value):
         # these tests are using secrets, but they could just as well


### PR DESCRIPTION
Using a property like that returns the first role's name, yes... but filtering on it doesn't work at all.

Before RD-7054, `sm.list(User, filters={'role': 'sys_admin'})` used to just... return all users :) The filter was not applied at all.

After RD-7054, the filter was now applied, but comparing a `class_property_object == 'sys_admin'` just returned False, and we ended up doing essentially a `.filter(False)`, so that `sm.list` call would just return no users.

That made some tests fail, including e.g.
`integration_tests/tests/agentless_tests/multi_tenancy/test_users.py -k test_delete_last_sysadmin_fails` Before, they were passing, but that was a false positive, because the filter was just returning all users (even non-admins).

With this change, user.role is now a bit smarter, and we have some control what the _first_ role actually is (via the order_by), and it is now possible to filter on it.