### PR TITLE
RD-4801 Composer snapshots cleanup

### DIFF
--- a/mgmtworker/cloudify_system_workflows/tests/snapshots/test_create.py
+++ b/mgmtworker/cloudify_system_workflows/tests/snapshots/test_create.py
@@ -196,7 +196,7 @@ MOCK_CLIENT_RESPONSES = {
 }
 MOCK_COMPOSER_RESPONSES = {
     'blueprints.zip': base64.b64decode(EMPTY_B64_ZIP),
-    'blueprints.json': b'{}',
+    'blueprints.json': b'[]',
     'configuration.json': b'{}',
     'favorites.json': b'[]',
 }
@@ -393,7 +393,7 @@ def mock_get_composer_client():
                     return b'{}'
 
         def get_metadata(self):
-            return b'{}'
+            return b'[]'
 
     class MockComposerClient:
         blueprints = MockComposerBaseSnapshotClient('blueprints')


### PR DESCRIPTION
* dropping MultipartEncoder in blueprints' snapshot restore,
* test fix: blueprint's metadata are a list not a dict,
* small refactor,
* docstrings.

This is `7.0.0-build` cherry-pick of https://github.com/cloudify-cosmo/cloudify-manager/pull/4105