### PR TITLE
RND-309 Append altered objects to the snapshot

### DIFF
--- a/mgmtworker/cloudify_system_workflows/snapshots/constants.py
+++ b/mgmtworker/cloudify_system_workflows/snapshots/constants.py
@@ -76,6 +76,28 @@ V_7_0_0 = ManagerVersion('7.0.0')
 V_7_1_0 = ManagerVersion('7.1.0')
 
 
+DUMP_TYPE_IDS = {
+    'agents': 'agent_ids',
+    'blueprints': 'blueprint_ids',
+    'deployment_updates': 'deployment_update_ids',
+    'deployments': 'deployment_ids',
+    'events': 'event_storage_ids',
+    'execution_schedules': 'execution_schedule_ids',
+    'execution_groups': 'execution_group_ids',
+    'executions': 'execution_ids',
+    'blueprints_filters': 'filter_ids',
+    'deployments_filters': 'filter_ids',
+    'inter_deployment_dependencies': 'inter_deployment_dependency_ids',
+    'node_instances': 'node_instance_ids',
+    'nodes': 'node_ids',
+    'tasks_graphs': 'tasks_graph_ids',
+    'plugins': 'plugin_ids',
+    'plugins_updates': 'plugins_update_ids',
+    'secrets_providers': 'secrets_provider_ids',
+    'sites': 'sites_ids',
+}
+
+
 class VisibilityState(object):
     PRIVATE = 'private'
     TENANT = 'tenant'

--- a/mgmtworker/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/mgmtworker/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -207,7 +207,7 @@ class SnapshotRestore(object):
                 if f.endswith('.json')
             ]
 
-        for filename in dump_files:
+        for filename in sorted(dump_files):
             ctx.logger.debug('Checking for data to restore in %s',
                              filename)
 

--- a/mgmtworker/cloudify_system_workflows/tests/snapshots/test_auditlog_listener.py
+++ b/mgmtworker/cloudify_system_workflows/tests/snapshots/test_auditlog_listener.py
@@ -1,10 +1,12 @@
 from unittest import mock
 
 from cloudify_system_workflows.snapshots.snapshot_create import EMPTY_B64_ZIP
-from cloudify_system_workflows.tests.snapshots.mocks import (
+from cloudify_system_workflows.tests.snapshots.utils import (
     AuditLogResponse,
     ExecutionResponse,
     ExecutionGroupResponse,
+    ListResponse,
+    load_snapshot_to_dict,
     prepare_snapshot_create_with_mocks,
     TWO_TENANTS_LIST_SE,
     ONE_BLUEPRINT_LIST_SE,
@@ -57,30 +59,11 @@ def test_reconnect():
              [[{'id': 'bp1'}, {'id': 'bp2'}]]),
         ],
     ) as snap_cre:
-        snap_cre._append_new_object_from_auditlog = mock.Mock()
+        snap_cre._dump_from_auditlog = mock.Mock()
         snap_cre.create(timeout=0.2)
-        snap_cre._append_new_object_from_auditlog.assert_has_calls([
-            mock.call({
-                'id': 1192,
-                'ref_table': 'blueprints',
-                'ref_id': 0,
-                'ref_identifier': {'id': 'bp1', 'tenant_name': 'tenant1'},
-                'operation': 'update',
-                'creator_name': '',
-                'execution_id': '',
-                'created_at': '2023-04-05T09:27:57.926'
-            }),
-            mock.call({
-                'id': 1193,
-                'ref_table': 'blueprints',
-                'ref_id': 0,
-                'ref_identifier': {'id': 'bp1', 'tenant_name': 'tenant1'},
-                'operation': 'update',
-                'creator_name': '',
-                'execution_id': '',
-                'created_at': '2023-04-05T09:27:57.927'
-            }),
-        ])
+        snap_cre._dump_from_auditlog.assert_called_once_with({
+            'tenant1': {'blueprints': {'bp1'}}
+        })
 
 
 def test_dont_append_new_blueprints():
