### PR TITLE
RND-635 rabbitmq image: add the k8s discovery plugin

### DIFF
--- a/service_containers/rabbitmq/config/enabled_plugins
+++ b/service_containers/rabbitmq/config/enabled_plugins
@@ -1,1 +1,1 @@
-[rabbitmq_management,rabbitmq_prometheus,rabbitmq_tracing].
+[rabbitmq_management,rabbitmq_prometheus,rabbitmq_tracing,rabbitmq_peer_discovery_k8s].


### PR DESCRIPTION
Without this plugin, in k8s, rabbitmq tries to use native DNS discovery, which takes a long time, and ends up often timing out on the liveness probes.

With this, `rabbitmq-diagnostics ping` takes 1 second, without - 10.