### PR TITLE
CYBL-2036 Don't block uninstall in components mid-resume

### DIFF
--- a/amqp-postgres/test-requirements.txt
+++ b/amqp-postgres/test-requirements.txt
@@ -3,3 +3,5 @@ git+https://github.com/cloudify-cosmo/cloudify-common@7.0.0-build#egg=cloudify-c
 mock
 pytest
 pytest-cov
+# Pin urllib3 to the version which does not depend on appengine
+urllib3<1.27,>=1.21.1

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2547,6 +2547,26 @@ class ResourceManager(object):
         deployment = execution.deployment
         idds = self._get_blocking_dependencies(
             deployment, skip_component_children=True)
+        # allow uninstall of a component if its creator is in the middle of a
+        # resumed installation
+        if execution.workflow_id == 'uninstall':
+            filtered_idds = []
+            for idd in idds:
+                if idd.dependency_creator.startswith('component.'):
+                    creator_execs = self.sm.list(
+                        models.Execution,
+                        filters={
+                            'deployment_id': idd.source_deployment.id,
+                            'workflow_id': 'install',
+                            'status': ExecutionState.STARTED
+                        },
+                        all_tenants=True,
+                        get_all_results=True
+                    )
+                    if creator_execs and creator_execs[0].resume:
+                        continue
+                filtered_idds.append[idd]
+            idds = filtered_idds
         # allow uninstall of get-capability dependencies
         # if the dependent deployment is inactive
         if execution.workflow_id == 'uninstall':

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2521,7 +2521,7 @@ class ResourceManager(object):
                     models.Execution.workflow_id.in_([
                         'stop', 'uninstall', 'update',
                         'csys_new_deployment_update',
-                        'heal',
+                        'heal', 'install',
                     ])
                 )
                 .exists()
@@ -2547,26 +2547,6 @@ class ResourceManager(object):
         deployment = execution.deployment
         idds = self._get_blocking_dependencies(
             deployment, skip_component_children=True)
-        # allow uninstall of a component if its creator is in the middle of a
-        # resumed installation
-        if execution.workflow_id == 'uninstall':
-            filtered_idds = []
-            for idd in idds:
-                if idd.dependency_creator.startswith('component.'):
-                    creator_execs = self.sm.list(
-                        models.Execution,
-                        filters={
-                            'deployment_id': idd.source_deployment.id,
-                            'workflow_id': 'install',
-                            'status': ExecutionState.STARTED
-                        },
-                        all_tenants=True,
-                        get_all_results=True
-                    )
-                    if creator_execs and creator_execs[0].resume:
-                        continue
-                filtered_idds.append[idd]
-            idds = filtered_idds
         # allow uninstall of get-capability dependencies
         # if the dependent deployment is inactive
         if execution.workflow_id == 'uninstall':

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1129,8 +1129,9 @@ class ResourceManager(object):
             execution.deployment_id)
         for exec_id in components_executions:
             execution = self.sm.get(models.Execution, exec_id)
-            if execution.status in [ExecutionState.CANCELLED,
-                                    ExecutionState.FAILED]:
+            if (execution.status in [ExecutionState.CANCELLED,
+                                     ExecutionState.FAILED]
+                    and execution.workflow_id != 'install'):
                 self.resume_execution(exec_id, force)
 
         return execution
@@ -2521,7 +2522,7 @@ class ResourceManager(object):
                     models.Execution.workflow_id.in_([
                         'stop', 'uninstall', 'update',
                         'csys_new_deployment_update',
-                        'heal', 'install',
+                        'heal',
                     ])
                 )
                 .exists()

--- a/tests/integration_tests/resources/dsl/idd/destructive_component.yaml
+++ b/tests/integration_tests/resources/dsl/idd/destructive_component.yaml
@@ -1,0 +1,13 @@
+tosca_definitions_version: cloudify_dsl_1_4
+
+imports:
+  - cloudify/types/types.yaml
+
+node_templates:
+  script:
+    type: cloudify.nodes.Root
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        start:
+          implementation: scripts/fail_once.sh
+          max_retries: 0

--- a/tests/integration_tests/resources/dsl/idd/destructive_component_parent.yaml
+++ b/tests/integration_tests/resources/dsl/idd/destructive_component_parent.yaml
@@ -1,0 +1,13 @@
+tosca_definitions_version: cloudify_dsl_1_4
+
+imports:
+  - cloudify/types/types.yaml
+
+node_templates:
+  component:
+    type: cloudify.nodes.ServiceComponent
+    properties:
+      resource_config:
+        blueprint:
+          external_resource: true
+          id: component

--- a/tests/integration_tests/resources/dsl/idd/scripts/fail_once.sh
+++ b/tests/integration_tests/resources/dsl/idd/scripts/fail_once.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# The purpose of this script is to fail exactly once.
+# It checks to see if a "ran" file exists in the deployment directory
+# If it does not exist (e.g., first run), then create it and exit
+# If it does exist (e.g., second run), then exit 0
+
+WORKDIR=$(ctx local_deployment_workdir)
+
+if [ -f "${WORKDIR}/ran" ]
+then
+    exit 0
+else
+    touch "${WORKDIR}/ran"
+    exit 1
+fi


### PR DESCRIPTION
We need to not block a component's uninstall when its component creator is in the middle of an install.
This is for correctly supporting `resume` on the creator's install - which needs to first rollback a botched installation of the component so it can then be installed correctly.