### PR TITLE
RND-328 execution-scheduler: update config when it changes

### DIFF
--- a/execution-scheduler/execution_scheduler/main.py
+++ b/execution-scheduler/execution_scheduler/main.py
@@ -10,7 +10,7 @@ from cloudify.models_states import ExecutionState
 
 from manager_rest import config, workflow_executor
 from manager_rest.storage import models
-from manager_rest.flask_utils import setup_flask_app
+from manager_rest.flask_utils import setup_flask_app, query_service_settings
 from manager_rest.maintenance import get_maintenance_state
 from manager_rest.constants import MAINTENANCE_MODE_ACTIVATED
 from manager_rest.resource_manager import get_resource_manager
@@ -58,6 +58,10 @@ def check_schedules():
         db.session.rollback()
         return
 
+    # before running any schedules, let's see if anything changed in the
+    # config, so that we start the executions with the most up-to-date
+    # settings, such as rabbitmq address, etc.
+    query_service_settings()
     for schedule in schedules:
         try_run(schedule)
 

--- a/rest-service/manager_rest/flask_utils.py
+++ b/rest-service/manager_rest/flask_utils.py
@@ -1,9 +1,9 @@
-from flask import Flask
+from flask import Flask, current_app
 from flask_migrate import Migrate
 from flask_security import Security
 
 from manager_rest import config, utils
-from manager_rest.storage import user_datastore, db
+from manager_rest.storage import user_datastore, db, models
 from manager_rest.storage.models import Tenant
 from manager_rest.config import instance as manager_config
 
@@ -75,3 +75,33 @@ def get_tenant_by_name(tenant_name):
             'not exist.'.format(name=tenant_name)
         )
     return tenant
+
+
+def query_service_settings():
+    """Check for when was the config updated, and if needed, reload it.
+
+    This makes sure that config updates will (eventually) be propagated
+    to all workers, and that every worker always has the most recent
+    config/permissions settings available.
+    """
+    last_updated_subquery = (
+        db.session.query(models.Role.updated_at.label('updated_at'))
+        .union_all(
+            db.session.query(models.Config.updated_at.label('updated_at')),
+            db.session.query(
+                models.Certificate.updated_at.label('updated_at')
+            ),
+        ).subquery()
+    )
+    db_config_last_updated = db.session.query(
+        db.func.max(last_updated_subquery.c.updated_at)
+    ).scalar()
+    current_app.logger.debug('Last updated locally: %s, in db: %s',
+                             config.instance.last_updated,
+                             db_config_last_updated)
+    if db_config_last_updated is not None and (
+            config.instance.last_updated is None or
+            db_config_last_updated > config.instance.last_updated):
+        current_app.logger.warning('Config has changed - reloading')
+        config.instance.load_from_db()
+        current_app.logger.setLevel(config.instance.rest_service_log_level)


### PR DESCRIPTION
This ports #4147 to 7.0.0

* RND-328 execution-scheduler: update config when it changes

Commonly, the scheduler starts before the restservice does, and in the case of the k8s deployment, even before the restservice is finished inserting rabbitmq address & credentials into the db.

Then, the scheduler fails to run anything, because it started and queried the config before the rabbitmq address was populated there.

Restarting the scheduler would mitigate that, but it's of course not practical to restart the scheduler after every change to the config (including the initial "change" - first inserting it).

So, let's use the same method we use in the restservice, and query last-changed times for the configs. To do that, move the function to the utils module, so that it can be imported into the scheduler service (importing server.py has side-effects, unfortunately...)

* query_service_settings: also check Certificate

---------