### PR TITLE
RND-584 inte-tests: disable nginx rate-limit

### DIFF
--- a/tests/integration_tests/framework/utils.py
+++ b/tests/integration_tests/framework/utils.py
@@ -457,6 +457,9 @@ validations:
     skip_validations: true
 sanity:
     skip_sanity: true
+nginx:
+    rate_limit:
+        enabled: false
 restservice:
     gunicorn:
         max_worker_count: 4


### PR DESCRIPTION
No need to limit our own tests! Let's keep them fast. Although the rate-limit mostly doesn't affect the tests, it does affect the benchmarks.