### PR TITLE
RND-622 uninstall workflow: allow recursive uninstalls

### DIFF
--- a/resources/rest-service/cloudify/types/types.yaml
+++ b/resources/rest-service/cloudify/types/types.yaml
@@ -816,6 +816,13 @@ workflows:
       ignore_failure:
         default: false
         type: boolean
+      recursive:
+        default: false
+        type: boolean
+        description: >
+          Before uninstalling node instances of this deployments, first
+          uninstall service deployments - that is, deployments that are
+          using the current deployment as an environment.
       type_names:
         type: list
         item_type: node_type

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2558,8 +2558,16 @@ class ResourceManager(object):
         # if we're in the middle of an execution initiated by the component
         # creator, we'd like to drop the component dependency from the list
         deployment = execution.deployment
+        is_recursive_uninstall = (
+            execution.workflow_id == 'uninstall'
+            and execution.parameters
+            and execution.parameters.get('recursive')
+        )
         idds = self._get_blocking_dependencies(
-            deployment, skip_component_children=True)
+            deployment,
+            skip_component_children=True,
+            recursive=is_recursive_uninstall,
+        )
         # allow uninstall of get-capability dependencies
         # if the dependent deployment is inactive
         if execution.workflow_id == 'uninstall':

--- a/tests/integration_tests/tests/test_cases.py
+++ b/tests/integration_tests/tests/test_cases.py
@@ -182,13 +182,16 @@ class BaseTestCase(unittest.TestCase):
                                     parameters=None,
                                     inputs=None,
                                     queue=False,
+                                    deployment_labels=None,
                                     **kwargs):
         """
         A blocking method which deploys an application from
         the provided dsl path, and runs the requested workflows
         """
         deployment = self.deploy(
-            dsl_path, blueprint_id, deployment_id, inputs)
+            dsl_path, blueprint_id, deployment_id, inputs,
+            deployment_labels=deployment_labels,
+        )
         execution = self.execute_workflow(
             workflow_name, deployment.id, parameters,
             timeout_seconds, wait_for_execution, queue=queue, **kwargs)


### PR DESCRIPTION
This is the other part of cloudify-cosmo/cloudify-common#1282

- declare the new parameter
- make the validations ignore blocking dependencies if we're uninstalling them
- add an inte-test