### PR TITLE
RD-5656 Remove deprecated ldap_ca_path

### DIFF
--- a/rest-service/migrations/versions/edd6d829a209_6_4_to_7_0.py
+++ b/rest-service/migrations/versions/edd6d829a209_6_4_to_7_0.py
@@ -51,9 +51,11 @@ def upgrade():
     add_file_server_type_config()
     add_default_agents_rest_port_config()
     add_blueprint_requirements_column()
+    drop_ldap_ca_config()
 
 
 def downgrade():
+    add_ldap_ca_config()
     drop_blueprint_requirements_column()
     drop_default_agents_rest_port_config()
     drop_file_server_type_config()
@@ -787,6 +789,27 @@ def drop_s3_client_config():
                 & (config_table.c.scope == op.inline_literal('rest'))
             )
         )
+
+
+def drop_ldap_ca_config():
+    op.execute(
+        config_table.delete().where(
+            (config_table.c.name == op.inline_literal('ldap_ca_path'))
+            & (config_table.c.scope == op.inline_literal('rest'))
+        )
+    )
+
+
+def add_ldap_ca_config():
+    op.bulk_insert(config_table, [
+            dict(
+                name='ldap_ca_path',
+                value=op.inline_literal('null'),
+                scope='rest',
+                schema={'type': 'string'},
+                is_editable=True
+            )
+        ])
 
 
 def add_file_server_type_config():


### PR DESCRIPTION
This setting is unused, because ldap_ca_cert is used instead. (stored in the certs table)