### PR TITLE
RND-390 Executions summary: specialcase status_display

### DIFF
--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -292,6 +292,7 @@ class BaseServerTestCase(unittest.TestCase):
                         client.secrets_providers.api = mock_http_client
                         client.resources.api = mock_http_client
                         client.summary.node_instances.api = mock_http_client
+                        client.summary.executions.api = mock_http_client
 
         return client
 

--- a/rest-service/manager_rest/test/endpoints/test_nodes.py
+++ b/rest-service/manager_rest/test/endpoints/test_nodes.py
@@ -403,6 +403,12 @@ class NodesTest(_NodeSetupMixin, base_test.BaseServerTestCase):
         assert all(ni.node_id == node4.id for ni in dep2_n4_instances)
 
     def test_summarize_instances(self):
+        with self.assertRaises(CloudifyClientError) as cm:
+            self.client.summary.node_instances.get('invalid-field')
+        assert cm.exception.status_code == 400
+        error_text = str(cm.exception)
+        assert 'deployment_id' in error_text and 'node_id' in error_text
+
         summary = self.client.summary.node_instances.get(
             'deployment_id', 'node_id')
         assert not summary


### PR DESCRIPTION
Essentially just see the first commit :)

The idea is, let's just avoid passing `status_display` to the storage-manager, and instead, summarize on status, and then rewrite the results as needed.