@@ -126,17 +109,10 @@ def test_dont_append_new_blueprints():
             (mock.Mock, ('blueprints', 'dump'), [[{'id': 'bp1'}]]),
         ],
     ) as snap_cre:
-        snap_cre._append_new_object_from_auditlog = mock.Mock()
+        snap_cre._dump_from_auditlog = mock.Mock()
         snap_cre.create(timeout=0.2)
-        snap_cre._append_new_object_from_auditlog.assert_called_once_with({
-            'id': 1293,
-            'ref_table': 'blueprints',
-            'ref_id': 1,
-            'ref_identifier': {'id': 'bp1', 'tenant_name': 'tenant1'},
-            'operation': 'update',
-            'creator_name': 'admin',
-            'execution_id': '',
-            'created_at': '2023-04-05T10:27:57.928'
+        snap_cre._dump_from_auditlog.assert_called_once_with({
+            'tenant1': {'blueprints': {'bp1'}}
         })
 
 
@@ -191,27 +167,85 @@ def test_append_related_executions():
             (mock.Mock, ('execution_groups', 'get'), execution_groups_get_se),
         ],
     ) as snap_cre:
-        snap_cre._append_new_object_from_auditlog = mock.Mock()
+        snap_cre._dump_from_auditlog = mock.Mock()
         snap_cre.create(timeout=0.2)
-        snap_cre._append_new_object_from_auditlog.assert_has_calls([
-            mock.call({
-                'id': 1392,
-                'ref_table': 'executions',
-                'ref_id': 1,
-                'ref_identifier': {'id': 'exec2', 'tenant_name': 'tenant1'},
-                'operation': 'update',
-                'creator_name': 'admin',
-                'execution_id': '',
-                'created_at': '2023-04-05T11:27:57.926'
-            }),
-            mock.call({
-                'id': 1393,
-                'ref_table': 'execution_groups',
-                'ref_id': 1,
-                'ref_identifier': {'id': 'execgr2', 'tenant_name': 'tenant1'},
-                'operation': 'update',
-                'creator_name': 'admin',
-                'execution_id': '',
-                'created_at': '2023-04-05T11:27:57.927'
-            }),
-        ])
+        snap_cre._dump_from_auditlog.assert_called_once_with({
+            'tenant1': {
+                'executions': {'exec2'},
+                'execution_groups': {'execgr2'},
+            }
+        })
+
+
+def test_append_related_entities():
+    auditlog_stream_se = [
+        AuditLogResponse([{
+            'id': 1491,
+            'ref_table': 'blueprints',
+            'ref_id': 1,
+            'ref_identifier': {'id': 'bp1', 'tenant_name': 'tenant1'},
+            'operation': 'update',
+            'creator_name': 'admin',
+            'execution_id': '',
+            'created_at': '2023-04-05T12:27:57.926',
+        }]),
+        AuditLogResponse([{
+            'id': 1492,
+            'ref_table': 'deployments',
+            'ref_id': 1,
+            'ref_identifier': {'id': 'd1', 'tenant_name': 'tenant1'},
+            'operation': 'update',
+            'creator_name': 'admin',
+            'execution_id': '',
+            'created_at': '2023-04-05T12:27:57.927',
+        }]),
+    ]
+    deployments_list_se = [
+        ListResponse(
+                items=[{'id': 'd1', 'tenant_name': 'tenant1'}],
+                metadata={'pagination': {'offset': 0, 'size': 1, 'total': 1}}
+        )
+    ]
+    with prepare_snapshot_create_with_mocks(
+        'test-snapshot-append-related-entities',
+        rest_mocks=[
+            (mock.Mock, (dump_type, 'dump'), [[]])
+            for dump_type in [
+                'user_groups', 'tenants', 'users', 'permissions', 'sites',
+                'plugins', 'secrets_providers', 'secrets', 'deployment_groups',
+                'inter_deployment_dependencies', 'deployment_updates',
+                'plugins_update', 'deployments_filters', 'blueprints_filters',
+                'execution_schedules', 'nodes', 'node_instances', 'agents',
+                'executions', 'execution_groups', 'operations', 'tasks_graphs',
+                'events',
+            ]
+        ] + [
+            (mock.AsyncMock, ('auditlog', 'stream'), auditlog_stream_se),
+            (mock.Mock, ('tenants', 'list'), TWO_TENANTS_LIST_SE),
+            (mock.Mock, ('blueprints', 'dump'), [
+                [
+                    {'id': 'bp1'},
+                    {'id': 'bp2'},
+                ],
+                [
+                    {'id': 'bp1', 'created_by': 'someone'},
+                ],
+            ]),
+            (mock.Mock, ('deployments', 'list'), deployments_list_se),
+            (mock.Mock, ('deployments', 'dump'), [
+                [{'id': 'd1'}],
+                [{'id': 'd1', 'display_name': 'deployment #1'}],
+            ]),
+            (mock.Mock, ('deployments', 'get'),
+             {'workdir_zip': EMPTY_B64_ZIP}),
+        ],
+    ) as sc:
+        sc.create(timeout=0.2)
+        snapshot = load_snapshot_to_dict(sc._archive_dest.with_suffix('.zip'))
+
+        blueprints = snapshot['tenants']['tenant1'][('blueprints', None, None)]
+
+        assert blueprints['items'] == {
+            'bp1': {'id': 'bp1', 'created_by': 'someone'},
+            'bp2': {'id': 'bp2'}
+        }

