### PR TITLE
RND-1188 Use boto3 for s3 compatibility

### DIFF
--- a/rest-service/manager_rest/persistent_storage.py
+++ b/rest-service/manager_rest/persistent_storage.py
@@ -127,7 +127,7 @@ class LocalStorageHandler(FileStorageHandler):
 
     def delete(self, path: str):
         full_path = os.path.join(self.base_uri, path)
-        if not os.path.exists(path):
+        if not os.path.exists(full_path):
             # already gone
             return
         if os.path.isdir(full_path):

--- a/rest-service/manager_rest/persistent_storage.py
+++ b/rest-service/manager_rest/persistent_storage.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from xml.etree import ElementTree
 
 import boto3
-import requests
 from flask import current_app
 
 from manager_rest import manager_exceptions

--- a/rest-service/manager_rest/persistent_storage.py
+++ b/rest-service/manager_rest/persistent_storage.py
@@ -127,6 +127,9 @@ class LocalStorageHandler(FileStorageHandler):
 
     def delete(self, path: str):
         full_path = os.path.join(self.base_uri, path)
+        if not os.path.exists(path):
+            # already gone
+            return
         if os.path.isdir(full_path):
             shutil.rmtree(full_path)
         else:

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -38,6 +38,7 @@ from manager_rest.maintenance import get_maintenance_state
 from manager_rest.constants import (
     COMPONENT_TYPE,
     DEFAULT_TENANT_NAME,
+    FILE_SERVER_PLUGINS_FOLDER,
     FILE_SERVER_BLUEPRINTS_FOLDER,
     FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER,
     FILE_SERVER_DEPLOYMENTS_FOLDER,
@@ -793,7 +794,7 @@ class ResourceManager(object):
         # Remove from file system
         self.sh.delete(
             os.path.join(
-                constants.FILE_SERVER_PLUGINS_FOLDER,
+                FILE_SERVER_PLUGINS_FOLDER,
                 plugin_id,
                 ''
             )

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -925,7 +925,6 @@ class ResourceManager(object):
                         ','.join(dep.id for dep in blueprint.deployments)))
         if remove_files:
             # Delete blueprint resources from file server
