### PR TITLE
_is_legacy_snapshot: examine the metadata file

### DIFF
--- a/mgmtworker/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/mgmtworker/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -834,13 +834,11 @@ class SnapshotRestore(object):
             self._snapshot_version = ManagerVersion(self._metadata[M_VERSION])
             os.unlink(metadata_path)
 
-        if self._metadata.get(M_SCHEMA_REVISION) and \
-                self._metadata.get(M_COMPOSER_SCHEMA_REVISION) and \
-                self._metadata.get(M_STAGE_SCHEMA_REVISION):
-            return True
-        if self._snapshot_version >= ManagerVersion('7.1'):
-            return False
-        return True
+        return (
+            M_SCHEMA_REVISION in self._metadata and
+            M_COMPOSER_SCHEMA_REVISION in self._metadata and
+            M_STAGE_SCHEMA_REVISION in self._metadata
+        )
 
     @contextmanager
     def _pause_services(self):


### PR DESCRIPTION
7.0 will create new snapshots too, so let's just examine if the metadata file looks like a new or old snapshot, instead of just tying that to the version only