### PR TITLE
Fix legacy snapshot restore

### DIFF
--- a/rest-service/migrations/versions/edd6d829a209_6_4_to_7_0.py
+++ b/rest-service/migrations/versions/edd6d829a209_6_4_to_7_0.py
@@ -81,7 +81,6 @@ tables_to_audit = {
     'snapshots': ('_storage_id', ['_tenant_id', 'id']),
     'tasks_graphs': ('_storage_id', ['_tenant_id', 'id']),
     'tenants': ('id', ['_tenant_id', 'name']),
-    'usage_collector': ('id', ['manager_id', 'id']),
     'users': ('id', ['username']),
 }
 


### PR DESCRIPTION
* disable auditing triggers while restoring DB tables

* do not create triggered function for usage_collector (it was already removed in 6.4)