### PR TITLE
CYBL-2070 Dep-groups extend: fetch all results

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1702,7 +1702,8 @@ class ResourceManager(object):
 
         if labels:
             db.session.flush()
-        self.insert_labels(models.DeploymentLabel, deployment, labels)
+        self.insert_labels(
+            models.DeploymentLabel, deployment._storage_id, labels)
 
         return new_deployment
 
@@ -2651,7 +2652,7 @@ class ResourceManager(object):
                 resource.labels.remove(label)
 
         self.create_resource_labels(labels_resource_model,
-                                    resource,
+                                    resource._storage_id,
                                     labels_to_create,
                                     creator=creator,
                                     created_at=created_at)
@@ -2721,10 +2722,7 @@ class ResourceManager(object):
 
         self.insert_labels(labels_resource_model, resource, new_labels)
 
-    def insert_labels(self,
-                      labels_resource_model,
-                      resource,
-                      labels):
+    def insert_labels(self, labels_resource_model, target_storage_id, labels):
         if not labels:
             return
 
@@ -2738,7 +2736,7 @@ class ResourceManager(object):
         user_cache = {current_user.username: current_user.id}
 
         for label in labels:
-            label['_labeled_model_fk'] = resource._storage_id
+            label['_labeled_model_fk'] = target_storage_id
             if label.get('created_by'):
                 creator_id = lookup_user(label.pop('created_by'),
                                          user_cache, self.sm)

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1723,14 +1723,6 @@ class ResourceManager(object):
                 obj_types.add(label.value)
         return obj_types
 
-    def get_deployment_object_types_from_labels(self,
-                                                resource: SQLResourceBase,
-                                                labels: list[Label]):
-        labels_to_add = self.get_labels_to_create(resource, labels)
-        labels_to_delete = self.get_labels_to_delete(resource, labels)
-        created_types = self.get_object_types_from_labels(labels_to_add)
-        delete_types = self.get_object_types_from_labels(labels_to_delete)
-        return created_types, delete_types
 
     def add_deployment_to_labels_graph(self, deployments, parent_ids):
         if not deployments or not parent_ids:

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1717,12 +1717,7 @@ class ResourceManager(object):
         return parents
 
     def get_object_types_from_labels(self, labels: list[Label]):
-        obj_types = set()
-        for label in labels:
-            if label.key == 'csys-obj-type' and label.value:
-                obj_types.add(label.value)
-        return obj_types
-
+        return {lbl.value for lbl in labels if lbl.key == 'csys-obj-type'}
 
     def add_deployment_to_labels_graph(self, deployments, parent_ids):
         if not deployments or not parent_ids:

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -1162,13 +1162,7 @@ class DeploymentGroupsId(SecuredResource):
                 sm, deployments, [Label(label.key, label.value)
                                   for label in group.labels],
             )
-        # Update deployment conversion which could be from service to env or
-        # vice versa
-        self._handle_resource_counts_after_source_conversion(
-            _target_deployments,
-            labels_to_add,
-            []
-        )
+
         # Add new labels
         self._create_deployments_labels(rm, deployments, labels_to_add)
 

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -1099,7 +1099,7 @@ class DeploymentGroupsId(SecuredResource):
         if deleted_parents:
             changed_deps |= deleted_parents
         rm.create_resource_labels(
-            models.DeploymentGroupLabel, group, labels_to_create)
+            models.DeploymentGroupLabel, group._storage_id, labels_to_create)
         for label in labels_to_delete:
             sm.delete(label)
         return changed_deps
@@ -1134,7 +1134,7 @@ class DeploymentGroupsId(SecuredResource):
         """Bulk create the labels for the given deployments"""
         for dep in deployments:
             rm.create_resource_labels(
-                models.DeploymentLabel, dep, created_labels)
+                models.DeploymentLabel, dep._storage_id, created_labels)
 
     def _delete_deployments_labels(self, sm, deployments, labels_to_delete):
         """Bulk delete the labels for the given deployments."""

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -1185,6 +1185,8 @@ class DeploymentGroupsId(SecuredResource):
         if filter_id is not None:
             deployments_to_add |= set(sm.list(
                 models.Deployment,
+                include=['_storage_id', 'id'],
+                get_all_results=True,
                 filter_rules=get_filter_rules_from_filter_id(
                     sm, filter_id, models.DeploymentsFilter)
             ).items)
@@ -1193,6 +1195,8 @@ class DeploymentGroupsId(SecuredResource):
         if filter_rules:
             deployments_to_add |= set(sm.list(
                 models.Deployment,
+                include=['_storage_id', 'id'],
+                get_all_results=True,
                 filter_rules=filter_rules).items)
 
         add_group = request_dict.get('deployments_from_group')


### PR DESCRIPTION
In order to make dep-groups extend not be limited to 1000 items, use `get_all_results=True`. However, for that to be workable, we need some optimizations as well.