### PR TITLE
RND-623 Delete dep-group with deployments: return excgroup id

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -1427,12 +1427,12 @@ class DeploymentGroupsId(SecuredResource):
         rm = get_resource_manager()
 
         group = sm.get(models.DeploymentGroup, group_id)
+        response = None, 204
         if args.delete_deployments:
             with sm.transaction():
                 delete_exc_group = models.ExecutionGroup(
                     id=str(uuid.uuid4()),
                     workflow_id='delete_deployment_environment',
-                    deployment_group=group,
                 )
                 sm.put(delete_exc_group)
                 for dep in group.deployments:
@@ -1443,13 +1443,14 @@ class DeploymentGroupsId(SecuredResource):
                     )
                     delete_exc_group.executions.append(delete_exc)
                 messages = delete_exc_group.start_executions(sm, rm)
+            response = {'execution_group_id': delete_exc_group.id}, 200
 
         sm.delete(group)
 
         if args.delete_deployments:
             workflow_executor.execute_workflow(messages)
 
-        return None, 204
+        return response
 
 
 def _create_inter_deployment_dependency(

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -385,15 +385,19 @@ class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
             'group1',
             deployment_ids=['dep1']
         )
-        self.client.deployment_groups.delete(
+        response = self.client.deployment_groups.delete(
             'group1', delete_deployments=True)
         assert len(self.client.deployment_groups.list()) == 0
+        assert 'execution_group_id' in response
 
         # dep hasn't been deleted _yet_, but check that delete-dep-env for it
         # was run
         dep = self.sm.get(models.Deployment, 'dep1')
         assert any(exc.workflow_id == 'delete_deployment_environment'
                    for exc in dep.executions)
+        exc_group = self.sm.get(
+            models.ExecutionGroup, response['execution_group_id'])
+        assert len(exc_group.executions) == 1
 
     def test_create_filters(self):
         """Create a group with filter_id to set the deployments"""


### PR DESCRIPTION
In order to follow the progress of deleting the deployments, it'll be useful to receive the execution group id