### PR TITLE
RD-206 Replace sm.full_access_list with direct queries

### DIFF
--- a/execution-scheduler/execution_scheduler/main.py
+++ b/execution-scheduler/execution_scheduler/main.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from cloudify.models_states import ExecutionState
 
 from manager_rest import config, workflow_executor
-from manager_rest.storage import models, get_storage_manager
+from manager_rest.storage import models
 from manager_rest.flask_utils import setup_flask_app
 from manager_rest.maintenance import get_maintenance_state
 from manager_rest.constants import MAINTENANCE_MODE_ACTIVATED
@@ -48,24 +48,21 @@ def check_schedules():
         return
 
     logger.debug('Checking schedules...')
-    sm = get_storage_manager()
-    schedules = sm.full_access_list(
-        models.ExecutionSchedule,
-        filters={
-            models.ExecutionSchedule.enabled: True,
-            models.ExecutionSchedule.next_occurrence:
-            lambda x: x < datetime.utcnow()
-        }
+    schedules = (
+        models.ExecutionSchedule.query
+        .filter_by(enabled=True)
+        .filter(models.ExecutionSchedule.next_occurrence < datetime.utcnow())
+        .all()
     )
     if not schedules:
         db.session.rollback()
         return
 
     for schedule in schedules:
-        try_run(schedule, sm)
+        try_run(schedule)
 
 
-def try_run(schedule, sm):
+def try_run(schedule):
     lock_num = SCHEDULER_LOCK_BASE + schedule._storage_id
     with scheduler_lock(lock_num) as locked:
         if not locked:
@@ -84,7 +81,7 @@ def try_run(schedule, sm):
             execution = execute_workflow(schedule)
             schedule.latest_execution = execution
         schedule.next_occurrence = next_occurrence
-        sm.update(schedule)
+        db.session.commit()
 
 
 @contextmanager

--- a/rest-service/manager_rest/maintenance.py
+++ b/rest-service/manager_rest/maintenance.py
@@ -22,7 +22,7 @@ from io import StringIO
 from cloudify.models_states import ExecutionState
 
 from manager_rest import utils
-from manager_rest.storage import get_storage_manager, models
+from manager_rest.storage import models
 from manager_rest.storage.models_base import db
 from manager_rest.constants import (FORBIDDEN_METHODS,
                                     MAINTENANCE_MODE_ACTIVATED,
@@ -113,17 +113,19 @@ def _return_maintenance_error(status):
 
 
 def get_running_executions():
-    executions = get_storage_manager().full_access_list(models.Execution)
+    executions = (
+        models.Execution.query
+        .filter(models.Execution.status.notin_(ExecutionState.END_STATES))
+        .all()
+    )
     running_executions = []
     for execution in executions:
-        if execution.status not in ExecutionState.END_STATES:
-            running_executions.append({
-                'id': execution.id,
-                'status': execution.status,
-                'deployment_id': execution.deployment_id,
-                'workflow_id': execution.workflow_id
-            })
-
+        running_executions.append({
+            'id': execution.id,
+            'status': execution.status,
+            'deployment_id': execution.deployment_id,
+            'workflow_id': execution.workflow_id
+        })
     return running_executions
 
 

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -858,32 +858,6 @@ class SQLStorageManager(object):
                                 all_tenants=all_tenants)
         return True if query.first() else False
 
-    def full_access_list(self, model_class, filters=None):
-        """Return a list of `model_class` results, without considering the
-           user or the tenant
-
-        :param model_class: SQL DB table class
-        :param filters: An optional dictionary where keys are column names to
-                        filter by, and values are values applicable for those
-                        columns (or lists of such values)
-        :return: A (possibly empty) list of `model_class` results
-        """
-        query = model_class.query
-
-        # first, resolve the filters into a format used by ._add_value_filter
-        _include, filters, _substr_filters, _sort, _distinct = \
-            self._get_columns_from_field_names(
-                model_class,
-                include=[],
-                filters=filters or {},
-                substr_filters={},
-                sort={},
-                distinct=[],
-            )
-        if filters:
-            query = self._add_value_filter(query, filters)
-        return query.all()
-
     def put(self, instance):
         """Create a `model_class` instance from a serializable `model` object
 

--- a/rest-service/manager_rest/test/endpoints/test_maintenance_mode.py
+++ b/rest-service/manager_rest/test/endpoints/test_maintenance_mode.py
@@ -234,7 +234,7 @@ class MaintenanceModeTest(BaseServerTestCase):
 
     def _test_different_execution_status_in_activating_mode(
             self,
-            execution_status=None):
+            execution_status=ExecutionState.STARTED):
         self.put_blueprint(blueprint_id='b1')
         self._start_maintenance_transition_mode(
             execution_status=execution_status)

--- a/rest-service/manager_rest/update_managers_version.py
+++ b/rest-service/manager_rest/update_managers_version.py
@@ -8,25 +8,26 @@ import argparse
 
 from manager_rest import config
 from manager_rest.flask_utils import setup_flask_app
-from manager_rest.storage import models, get_storage_manager
+from manager_rest.storage import db, models
 
 logger = logging.getLogger(__name__)
 
 
 def update_managers_version(version):
     logger.debug('Updating Cloudify managers version in DB...')
-    sm = get_storage_manager()
-    managers = sm.full_access_list(models.Manager)
 
     hostname = socket.gethostname()
     if hasattr(config.instance, 'manager_hostname'):
         hostname = config.instance.manager_hostname
 
+    managers = (
+        models.Manager.query
+        .filter_by(hostname=hostname)
+        .all()
+    )
     for manager in managers:
-        if manager.hostname == hostname:
-            manager.version = version
-            sm.update(manager)
-            break
+        manager.version = version
+    db.session.commit()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Turns out we don't really need .full_access_list: it's used in only a few places, and it's easily replaceable by just direct queries. I prefer that, and it'll make the upcoming changes easier, by reducing the storage-manager scope somewhat.

Also, for the maintenance-mode test: I replace the python-side forloop with a query - so I also change the test to not have status=None, but a valid status, because I don't really want to make the query have to cover None.  (and if an execution does have None somehow - we don't really want to block maintenance on it anyway. So that used to be a bug, really)