--- a/rest-service/manager_rest/test/endpoints/test_agents.py
+++ b/rest-service/manager_rest/test/endpoints/test_agents.py
@@ -297,3 +297,25 @@ class AgentsTest(base_test.BaseServerTestCase):
         self.assertEqual(len(self.client.agents.list(version='5.0')), 0)
         self.assertEqual(len(self.client.agents.list(node_id='node_id')), 1)
         self.assertEqual(len(self.client.agents.list(node_instance_id='a')), 0)
+
+    def test_dump(self):
+        def get_entities(data):
+            return (d['__entity'] for d in data)
+        self._agent('a1')
+        d2 = self.dep2 = self._deployment('d2')
+        node2 = self.node2 = self._node('node_id', deployment=d2)
+        ni2 = self._instance('node_instance_1', node=node2)
+        self._agent('a2', node_instance=ni2)
+        agents = get_entities(self.client.agents.dump(
+                deployment_ids=['d1', 'd2']
+        ))
+        assert set(a['id'] for a in agents) == {'a1', 'a2'}
+        agents = get_entities(self.client.agents.dump(
+                deployment_ids=['d1', 'd2'],
+                agent_ids=['a2']
+        ))
+        assert set(a['id'] for a in agents) == {'a2'}
+        agents = get_entities(self.client.agents.dump(
+                deployment_ids=['d1']
+        ))
+        assert set(a['id'] for a in agents) == {'a1'}

--- a/rest-service/manager_rest/test/endpoints/test_blueprints.py
+++ b/rest-service/manager_rest/test/endpoints/test_blueprints.py
@@ -507,3 +507,21 @@ class BlueprintsTestCase(base_test.BaseServerTestCase):
             self.client.blueprints.set_visibility(
                 bp.id, VisibilityState.TENANT)
         assert bp.visibility == VisibilityState.GLOBAL
