### PR TITLE
RND-623 Recursive delete for deployments

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v1/deployments.py
@@ -148,7 +148,8 @@ class DeploymentsId(SecuredResource):
         """Delete deployment by id"""
         args = get_args_and_verify_arguments([
             Argument('force', type=boolean, default=False),
-            Argument('delete_logs', type=boolean, default=False)
+            Argument('delete_logs', type=boolean, default=False),
+            Argument('recursive', type=boolean, default=False),
         ])
 
         bypass_maintenance = is_bypass_maintenance_mode()
@@ -157,10 +158,15 @@ class DeploymentsId(SecuredResource):
         dep.deployment_status = DeploymentState.IN_PROGRESS
         sm.update(dep, modified_attrs=('deployment_status',))
         rm = get_resource_manager()
-        rm.check_deployment_delete(dep, force=args.force)
+        rm.check_deployment_delete(
+            dep,
+            force=args.force,
+            recursive=args.recursive,
+        )
         delete_execution = dep.make_delete_environment_execution(
             delete_logs=args.delete_logs,
             force=args.force,
+            recursive=args.recursive,
         )
         messages = rm.prepare_executions(
             [delete_execution], bypass_maintenance=bypass_maintenance)

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -1422,6 +1422,7 @@ class DeploymentGroupsId(SecuredResource):
             Argument('delete_deployments', type=boolean, default=False),
             Argument('force', type=boolean, default=False),
             Argument('delete_logs', type=boolean, default=False),
+            Argument('recursive', type=boolean, default=False),
         ])
         sm = get_storage_manager()
         rm = get_resource_manager()
@@ -1436,10 +1437,15 @@ class DeploymentGroupsId(SecuredResource):
                 )
                 sm.put(delete_exc_group)
                 for dep in group.deployments:
-                    rm.check_deployment_delete(dep, force=args.force)
+                    rm.check_deployment_delete(
+                        dep,
+                        force=args.force,
+                        recursive=args.recursive,
+                    )
                     delete_exc = dep.make_delete_environment_execution(
                         delete_logs=args.delete_logs,
                         force=args.force,
+                        recursive=args.recursive,
                     )
                     delete_exc_group.executions.append(delete_exc)
                 messages = delete_exc_group.start_executions(sm, rm)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -845,12 +845,21 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
                 f'{ ", ".join(undeclared_inputs) }'
             )
 
-    def make_delete_environment_execution(self, delete_logs=True, force=False):
+    def make_delete_environment_execution(
+        self,
+        delete_logs=True,
+        force=False,
+        recursive=False,
+    ):
         return Execution(
             workflow_id='delete_deployment_environment',
             deployment=self,
             status=ExecutionState.PENDING,
-            parameters={'delete_logs': delete_logs, 'force': force},
+            parameters={
+                'delete_logs': delete_logs,
+                'force': force,
+                'recursive': recursive,
+            },
         )
 
     @hybrid_property


### PR DESCRIPTION
Allow a way to delete deployments recursively, i.e. also delete all contained-in services.

- adjust the checks so that those services are exempt when deleting recursively
- add the deletion code itself to delete-dep-env
- add a test