### PR TITLE
Cybl 2036 fix component resume 710

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1134,8 +1134,9 @@ class ResourceManager(object):
             execution.deployment_id)
         for exec_id in components_executions:
             execution = self.sm.get(models.Execution, exec_id)
-            if execution.status in [ExecutionState.CANCELLED,
-                                    ExecutionState.FAILED]:
+            if (execution.status in [ExecutionState.CANCELLED,
+                                     ExecutionState.FAILED]
+                    and execution.workflow_id != 'install'):
                 self.resume_execution(exec_id, force)
 
         return execution

--- a/tests/integration_tests/resources/dsl/idd/destructive_component.yaml
+++ b/tests/integration_tests/resources/dsl/idd/destructive_component.yaml
@@ -1,0 +1,13 @@
+tosca_definitions_version: cloudify_dsl_1_4
+
+imports:
+  - cloudify/types/types.yaml
+
+node_templates:
+  script:
+    type: cloudify.nodes.Root
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        start:
+          implementation: scripts/fail_once.sh
+          max_retries: 0

--- a/tests/integration_tests/resources/dsl/idd/destructive_component_parent.yaml
+++ b/tests/integration_tests/resources/dsl/idd/destructive_component_parent.yaml
@@ -1,0 +1,13 @@
+tosca_definitions_version: cloudify_dsl_1_4
+
+imports:
+  - cloudify/types/types.yaml
+
+node_templates:
+  component:
+    type: cloudify.nodes.ServiceComponent
+    properties:
+      resource_config:
+        blueprint:
+          external_resource: true
+          id: component

--- a/tests/integration_tests/resources/dsl/idd/scripts/fail_once.sh
+++ b/tests/integration_tests/resources/dsl/idd/scripts/fail_once.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# The purpose of this script is to fail exactly once.
+# It checks to see if a "ran" file exists in the deployment directory
+# If it does not exist (e.g., first run), then create it and exit
+# If it does exist (e.g., second run), then exit 0
+
+WORKDIR=$(ctx local_deployment_workdir)
+
+if [ -f "${WORKDIR}/ran" ]
+then
+    exit 0
+else
+    touch "${WORKDIR}/ran"
+    exit 1
+fi


### PR DESCRIPTION
We need to not block a component's uninstall when its component creator is in the middle of an install.
This is for correctly supporting `resume` on the creator's install - which needs to first rollback a botched installation of the component so it can then be installed correctly.