### PR TITLE
RND-1139 configure_manager: allow passing in s3 settings

### DIFF
--- a/rest-service/manager_rest/configure_manager.py
+++ b/rest-service/manager_rest/configure_manager.py
@@ -565,6 +565,9 @@ def _generate_db_config_entries(cfg):
             'credentials', {}).get('password'),
         default_agent_port=internal_rest_port,
         prometheus_url=manager_cfg.get('prometheus_url'),
+        s3_server_url=manager_cfg.get('s3_server_url'),
+        s3_resources_bucket=manager_cfg.get('s3_resources_bucket'),
+        s3_client_timeout=manager_cfg.get('s3_client_timeout'),
     )
     mgmtworker_cfg = build_dict(
         max_workers=mgmtworker_cfg.get('max_workers'),


### PR DESCRIPTION
s3_x settings will now be taken from the `manager` section of a config.yaml, by configure_manager.py - before, it wasn't set at all and only the default was ever used.

Building this dict is a bit ugly now, maybe we should just use a loop here of known config attrs, or something else entirely, but for right now, I'm just going to do the simple thing instead