### PR TITLE
NE-6712 plugin.yaml_file_path: return the best version available

### DIFF
--- a/rest-service/manager_rest/persistent_storage.py
+++ b/rest-service/manager_rest/persistent_storage.py
@@ -232,6 +232,8 @@ class S3StorageHandler(FileStorageHandler):
         # to proxy to a s3 resource, generate a pre-signed url, and pass that
         # in a header to nginx; nginx will then use proxy_pass to proxy
         # that resource back to the user
+        if not path:
+            raise manager_exceptions.NotFoundError(path)
         presigned_url = self.s3_client.generate_presigned_url(
             'get_object', Params={
                 'Bucket': self.bucket_name,

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -218,16 +218,33 @@ class Plugin(SQLResourceBase):
 
     def yaml_file_path(self, dsl_version=None):
         unknown_dsl_version_yaml_files_paths = []
+        versions = {}
+
         for yaml_file_path in self.yaml_files_paths:
-            if not dsl_version:
+            if dsl_version and yaml_file_path.endswith(f'{dsl_version}.yaml'):
+                # direct hit!
                 return yaml_file_path
 
-            if yaml_file_path.endswith(f'{dsl_version}.yaml'):
-                return yaml_file_path
-            if not re.search(r"_\d_\d+.yaml$", yaml_file_path):
-                unknown_dsl_version_yaml_files_paths += [yaml_file_path]
+            if m := re.search(r"_(\d_\d+)\.yaml$", yaml_file_path):
+                version = m.group(1)
+                versions[version] = yaml_file_path
+            else:
+                unknown_dsl_version_yaml_files_paths.append(yaml_file_path)
+
+        if dsl_version:
+            # if the user did specify a version, we will only consider
+            # yamls for versions lower or equal than the requested version
+            versions = {
+                ver: path for ver, path in versions.items()
+                if ver <= dsl_version
+            }
+
+        if versions:
+            # multiple matches? get the highest available!
+            return max(versions.items())[1]
 
         if unknown_dsl_version_yaml_files_paths:
+            # no match yet? just try to return any yaml at all
             return unknown_dsl_version_yaml_files_paths[0]
 
         return ''

--- a/rest-service/manager_rest/test/endpoints/test_plugins.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins.py
@@ -487,3 +487,24 @@ plugins:
             # already has wider visibility, can't move back from global!
             self.client.plugins.set_visibility(plug.id, VisibilityState.TENANT)
         assert plug.visibility == VisibilityState.GLOBAL
+
+    def test_plugin_yaml_path_version(self):
+        for available, version, expected in (
+            ([], None, ''),
+            (['xxx.yaml'], None, 'xxx.yaml'),
+            (['xxx.yaml'], '1_5', 'xxx.yaml'),
+            (['plugin.yaml'], None, 'plugin.yaml'),
+            (['plugin.yaml'], '1_5', 'plugin.yaml'),
+            (['plugin_1_5.yaml'], '1_5', 'plugin_1_5.yaml'),
+            (['plugin_1_4.yaml', 'plugin_1_5.yaml'], '1_5', 'plugin_1_5.yaml'),
+            (['plugin_1_4.yaml', 'plugin_1_5.yaml'], '1_4', 'plugin_1_4.yaml'),
+            (['plugin_1_4.yaml'], '1_5', 'plugin_1_4.yaml'),
+            (['plugin_1_4.yaml', 'plugin_1_5.yaml'], None, 'plugin_1_5.yaml'),
+            (['plugin_1_4.yaml', 'plugin_1_5.yaml'], '1_3', ''),
+            (['plugin_1_4.yaml', 'plugin_1_5.yaml', 'plugin.yaml'], '1_3',
+             'plugin.yaml'),
+        ):
+            with mock.patch.object(
+                models.Plugin, 'yaml_files_paths', available,
+            ):
+                assert models.Plugin().yaml_file_path(version) == expected


### PR DESCRIPTION
When trying to fetch a yaml file for a specific version, also give out yamls for older versions, if the requested one is not available (not newer).