### PR TITLE
RD-7094 Usable audit_log reference to the original object

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -12,6 +12,7 @@ from flask_restful import fields as flask_fields
 
 from sqlalchemy import case
 from sqlalchemy import func, select, table, column, exists
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import validates, aliased
@@ -2704,6 +2705,7 @@ class AuditLog(CreatedAtMixin, SQLModelBase):
     _storage_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     ref_table = db.Column(db.Text, nullable=False, index=True)
     ref_id = db.Column(db.Integer, nullable=False)
+    ref_identifier = db.Column(JSONB)
     operation = db.Column(db.Enum(*AUDIT_OPERATIONS, name='audit_operation'),
                           nullable=False)
     creator_name = db.Column(db.Text, nullable=True, index=True)

--- a/rest-service/migrations/versions/edd6d829a209_6_4_to_7_0.py
+++ b/rest-service/migrations/versions/edd6d829a209_6_4_to_7_0.py
@@ -447,8 +447,7 @@ def remove_p_from_pickle_columns():
                     new_column_name='supported_py_versions')
     op.alter_column('plugins',
                     column_name='wheels_p',
-                    new_column_name='wheels',
-                    nullable=False)
+                    new_column_name='wheels')
 
     op.alter_column('plugins_updates',
                     column_name='deployments_to_update_p',

--- a/rest-service/migrations/versions/edd6d829a209_6_4_to_7_0.py
+++ b/rest-service/migrations/versions/edd6d829a209_6_4_to_7_0.py
@@ -948,12 +948,13 @@ def create_functions_write_audit_log():
                 _operation := 'delete';
                 _record := to_json(OLD);
             END IF;
+
             _ref_identifier := (
                 SELECT jsonb_object(
-                    array_agg(kv.key::TEXT),
-                    array_agg(trim(both '"' from kv.value::TEXT))
+                    array_agg(key),
+                    array_agg(_record ->> key)
                 )
-                FROM jsonb_each(_record) kv WHERE kv.key = ANY(_id_columns)
+                FROM unnest(_id_columns) id_cols(key)
             );
 
             INSERT INTO public.audit_log (ref_table, ref_id, ref_identifier,


### PR DESCRIPTION
This patch is about the usability of data stored in the audit_log DB table.  Adding ref_identifier field enables storing arbitrary fields used to better identify referenced object.