### PR TITLE
inte-tests: cleanup allow_agent & reset_storage

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -234,26 +234,6 @@ def prepare_manager_storage(request, tests_env):
 
 
 @pytest.fixture(scope='session')
-def allow_agent(tests_env, package_agent):
-    """Allow installing an agent on the manager container.
-
-    Agent installation scripts have all kinds of assumptions about
-    sudo and su, so those need to be available.
-    """
-    tests_env.execute_on_manager([
-        'bash',
-        '-c',
-        "echo 'cfyuser ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/cfyuser",
-    ])
-    tests_env.execute_on_manager([
-        'sed',
-        '-i',
-        "1iauth sufficient pam_succeed_if.so user = cfyuser",
-        '/etc/pam.d/su'
-    ])
-
-
-@pytest.fixture(scope='session')
 def package_agent(tests_env, request):
     """Repackage the on-manager agent with the provided sources.
 

--- a/tests/integration_tests/tests/agent_tests/test_snapshots.py
+++ b/tests/integration_tests/tests/agent_tests/test_snapshots.py
@@ -21,7 +21,6 @@ import pytest
 from integration_tests import AgentTestCase
 from cloudify.models_states import AgentState
 from integration_tests.tests.utils import get_resource as resource
-from integration_tests.framework.flask_utils import reset_storage
 
 pytestmark = pytest.mark.group_snapshots
 
@@ -135,7 +134,7 @@ class TestSnapshots(AgentTestCase):
             output_file=downloaded_snapshot,
         )
 
-        reset_storage(self.env)
+        self.env.reset_storage()
         self.client.snapshots.upload(downloaded_snapshot, snapshot_id)
         self._restore_snapshot(states, deployments, snapshot_id)
 
@@ -168,7 +167,7 @@ class TestSnapshots(AgentTestCase):
 
         self._undeploy(states, deployments)
 
-        reset_storage(self.env)
+        self.env.reset_storage()
         self.client.snapshots.upload(downloaded_snapshot, snapshot_id)
         self._restore_snapshot(states, deployments, snapshot_id)
 
@@ -186,6 +185,6 @@ class TestSnapshots(AgentTestCase):
 
         self._undeploy_multitenant(mike_client)
 
-        reset_storage(self.env)
+        self.env.reset_storage()
         self.client.snapshots.upload(downloaded_snapshot, snapshot_id)
         self._restore_snapshot_multitenant(snapshot_id)

--- a/tests/integration_tests/tests/agentless_tests/test_snapshot.py
+++ b/tests/integration_tests/tests/agentless_tests/test_snapshot.py
@@ -25,7 +25,6 @@ from collections import Counter
 from integration_tests.framework import utils
 from integration_tests import AgentlessTestCase
 from integration_tests.tests.utils import get_resource as resource
-from integration_tests.framework.flask_utils import reset_storage
 
 from cloudify.snapshots import STATES
 from cloudify.models_states import AgentState
@@ -267,7 +266,7 @@ class TestSnapshot(AgentlessTestCase):
             output_file=downloaded_snapshot,
         )
 
-        reset_storage(self.env)
+        self.env.reset_storage()
 
         self.client.snapshots.upload(downloaded_snapshot, snapshot_id)
         self.client.snapshots.restore(snapshot_id)
@@ -299,7 +298,7 @@ class TestSnapshot(AgentlessTestCase):
             output_file=downloaded_snapshot,
         )
 
-        reset_storage(self.env)
+        self.env.reset_storage()
 
         self.client.snapshots.upload(downloaded_snapshot, snapshot_id)
         self.client.maintenance_mode.activate()

--- a/tests/integration_tests/tests/test_cases.py
+++ b/tests/integration_tests/tests/test_cases.py
@@ -468,7 +468,6 @@ class AgentlessTestCase(BaseTestCase):
 
 
 @pytest.mark.usefixtures('dockercompute_plugin')
-@pytest.mark.usefixtures('allow_agent')
 class AgentTestCase(BaseTestCase):
     pass
 


### PR DESCRIPTION
- allow_agent is now unnecessary, and it of course breaks k8s tests
- fixup reset_storage usage. I dunno why I missed it in #4153. Whoops.