### PR TITLE
test_download_blueprint: use subprocess.run

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/test_download_blueprint.py
+++ b/tests/integration_tests/tests/agentless_tests/test_download_blueprint.py
@@ -17,6 +17,7 @@ import filecmp
 import os
 import pytest
 import shutil
+import subprocess
 import tarfile
 import uuid
 
@@ -71,4 +72,4 @@ class DownloadBlueprintTest(AgentlessTestCase):
 
     @staticmethod
     def _create_file(file_size, file_location):
-        os.system('fallocate -l {0} {1}'.format(file_size, file_location))
+        subprocess.run(['fallocate', '-l', file_size, file_location])


### PR DESCRIPTION
instead of os.system, use subprocess.run

In principle, this use of os.system was vulnerable to injection attacks. Of course, the impact is practically zero, because this function was only called from one test. Still, might as well use the correct approach instead.