### PR TITLE
CYBL-2097 Snapshot creation/restore fixup

### DIFF
--- a/mgmtworker/cloudify_system_workflows/snapshots/snapshot_create.py
+++ b/mgmtworker/cloudify_system_workflows/snapshots/snapshot_create.py
@@ -90,6 +90,7 @@ class SnapshotCreate:
                 self._dump_tenant(tenant_name)
             self._append_from_auditlog(timeout)
             self._create_archive()
+            self._upload_archive(tenant_name)
             self._update_snapshot_status(self._config.created_status)
             ctx.logger.info('Snapshot created successfully')
         except BaseException as exc:
@@ -279,6 +280,14 @@ class SnapshotCreate:
     def _create_archive(self):
         ctx.logger.debug('Creating snapshot archive')
         shutil.make_archive(self._archive_dest, 'zip', self._temp_dir)
+
+    def _upload_archive(self, tenant_name: str):
+        ctx.logger.debug('Uploading archive to manager')
+        client = get_rest_client(tenant=tenant_name)
+        client.snapshots.upload(
+            str(self._archive_dest.with_suffix('.zip')),
+            self._snapshot_id,
+        )
 
     def _append_from_auditlog(self, timeout):
         """Fetch all the remaining items in a queue

--- a/mgmtworker/cloudify_system_workflows/snapshots/snapshot_restore.py
+++ b/mgmtworker/cloudify_system_workflows/snapshots/snapshot_restore.py
@@ -487,6 +487,7 @@ class SnapshotRestore(object):
         self._mark_manager_restoring()
         self._tempdir = tempfile.mkdtemp('-snapshot-data')
         snapshot_path = self._get_snapshot_path()
+        self._download_archive(snapshot_path)
         ctx.logger.debug('Going to restore snapshot, '
                          'snapshot_path: {0}'.format(snapshot_path))
         try:
@@ -1064,11 +1065,18 @@ class SnapshotRestore(object):
     def _get_snapshot_dir(self):
         """Get the snapshot base path (the directory it is put in)."""
         file_server_root = self._config.file_server_root
-        return os.path.join(
+        snapshot_dir = os.path.join(
             file_server_root,
             FILE_SERVER_SNAPSHOTS_FOLDER,
             self._snapshot_id,
         )
+        if not os.path.exists(snapshot_dir):
+            os.makedirs(snapshot_dir)
+        return snapshot_dir
+
+    def _download_archive(self, archive_path: str):
+        ctx.logger.info('Fetching snapshot archive')
+        self._client.snapshots.download(self._snapshot_id, archive_path)
 
     def _restore_credentials(self, postgres):
         ctx.logger.info('Restoring credentials')


### PR DESCRIPTION
* Implement upload snapshot archive as "upsert"

In case a snapshot already exists in a database (e.g. it is being created in create_snapshot workflow), only update its archive.

* Upload snapshot archive after creation

In a distributed environment files created by mgmtworker must be uploaded to "fileserver", which, in case of `file_server_type="local"`, might be just a manager.

* Download snapshot archive before restoring

In a distributed environment uploaded snapshots are stored by the "fileserver", which, in case of `file_server_type="local"`, might be just a manager.  In any case, mgmtworker must fetch the archive it is going to restore.

This is a cherry-pick of https://github.com/cloudify-cosmo/cloudify-manager/pull/4294