+
+    def test_dump(self):
+        models.Blueprint(
+                id='bp1',
+                creator=self.user,
+                tenant=self.tenant,
+        )
+        models.Blueprint(
+                id='bp2',
+                creator=self.user,
+                tenant=self.tenant,
+        )
+
+        blueprints = self.client.blueprints.dump()
+        assert set(b['id'] for b in blueprints) == {'bp1', 'bp2'}
+
+        blueprints = self.client.blueprints.dump(blueprint_ids=('bp1', ))
+        assert set(b['id'] for b in blueprints) == {'bp1'}

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -114,7 +114,7 @@ class TestCheckDeploymentDelete(base_test.BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        self.rm.check_deployment_delete(dep1)  # doesnt throw
+        self.rm.check_deployment_delete(dep1)  # doesn't throw
         with self.assertRaises(manager_exceptions.DependentExistsError):
             # you can't just delete a component, dep1 uses it; it must be
             # deleted by deleting dep1 as well
@@ -139,7 +139,7 @@ class TestCheckDeploymentDelete(base_test.BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        self.rm.check_deployment_delete(dep2)  # doesnt throw
+        self.rm.check_deployment_delete(dep2)  # doesn't throw
 
     def test_parent_child(self):
         # dep2 is dep1's parent
@@ -151,7 +151,7 @@ class TestCheckDeploymentDelete(base_test.BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        self.rm.check_deployment_delete(dep1)  # doesnt throw
+        self.rm.check_deployment_delete(dep1)  # doesn't throw
         with self.assertRaises(manager_exceptions.DependentExistsError):
             # you can't delete parents whose children still exist
             self.rm.check_deployment_delete(dep2)
@@ -188,7 +188,7 @@ class TestCheckDeploymentDelete(base_test.BaseServerTestCase):
             tenant=self.tenant,
         )
 
-        self.rm.check_deployment_delete(dep1)  # doesnt throw
+        self.rm.check_deployment_delete(dep1)  # doesn't throw
         with self.assertRaises(manager_exceptions.DependentExistsError):
             # you can't delete parents whose children still exist
             self.rm.check_deployment_delete(dep2)
@@ -239,7 +239,7 @@ class TestCheckDeploymentDelete(base_test.BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        self.rm.check_deployment_delete(dep1)  # doesnt throw
+        self.rm.check_deployment_delete(dep1)  # doesn't throw
 
     def test_external_dependency_source(self):
         dep1 = self._deployment(id='dep1')
@@ -262,7 +262,7 @@ class TestCheckDeploymentDelete(base_test.BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        self.rm.check_deployment_delete(dep1)  # doesnt throw
+        self.rm.check_deployment_delete(dep1)  # doesn't throw
 
     def test_external_component_creator(self):
         dep1 = self._deployment(id='dep1')
@@ -273,7 +273,7 @@ class TestCheckDeploymentDelete(base_test.BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        self.rm.check_deployment_delete(dep1)  # doesnt throw
+        self.rm.check_deployment_delete(dep1)  # doesn't throw
 
 
 class TestValidateExecutionDependencies(base_test.BaseServerTestCase):
@@ -396,7 +396,7 @@ class TestValidateExecutionDependencies(base_test.BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        self.rm._verify_dependencies_not_affected(exc, False)  # doesnt throw
+        self.rm._verify_dependencies_not_affected(exc, False)  # doesn't throw
 
     def test_uninstall_parent_component(self):
         # dep2 is dep1's parent AND dep1 is a component used inside of dep2
@@ -422,7 +422,7 @@ class TestValidateExecutionDependencies(base_test.BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        self.rm._verify_dependencies_not_affected(exc, False)  # doesnt throw
+        self.rm._verify_dependencies_not_affected(exc, False)  # doesn't throw
 
     def test_uninstall_capability_dependency(self):
         # dep2 is using a capability of dep1
@@ -456,7 +456,7 @@ class TestValidateExecutionDependencies(base_test.BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        self.rm._verify_dependencies_not_affected(exc2, False)  # doesnt throw
+        self.rm._verify_dependencies_not_affected(exc2, False)  # doesn't throw
 
     def test_external_dependency_source(self):
         dep1 = self._deployment(id='dep1')
@@ -493,7 +493,7 @@ class TestValidateExecutionDependencies(base_test.BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        self.rm._verify_dependencies_not_affected(exc, False)  # doesnt throw
+        self.rm._verify_dependencies_not_affected(exc, False)  # doesn't throw
 
 
 class TestLicensedEnvironments(base_test.BaseServerTestCase):
@@ -1757,6 +1757,30 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
             exc.total_operations
         assert retrieved.latest_execution_finished_operations == \
             exc.finished_operations
+
+    def test_dump(self):
+        bp = models.Blueprint(
+            id='bp',
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        models.Deployment(
+            id='dep1',
+            blueprint=bp,
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        models.Deployment(
+            id='dep2',
+            blueprint=bp,
+            creator=self.user,
+            tenant=self.tenant,
+        )
+        deployments = self.client.deployments.dump()
+        assert set(d['id'] for d in deployments) == {'dep1', 'dep2'}
+
+        deployments = self.client.deployments.dump(deployment_ids={'dep2'})
+        assert set(d['id'] for d in deployments) == {'dep2'}
 
 
 class DeploymentsDeleteTest(base_test.BaseServerTestCase):

--- a/rest-service/manager_rest/test/endpoints/test_events.py
+++ b/rest-service/manager_rest/test/endpoints/test_events.py
@@ -769,7 +769,7 @@ class BuildSelectQueryTest(TestCase):
 
     """Event retrieval query."""
 
-    # Parameters passed ot the _build_select_query_method
+    # Parameters passed on the _build_select_query_method
     # Each tests overwrites different fields as needed.
     DEFAULT_PARAMS = {
         'filters': {
@@ -1020,6 +1020,63 @@ class EventsTest(base_test.BaseServerTestCase):
         assert events[0].execution_group == eg
         assert len(logs) == 1
         assert logs[0].execution_group == eg
+
+    def test_dump(self):
+        def get_entities(data):
+            return [(d['__source_id'], d['__entity']) for d in data]
+        eg = ExecutionGroup(
+            id='eg1',
+            workflow_id='wf',
+            tenant=self.tenant,
+            creator=self.user,
+        )
+        self.client.events.create(
+                events=[{
+                    'message': {'text': 'hello'},
+                    'event_type': 'type1',
+                    'context': {},
+                }],
+                execution_group_id=eg.id,
+        )
+        ex = Execution(
+            id='ex1',
+            workflow_id='wf',
+            tenant=self.tenant,
+            creator=self.user,
+        )
+        self.client.events.create(
+                events=[{
+                    'message': {'text': 'hello'},
+                    'event_type': 'type2',
+                    'context': {},
+                }],
+                logs=[{
+                    'message': {'text': 'world'},
+                    'logger': 'root',
+                    'level': 'info',
+                    'context': {},
+                }],
+                execution_id=ex.id,
+        )
+        events = get_entities(self.client.events.dump(
+                execution_ids=['ex1'],
+                execution_group_ids=['eg1']
+        ))
+        assert len(events) == 2
+        assert set(e[0] for e in events) == {'ex1', 'eg1'}
+        execution_event_storage_id = [
+            event['_storage_id']
+            for src, event in events
+            if src == 'ex1' and event['type'] == 'cloudify_event'
+        ][0]
+        events = get_entities(self.client.events.dump(
+                execution_ids=['ex1'],
+                execution_group_ids=['eg1'],
+                event_storage_ids=[execution_event_storage_id]
+        ))
+        assert len(events) == 1
+        assert events[0][1]['_storage_id'] == execution_event_storage_id
+        assert events[0][1]['message'] == 'hello'
 
 
 class MapEventToDictTestV3(TestCase):

--- a/rest-service/manager_rest/test/endpoints/test_execution_schedules.py
+++ b/rest-service/manager_rest/test/endpoints/test_execution_schedules.py
@@ -215,3 +215,18 @@ class ExecutionSchedulesTestCase(BaseServerTestCase):
             'bad-freq', self.deployment_id, 'install',
             since=self.an_hour_from_now, recurrence='10 doboshes'
         )
+
+    def test_dump(self):
+        schedule_ids = ['sched-1', 'sched-2']
+        for schedule_id in schedule_ids:
+            self.client.execution_schedules.create(
+                schedule_id, self.deployment_id, 'install',
+                since=self.an_hour_from_now, recurrence='1 minutes', count=5)
+
+        schedules = self.client.execution_schedules.dump()
+        assert set(s['id'] for s in schedules) == {'sched-1', 'sched-2'}
+
+        schedules = self.client.execution_schedules.dump(
+                execution_schedule_ids=['sched-1']
+        )
+        assert set(s['id'] for s in schedules) == {'sched-1'}


### PR DESCRIPTION
The entities which are related to generated snapshot's content are appended to the snapshot.  This implements happy path for "zero-downtime" snapshots.