### PR TITLE
RD-7154 blueprint upload: handle visibility correctly

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -88,13 +88,15 @@ class BlueprintsId(resources_v2.BlueprintsId):
         form_params = request.form.get('params')
         if form_params:
             args = json.loads(form_params)
+            labels = args.get('labels', [])
         if not args:
-            args = request.args.to_dict(flat=False)
+            args = request.args.to_dict()
+            labels = request.args.getlist('labels') or []
 
         async_upload = args.get('async_upload', False)
         created_at = args.get('created_at')
         created_by = args.get('created_by')
-        labels = args.get('labels', [])
+
         visibility = args.get('visibility')
         private_resource = args.get('private_resource')
         application_file_name = args.get('application_file_name', '')


### PR DESCRIPTION
When doing .to_dict(flat=False), all querystring arguments are going to be lists. That's not what we want for essentially all of the parameters available, but most notably, it breaks with visibility (e.g. in the getting-started flow).

Instead, don't use flat=False, but keep the default of flat=True, and get the list in the one and only argument that cares about getting a list: the labels.