### PR TITLE
inte-tests: remove nonexistent fixture declaration

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_plugin_workdir.py
+++ b/tests/integration_tests/tests/agent_tests/test_plugin_workdir.py
@@ -23,9 +23,7 @@ pytestmark = pytest.mark.group_plugins
 
 
 @pytest.mark.usefixtures('testmockoperations_plugin')
-@pytest.mark.usefixtures('allow_agent')
 class PluginWorkdirTest(AgentTestCase):
-
     def test_plugin_workdir(self):
         filename = 'test_plugin_workdir.txt'
         host_content = 'HOST_CONTENT'


### PR DESCRIPTION
allow_agent is now unnecessary, and was already removed, but this test was forgotten about. It works fine without it, though.