### PR TITLE
RND-495 Make managers.public_ip not unique

### DIFF
--- a/rest-service/manager_rest/storage/management_models.py
+++ b/rest-service/manager_rest/storage/management_models.py
@@ -715,7 +715,7 @@ class Manager(_WithCACert, SQLModelBase, CloudifyNodeMixin):
     id = db.Column(db.Integer, autoincrement=True, primary_key=True)
     hostname = db.Column(db.Text, unique=True, nullable=False)
     private_ip = db.Column(db.Text, unique=True, nullable=False)
-    public_ip = db.Column(db.Text, unique=True, nullable=False)
+    public_ip = db.Column(db.Text, nullable=False)
     version = db.Column(db.Text, nullable=False)
     edition = db.Column(db.Text, nullable=False)
     distribution = db.Column(db.Text, nullable=False)

--- a/rest-service/migrations/versions/edd6d829a209_6_4_to_7_0.py
+++ b/rest-service/migrations/versions/edd6d829a209_6_4_to_7_0.py
@@ -104,9 +104,11 @@ def upgrade():
     add_audit_log_ref_identifier()
     create_functions_write_audit_log()
     update_audit_triggers()
+    managers_public_ip_not_unique()
 
 
 def downgrade():
+    managers_public_ip_unique()
     revert_audit_triggers()
     drop_functions_write_audit_log()
     drop_audit_log_ref_identifier()
@@ -1010,3 +1012,14 @@ def revert_audit_triggers():
         EXECUTE PROCEDURE
         write_audit_log_{ref_id_field.strip('_')}('{table_name}');
         """)
+
+
+def managers_public_ip_not_unique():
+    with op.batch_alter_table('managers', schema=None) as batch_op:
+        batch_op.drop_constraint('managers_public_ip_key', type_='unique')
+
+
+def managers_public_ip_unique():
+    with op.batch_alter_table('managers', schema=None) as batch_op:
+        batch_op.create_unique_constraint(
+            'managers_public_ip_key', ['public_ip'])


### PR DESCRIPTION
It's common - and somewhat expected - that multiple manager (restservice) instances will be sharing the public-ip, when they're behind a single LB/ingress/proxy.

In the future, it'd probably be better if there was only a single entry in the db, perhaps? But anyway, while we do have multiple managers that do indeed all respond behind the same public-ip, that needs to be representable in the db...