### PR TITLE
RND-1091 node-instance update: keep the version check

### DIFF
--- a/rest-service/manager_rest/test/endpoints/test_nodes.py
+++ b/rest-service/manager_rest/test/endpoints/test_nodes.py
@@ -313,23 +313,6 @@ class NodesTest(_NodeSetupMixin, base_test.BaseServerTestCase):
             )
         assert cm.exception.status_code == 409
 
-    def test_patch_instance_lower_version_unchanged(self):
-        """A conflict inside the storage manager propagates to the client."""
-        node_instance_id = '1234'
-        inst = self._instance(
-            node_instance_id,
-            runtime_properties={'key': 'value'},
-        )
-        db.session.commit()
-        inst.state = 'uninitialized'
-        db.session.commit()
-
-        self.client.node_instances.update(
-            node_instance_id,
-            runtime_properties=inst.runtime_properties,
-            version=inst.version - 1,
-        )
-
     def test_list_node_instances_multiple_value_filter(self):
         dep2 = self._deployment('d2')
         node1 = self._node('1', deployment=self.dep1)


### PR DESCRIPTION
This partially reverts #4263 - the version check is done always, the refactor stays...

Turns out, skipping the check doesn't quite work, but it breaks operations when there's many concurrent runs. It seems that it's important to keep the node-instances up to date on the workers.

I don't know the exact reason, but skipping this change, does make operations start to overwrite each others' changes, which makes the scale inte-tests flaky.