### PR TITLE
RND-561 inte-test for multiple scale calls from a custom wf

### DIFF
--- a/tests/integration_tests/tests/agentless_tests/scale/test_scale_group.py
+++ b/tests/integration_tests/tests/agentless_tests/scale/test_scale_group.py
@@ -140,3 +140,58 @@ node_templates:
         assert len(instances) == 2
         for ni in instances:
             assert ni.runtime_properties['result'] == ni.id
+
+    def test_scale_workflow_multiple(self):
+        # use a custom workflow to scale multiple entities; in this case, the
+        # custom workflow actually calls the scale workflow several times.
+        # Before RND-561, only one of those scale workflows actually ran.
+        bp = """
+tosca_definitions_version: cloudify_dsl_1_5
+imports:
+  - cloudify/types/types.yaml
+node_types:
+  t1:
+    derived_from: cloudify.nodes.Root
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create: |
+          from cloudify import ctx
+          ctx.instance.runtime_properties['created'] = True
+node_templates:
+  node1:
+    type: t1
+  node2:
+    type: t1
+  node3:
+    type: t1
+workflows:
+  wf1:
+    mapping: |
+      from cloudify.workflows import ctx
+      from cloudify.plugins import workflows
+      nodes_to_scale = ['node1', 'node2', 'node3']
+      for node_id in nodes_to_scale:
+        workflows.scale_entity(ctx, node_id, 1, False)
+"""
+        self.upload_blueprint_resource(
+            self.make_yaml_file(bp),
+            blueprint_id='bp',
+        )
+        self.deploy_application(
+            dsl_path=None,
+            deployment_id='dep1',
+            blueprint_id='bp',
+        )
+
+        instances = self.client.node_instances.list(deployment_id='dep1')
+        assert len(instances) == 3
+        assert all(ni.runtime_properties.get('created') for ni in instances)
+
+        self.execute_workflow(
+            'wf1',
+            'dep1',
+        )
+
+        instances = self.client.node_instances.list(deployment_id='dep1')
+        assert len(instances) == 6
+        assert all(ni.runtime_properties.get('created') for ni in instances)


### PR DESCRIPTION
In a custom workflow, call the scale workflow several times, and check that it did indeed run several times.

This tests the changes from cloudify-cosmo/cloudify-common#1292