### PR TITLE
RND-213 Add _common_only flag to searches/workflows

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/searches.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/searches.py
@@ -189,12 +189,16 @@ class WorkflowsSearches(ResourceSearches):
     def post(self, all_tenants=None, search=None, filter_id=None, **kwargs):
         """List workflows using filter rules"""
         _include = ['id', 'workflows']
+        common_only = rest_utils.verify_and_convert_bool(
+            '_common_only',
+            request.args.get('_common_only', False)
+        )
         filters = rest_utils.deployment_group_id_filter()
         result = super().post(models.Deployment, models.DeploymentsFilter,
                               _include, filters, None, None, all_tenants,
                               search, filter_id, **kwargs)
 
-        return workflows_list_response(result)
+        return workflows_list_response(result, common_only=common_only)
 
 
 class NodesSearches(ResourceSearches):

--- a/rest-service/manager_rest/rest/resources_v3_1/workflows.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/workflows.py
@@ -50,9 +50,10 @@ class Workflows(SecuredResource):
 
 
 def workflows_list_response(
-        deployments: Iterable[models.Deployment]
+        deployments: Iterable[models.Deployment],
+        common_only: bool = False,
 ) -> ListResponse:
-    workflows = _extract_workflows(deployments)
+    workflows = _extract_workflows(deployments, common_only=common_only)
     pagination = {
         'total': len(workflows),
         'size': len(workflows),
@@ -63,11 +64,18 @@ def workflows_list_response(
 
 
 def _extract_workflows(
-        deployments: Iterable[models.Deployment]
+        deployments: Iterable[models.Deployment],
+        common_only: bool = False,
 ) -> List[Workflow]:
-    workflows = set()
+    if not deployments:
+        return []
+    first_dep, *deployments = deployments
+    workflows = set(first_dep._list_workflows())
     for dep in deployments:
-        workflows |= set(dep._list_workflows())
+        if common_only:
+            workflows &= set(dep._list_workflows())
+        else:
+            workflows |= set(dep._list_workflows())
     return list(workflows)
 
 


### PR DESCRIPTION
This allows using `/api/v3.1/searches/workflows?_common_only=True` to list only the workflows which are common between the filtered deployments