### PR TITLE
RND-328 execution-scheduler: update config when it changes

### DIFF
--- a/execution-scheduler/execution_scheduler/main.py
+++ b/execution-scheduler/execution_scheduler/main.py
@@ -10,7 +10,7 @@ from cloudify.models_states import ExecutionState
 
 from manager_rest import config, workflow_executor
 from manager_rest.storage import models
-from manager_rest.flask_utils import setup_flask_app
+from manager_rest.flask_utils import setup_flask_app, query_service_settings
 from manager_rest.maintenance import get_maintenance_state
 from manager_rest.constants import MAINTENANCE_MODE_ACTIVATED
 from manager_rest.resource_manager import get_resource_manager
@@ -58,6 +58,10 @@ def check_schedules():
         db.session.rollback()
         return
 
+    # before running any schedules, let's see if anything changed in the
+    # config, so that we start the executions with the most up-to-date
+    # settings, such as rabbitmq address, etc.
+    query_service_settings()
     for schedule in schedules:
         try_run(schedule)
 

--- a/rest-service/manager_rest/flask_utils.py
+++ b/rest-service/manager_rest/flask_utils.py
@@ -87,7 +87,10 @@ def query_service_settings():
     last_updated_subquery = (
         db.session.query(models.Role.updated_at.label('updated_at'))
         .union_all(
-            db.session.query(models.Config.updated_at.label('updated_at'))
+            db.session.query(models.Config.updated_at.label('updated_at')),
+            db.session.query(
+                models.Certificate.updated_at.label('updated_at')
+            ),
         ).subquery()
     )
     db_config_last_updated = db.session.query(


### PR DESCRIPTION
Commonly, the scheduler starts before the restservice does, and in the case of the k8s deployment, even before the restservice is finished inserting rabbitmq address & credentials into the db.

Then, the scheduler fails to run anything, because it started and queried the config before the rabbitmq address was populated there.

Restarting the scheduler would mitigate that, but it's of course not practical to restart the scheduler after every change to the config (including the initial "change" - first inserting it).

So, let's use the same method we use in the restservice, and query last-changed times for the configs. To do that, move the function to the utils module, so that it can be imported into the scheduler service (importing server.py has side-effects, unfortunately...)