### PR TITLE
fix test_script_executor & test_bp_malformed_url

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_agent_install_workflow.py
+++ b/tests/integration_tests/tests/agent_tests/test_agent_install_workflow.py
@@ -204,6 +204,7 @@ node_types:
         interfaces:
             cloudify.interfaces.lifecycle:
                 create: |
+                    #!/usr/bin/env bash
                     ctx instance runtime-properties create "${AGENT_NAME:-mgmtworker}"
                 start: |
                     import os

--- a/tests/integration_tests/tests/agentless_tests/test_blueprint_upload.py
+++ b/tests/integration_tests/tests/agentless_tests/test_blueprint_upload.py
@@ -77,8 +77,8 @@ class BlueprintUploadTest(AgentlessTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertRegexpMatches(
             response.json()['message'],
-            r"failed uploading.* "
-            r"Failed to parse: \['{}'\]".format(archive_url))
+            fr"failed uploading.*{archive_url}",
+        )
 
     def test_blueprint_upload_from_url_bad_archive_format(self):
         blueprint_id = 'bp-url-bad-format'


### PR DESCRIPTION
Two inte-test fixups, unrelated to each other, but still in the same PR. After this, only snapshot inte-tests are going to be failing.