### PR TITLE
NE-6713 Avoid reloading config unnecessarily

### DIFF
--- a/rest-service/manager_rest/config.py
+++ b/rest-service/manager_rest/config.py
@@ -295,7 +295,7 @@ class Config(object):
             engine.dispose()
 
         self.last_updated = max((dt for dt in last_changed if dt),
-                                default=None)
+                                default=datetime.utcnow().isoformat())
         # disallow implicit loading
         self.can_load_from_db = False
 


### PR DESCRIPTION
When loading config, default the last_updated (if not set in the db, which it won't be after a clean installation) to the current time.

Otherwise, we'll always consider last_updated to be None, which means we'll reload the config every time...

Note: the date needs to be a string for this comparison, hence the isoformat.