### PR TITLE
NE-6694 execution-scheduler: declare HASH_SALT

### DIFF
--- a/execution-scheduler/Dockerfile
+++ b/execution-scheduler/Dockerfile
@@ -5,6 +5,7 @@ ARG groupname=cfyuser
 
 # For rest-service
 ENV SECRET_KEY=abcdefgh-secret-1234
+ENV HASH_SALT=abcdefgh-salt-1234
 ENV POSTGRES_DB=cloudify_db
 ENV POSTGRES_HOST=postgresql
 ENV POSTGRES_USER=cloudify

--- a/execution-scheduler/docker/entrypoint.sh
+++ b/execution-scheduler/docker/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S bash -eux
 
+set +x
 echo "
 postgresql_db_name: ${POSTGRES_DB}
 postgresql_host: ${POSTGRES_HOST}
@@ -7,10 +8,15 @@ postgresql_username: ${POSTGRES_USER}
 postgresql_password: ${POSTGRES_PASSWORD}
 " > /opt/manager/cloudify-rest.conf
 
-echo "
-secret_key: ${SECRET_KEY}
+if [ ! -e "/opt/manager/rest-security.conf" ]; then
+    echo "
+{
+    \"secret_key\": \"${SECRET_KEY}\",
+    \"hash_salt\": \"${HASH_SALT}\"
+}
 " > /opt/manager/rest-security.conf
-
+fi
+set -x
 
 python -m manager_rest.configure_manager --db-wait postgresql
 python -m manager_rest.configure_manager --rabbitmq-wait rabbitmq

--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -41,6 +41,7 @@ install_requires = [
     'pydantic<2',
     'distro',
     'boto3>1,<2',
+    'werkzeug>2,<3',
 ]
 
 


### PR DESCRIPTION
The execution scheduler needs to know the hash salt so that it can generate rest tokens when sending executions. We declare it the same way we do in the restservice.

Note: currently, this is not configurable in the helm chart, but it should be.