### PR TITLE
CYBL-2097 Update snapshot_restoring flag file path

### DIFF
--- a/api-service/Dockerfile
+++ b/api-service/Dockerfile
@@ -33,6 +33,7 @@ COPY docker/cloudify.pth /usr/local/lib/python3.11/site-packages/cloudify.pth
 
 RUN mkdir -p \
     /opt/manager \
+    /run/cloudify \
     /run/cloudify-api \
     /var/log/cloudify/rest
 
@@ -45,6 +46,7 @@ RUN groupadd $groupname && useradd -u 1000 -g $groupname $username
 
 RUN chown -R $username:$groupname \
     /opt \
+    /run/cloudify \
     /run/cloudify-api \
     /var/log/cloudify
 

--- a/execution-scheduler/Dockerfile
+++ b/execution-scheduler/Dockerfile
@@ -30,6 +30,7 @@ RUN --mount=type=cache,target=/root/.cache \
 RUN mkdir -p \
     /opt/manager \
     /var/log/cloudify/execution-scheduler \
+    /run/cloudify \
     /src
 
 COPY docker/cloudify.pth /usr/local/lib/python3.11/site-packages/cloudify.pth
@@ -43,8 +44,9 @@ RUN groupadd $groupname && useradd -u 1000 -g $groupname $username
 
 RUN chown -R $username:$groupname \
     /opt \
-    /src \
-    /var/log/cloudify
+    /var/log/cloudify \
+    /run/cloudify \
+    /src
 
 USER 1000
 

--- a/mgmtworker/Dockerfile
+++ b/mgmtworker/Dockerfile
@@ -46,9 +46,12 @@ RUN --mount=type=cache,target=/root/.cache \
 RUN groupadd $groupname && useradd -u 1000 -g $groupname $username
 RUN mkdir -p /usr/local/plugins
 
+RUN mkdir -p /run/cloudify
+
 RUN chown -R $username:$groupname \
     /opt \
-    /usr/local/plugins
+    /usr/local/plugins \
+    /run/cloudify
 
 USER 1000
 

--- a/packaging/cloudify-mgmtworker.spec
+++ b/packaging/cloudify-mgmtworker.spec
@@ -76,6 +76,7 @@ mv /opt/plugins-common-3.10 %{buildroot}/opt/plugins-common-3.10
 mv /opt/python3.10 %{buildroot}/opt/python3.10
 
 mkdir -p %{buildroot}/var/log/cloudify/mgmtworker
+mkdir -p %{buildroot}/run/cloudify
 mkdir -p %{buildroot}/opt/mgmtworker/config
 mkdir -p %{buildroot}/opt/mgmtworker/work
 mkdir -p %{buildroot}/opt/mgmtworker/env/plugins
@@ -106,3 +107,4 @@ groupadd -fr cfylogs
 /opt/plugins-common-3.10
 /opt/python3.10
 %attr(750,cfyuser,cfylogs) /var/log/cloudify/mgmtworker
+%attr(750,cfyuser,cfyuser) /run/cloudify

--- a/packaging/cloudify-rest-service.spec
+++ b/packaging/cloudify-rest-service.spec
@@ -68,6 +68,7 @@ cp -R "${RPM_SOURCE_DIR}/rest-service/migrations" "%{buildroot}/opt/manager/reso
 mkdir -p %{buildroot}/var/log/cloudify/rest
 mkdir -p %{buildroot}/var/log/cloudify/amqp-postgres
 mkdir -p %{buildroot}/var/log/cloudify/execution-scheduler
+mkdir -p %{buildroot}/run/cloudify
 
 # Dir for snapshot restore marker files (CY-1821)
 mkdir -p %{buildroot}/opt/manager/snapshot_status
@@ -188,4 +189,5 @@ exit 0
 %attr(750,cfyuser,cfylogs) /var/log/cloudify/rest
 %attr(750,cfyuser,cfylogs) /var/log/cloudify/amqp-postgres
 %attr(750,cfyuser,cfylogs) /var/log/cloudify/execution-scheduler
+%attr(750,cfyuser,cfyuser) /run/cloudify
 %attr(550,root,cfyuser) /opt/cloudify/encryption/update-encryption-key

--- a/rest-service/Dockerfile
+++ b/rest-service/Dockerfile
@@ -54,7 +54,8 @@ COPY docker/cloudify.pth /usr/local/lib/python3.11/site-packages/cloudify.pth
 RUN mkdir -p \
       /var/log/cloudify/rest \
       /opt/manager \
-      /run/cloudify-restservice
+      /run/cloudify-restservice \
+      /run/cloudify
 
 ADD https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager-install/master/cfy_manager/components/restservice/config/license_key.pem.pub /opt/manager/license_key.pem.pub
 
@@ -66,9 +67,10 @@ RUN --mount=type=cache,target=/root/.cache \
 RUN groupadd $groupname && useradd -u 1000 -g $groupname $username
 
 RUN chown -R $username:$groupname \
+    /var/log/cloudify \
     /opt \
     /run/cloudify-restservice \
-    /var/log/cloudify
+    /run/cloudify
 
 USER 1000
 


### PR DESCRIPTION
Because we are running more often in a distributed environment, and /run/cloudify is a common place to keep the "work" files.