### PR TITLE
RND-178 config.prometheus_url: normalize the base url

### DIFF
--- a/rest-service/manager_rest/prometheus_client.py
+++ b/rest-service/manager_rest/prometheus_client.py
@@ -5,7 +5,7 @@ from manager_rest import config
 
 
 def query(query_string: str, logger, timeout=None) -> typing.List[dict]:
-    query_url = '{}/monitoring/api/v1/query'.format(
+    query_url = '{}/api/v1/query'.format(
         config.instance.prometheus_url,
     )
     url_with_query_string = \

--- a/rest-service/migrations/versions/edd6d829a209_6_4_to_7_0.py
+++ b/rest-service/migrations/versions/edd6d829a209_6_4_to_7_0.py
@@ -909,7 +909,7 @@ def add_prometheus_url_config():
         [
             {
                 'name': 'prometheus_url',
-                'value': 'http://127.0.0.1:9090',
+                'value': 'http://127.0.0.1:9090/monitoring',
                 'scope': 'rest',
                 'schema': {'type': 'string'},
                 'is_editable': True,


### PR DESCRIPTION
Usually, prometheus exposes just `http://<addr>/api`. But our client tries to query `http://<addr>/monitoring/api`.

This is because in the AIO prometheus, we set
`--web.external-address=http://.../monitoring`.

However, in other deployments, like the cloudify-helm deployment, this url part isn't there.

So we can fix it in two ways:
1. either make the cloudify-helm prometheus expose it under that path,
2. or make the /monitoring part be part of the configuration.

This PR implements 2. I think it's more flexible.