### PR TITLE
RND-362 Recognise snapshot flavour by file content

### DIFF
--- a/mgmtworker/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/mgmtworker/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -749,19 +749,20 @@ class SnapshotRestore(object):
         snapshot_path = self._get_snapshot_path()
         ctx.logger.debug('Going to restore snapshot, '
                          'snapshot_path: {0}'.format(snapshot_path))
-        new_snapshot = False
         try:
             with ZipFile(snapshot_path, 'r') as zipf:
                 self.scan_snapshot(zipf)
 
-                if (
-                    self._snapshot_version.major >= 7
-                    or (
-                        self._snapshot_version.major == 6
-                        and self._snapshot_version.minor > 4
-                    )
-                ):
+                if self._metadata.get(M_SCHEMA_REVISION) and \
+                        self._metadata.get(M_COMPOSER_SCHEMA_REVISION) and \
+                        self._metadata.get(M_STAGE_SCHEMA_REVISION):
+                    new_snapshot = False
+                elif self._snapshot_version >= ManagerVersion('7.1'):
                     new_snapshot = True
+                else:
+                    new_snapshot = False
+
+                if new_snapshot:
                     self._new_restore(zipf)
                     return
 

--- a/mgmtworker/cloudify_system_workflows/tests/snapshots/partial_snapshot_contents/metadata.json
+++ b/mgmtworker/cloudify_system_workflows/tests/snapshots/partial_snapshot_contents/metadata.json
@@ -1,3 +1,3 @@
 {
-    "snapshot_version": "7.0.0"
+    "snapshot_version": "7.1.0"
 }

--- a/mgmtworker/cloudify_system_workflows/tests/snapshots/snapshot_contents/metadata.json
+++ b/mgmtworker/cloudify_system_workflows/tests/snapshots/snapshot_contents/metadata.json
@@ -1,3 +1,3 @@
 {
-    "snapshot_version": "7.0.0"
+    "snapshot_version": "7.1.0"
 }


### PR DESCRIPTION
* Recognise snapshot flavour by file content and not just snapshot version.

* Upgrade snapshot_version to 7.1.0 in tests

---

This is a cherry-pick of https://github.com/cloudify-cosmo/cloudify-manager/pull/4148