-            sh = get_storage_handler()
             self.sh.delete(
                 os.path.join(
                     FILE_SERVER_BLUEPRINTS_FOLDER,

--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -43,6 +43,7 @@ from manager_rest.constants import (
     FILE_SERVER_DEPLOYMENTS_FOLDER,
     DEPLOYMENT_UPDATE_STATES as UpdateStates,
 )
+from manager_rest.persistent_storage import get_storage_handler
 from manager_rest.utils import (get_formatted_timestamp,
                                 is_create_global_permitted,
                                 validate_global_modification,
@@ -77,8 +78,9 @@ _ExecGroupStats = namedtuple('_ExecGroupStats', ['active', 'concurrency'])
 
 class ResourceManager(object):
 
-    def __init__(self, sm=None):
+    def __init__(self, sm=None, sh=None):
         self.sm = sm or get_storage_manager()
+        self.sh = sh or get_storage_handler()
         self._cached_queued_execs_query = None
 
     def list_executions(
@@ -789,9 +791,13 @@ class ResourceManager(object):
         self.sm.delete(plugin)
 
         # Remove from file system
-        archive_path = utils.get_plugin_archive_path(plugin_id,
-                                                     plugin.archive_name)
-        shutil.rmtree(os.path.dirname(archive_path), ignore_errors=True)
+        self.sh.delete(
+            os.path.join(
+                constants.FILE_SERVER_PLUGINS_FOLDER,
+                plugin_id,
+                ''
+            )
+        )
 
     @staticmethod
     def _blueprint_plugins(blueprint):
@@ -883,17 +889,6 @@ class ResourceManager(object):
         except Exception as ex:
             raise manager_exceptions.DslParseException(str(ex))
 
-    @staticmethod
-    def _remove_folder(folder_name, blueprints_location):
-        blueprint_folder = os.path.join(
-            config.instance.file_server_root,
-            blueprints_location,
-            utils.current_tenant.name,
-            folder_name.id)
-        # Don't cry if the blueprint folder never got created
-        if os.path.exists(blueprint_folder):
-            shutil.rmtree(blueprint_folder)
-
     def delete_blueprint(self, blueprint_id, force, remove_files=True):
         blueprint = self.sm.get(models.Blueprint, blueprint_id)
         validate_global_modification(blueprint)
@@ -930,13 +925,23 @@ class ResourceManager(object):
                         ','.join(dep.id for dep in blueprint.deployments)))
         if remove_files:
             # Delete blueprint resources from file server
-            self._remove_folder(
-                folder_name=blueprint,
-                blueprints_location=FILE_SERVER_BLUEPRINTS_FOLDER)
-            self._remove_folder(
-                folder_name=blueprint,
-                blueprints_location=FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER)
-
+            sh = get_storage_handler()
+            self.sh.delete(
+                os.path.join(
+                    FILE_SERVER_BLUEPRINTS_FOLDER,
+                    blueprint.tenant.name,
+                    blueprint.id,
+                    '',
+                )
+            )
+            self.sh.delete(
+                os.path.join(
+                    FILE_SERVER_UPLOADED_BLUEPRINTS_FOLDER,
+                    blueprint.tenant.name,
+                    blueprint.id,
+                    '',
+                )
+            )
         return self.sm.delete(blueprint)
 
     def check_deployment_delete(

--- a/rest-service/manager_rest/server.py
+++ b/rest-service/manager_rest/server.py
@@ -110,10 +110,12 @@ def cope_with_db_failover():
             db.session.rollback()
 
 
-def init_storage_handler():
+def init_storage_handler(app=None):
     """Set up a storage handler used by upload_manager."""
-    if 'storage_handler' not in current_app.extensions:
-        current_app.extensions['storage_handler'] = \
+    if app is None:
+        app = current_app
+    if 'storage_handler' not in app.extensions:
+        app.extensions['storage_handler'] = \
             persistent_storage.init_storage_handler(config.instance)
 
 

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -313,6 +313,7 @@ class BaseServerTestCase(unittest.TestCase):
 
         copy_resources(cls.server_configuration.file_server_root)
         server.app = server.CloudifyFlaskApp(False)
+        server.init_storage_handler(server.app)
         cls._handle_flask_app_and_db()
         cls.client = cls.create_client()
 

--- a/rest-service/requirements.txt
+++ b/rest-service/requirements.txt
@@ -24,6 +24,12 @@ blinker==1.5
     # via
     #   flask-mail
     #   flask-principal
+boto3==1.28.29
+    # via cloudify-rest-service (setup.py)
+botocore==1.31.29
+    # via
+    #   boto3
+    #   s3transfer
 bottle==0.12.23
     # via cloudify-common
 cachetools==3.1.1
@@ -109,6 +115,10 @@ jinja2==3.1.2
     #   cloudify-common
     #   flask
     #   flask-babelex
+jmespath==1.0.1
+    # via
+    #   boto3
+    #   botocore
 jsonschema==3.2.0
     # via cloudify-rest-service (setup.py)
 mako==1.2.4
@@ -146,7 +156,9 @@ pydantic==1.10.11
 pyrsistent==0.19.3
     # via jsonschema
 python-dateutil==2.8.2
-    # via cloudify-rest-service (setup.py)
+    # via
+    #   botocore
+    #   cloudify-rest-service (setup.py)
 pytz==2022.2.1
     # via
     #   cloudify-common
@@ -165,6 +177,8 @@ requests-toolbelt==0.9.1
     # via cloudify-common
 retrying==1.3.4
     # via cloudify-rest-service (setup.py)
+s3transfer==0.6.2
+    # via boto3
 six==1.16.0
     # via
     #   flask-restful
@@ -183,7 +197,9 @@ typing-extensions==4.5.0
     #   alembic
     #   pydantic
 urllib3==1.26.14
-    # via requests
+    # via
+    #   botocore
+    #   requests
 wagon==0.12.0
     # via
     #   cloudify-common
@@ -199,4 +215,5 @@ wtforms==3.0.1
 yarl==1.8.2
     # via aiohttp
 
-setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/rest-service/requirements.txt
+++ b/rest-service/requirements.txt
@@ -217,3 +217,5 @@ yarl==1.8.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+# ...but I'll still attempt to make snyk happy
+setuptools==65.5.1

--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -40,6 +40,7 @@ install_requires = [
     'retrying',
     'pydantic<2',
     'distro',
+    'boto3>1,<2',
 ]
 
 


### PR DESCRIPTION
Just using requests was nice with a local on-prem server which didn't need authentication, but real s3 does. Let's use boto so that we can use signed requests.

Also, use pre-signed requests for proxying.

Also, fix an unrelated bug: turns out, files were never deleted from fileservers! Heh.