### PR TITLE
RND-782 Fix integration test: snapshot with agents

### DIFF
--- a/tests/integration_tests/tests/agent_tests/test_snapshots.py
+++ b/tests/integration_tests/tests/agent_tests/test_snapshots.py
@@ -36,13 +36,15 @@ class TestSnapshots(AgentTestCase):
         deployments = []
         execution_ids = []
         for _ in states:
+            # All agents are going to be deployed in the same container.
+            # Because agent installation is a "messy" process (lot of global
+            # state, directory creation etc.), let's do it sequentially.
             deployment, execution = self.deploy_application(
                 resource("dsl/agent_tests/with_agent.yaml"),
-                wait_for_execution=False,
+                wait_for_execution=True,
             )
             deployments.append(deployment)
             execution_ids.append(execution)
-            time.sleep(0.1)
 
         for execution_id in execution_ids:
             exc = self.client.executions.get(execution_id)

--- a/tests/integration_tests/tests/agent_tests/test_snapshots.py
+++ b/tests/integration_tests/tests/agent_tests/test_snapshots.py
@@ -34,21 +34,14 @@ class TestSnapshots(AgentTestCase):
 
     def _deploy_with_agents(self, states):
         deployments = []
-        execution_ids = []
         for _ in states:
             # All agents are going to be deployed in the same container.
             # Because agent installation is a "messy" process (lot of global
             # state, directory creation etc.), let's do it sequentially.
             deployment, execution = self.deploy_application(
-                resource("dsl/agent_tests/with_agent.yaml"),
-                wait_for_execution=True,
+                resource("dsl/agent_tests/with_agent.yaml")
             )
             deployments.append(deployment)
-            execution_ids.append(execution)
-
-        for execution_id in execution_ids:
-            exc = self.client.executions.get(execution_id)
-            self.wait_for_execution_to_end(exc, timeout_seconds=600)
 
         for deployment, state in zip(deployments, states):
             agent = self.client.agents.list(deployment_id=deployment.id)


### PR DESCRIPTION
A better (but slower) approach to fixing agent installation problems: instead of arbitrary sleep between installations, let's execute them sequentially.