### PR TITLE
NE-6889 set-visibility under a transaction

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3/secrets.py
+++ b/rest-service/manager_rest/rest/resources_v3/secrets.py
@@ -366,8 +366,10 @@ class SecretsSetVisibility(SecuredResource):
         Set the secret's visibility
         """
         visibility = rest_utils.get_visibility_parameter()
-        secret = get_storage_manager().get(models.Secret, key)
-        return get_resource_manager().set_visibility(secret, visibility)
+        sm = get_storage_manager()
+        with sm.transaction():
+            secret = sm.get(models.Secret, key)
+            return get_resource_manager().set_visibility(secret, visibility)
 
 
 class SecretsExport(SecuredResource):

--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -50,8 +50,10 @@ class BlueprintsSetVisibility(SecuredResource):
         Set the blueprint's visibility
         """
         visibility = rest_utils.get_visibility_parameter()
-        blueprint = get_storage_manager().get(models.Blueprint, blueprint_id)
-        return get_resource_manager().set_visibility(blueprint, visibility)
+        sm = get_storage_manager()
+        with sm.transaction():
+            blueprint = sm.get(models.Blueprint, blueprint_id)
+            return get_resource_manager().set_visibility(blueprint, visibility)
 
 
 class BlueprintsIcon(SecuredResource):

--- a/rest-service/manager_rest/rest/resources_v3_1/plugins.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/plugins.py
@@ -37,9 +37,11 @@ class PluginsSetVisibility(SecuredResource):
         """
         Set the plugin's visibility
         """
+        sm = get_storage_manager()
         visibility = rest_utils.get_visibility_parameter()
-        plugin = get_storage_manager().get(models.Plugin, plugin_id)
-        return get_resource_manager().set_visibility(plugin, visibility)
+        with sm.transaction():
+            plugin = sm.get(models.Plugin, plugin_id)
+            return get_resource_manager().set_visibility(plugin, visibility)
 
 
 class Plugins(resources_v2.Plugins):

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -1713,7 +1713,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
         )
         dep = models.Deployment(
             id='d1',
-            blueprint_id=bp1.id,
+            blueprint=bp1,
             visibility=VisibilityState.PRIVATE,
             tenant=self.tenant,
             creator=self.user,
@@ -1725,7 +1725,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
         )
         models.Deployment(
             id=dep.id,
-            blueprint_id=bp2.id,
+            blueprint=bp2,
             visibility=VisibilityState.PRIVATE,
             tenant=other_tenant,
             creator=self.user,

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -27,7 +27,7 @@ from dsl_parser import exceptions as dsl_exceptions
 
 from manager_rest.test import base_test
 from manager_rest import manager_exceptions
-from manager_rest.storage import models
+from manager_rest.storage import db, models
 from manager_rest.constants import (DEFAULT_TENANT_NAME,
                                     FILE_SERVER_DEPLOYMENTS_FOLDER)
 from manager_rest.rest.filters_utils import FilterRule
@@ -1702,6 +1702,41 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
         assert dep.visibility == VisibilityState.GLOBAL
         for node in self.sm.list(models.Node, filters={'deployment_id': 'd'}):
             assert node.visibility == VisibilityState.GLOBAL
+
+    def test_set_visibility_already_exists(self):
+        other_tenant = models.Tenant(name='other')
+        db.session.add(other_tenant)
+        bp1 = models.Blueprint(
+            id='bp1',
+            tenant=self.tenant,
+            creator=self.user,
+        )
+        dep = models.Deployment(
+            id='d1',
+            blueprint_id=bp1.id,
+            visibility=VisibilityState.PRIVATE,
+            tenant=self.tenant,
+            creator=self.user,
+        )
+        bp2 = models.Blueprint(
+            id='bp1',
+            tenant=other_tenant,
+            creator=self.user,
+        )
+        models.Deployment(
+            id=dep.id,
+            blueprint_id=bp2.id,
+            visibility=VisibilityState.PRIVATE,
+            tenant=other_tenant,
+            creator=self.user,
+        )
+        with self.assertRaisesRegex(CloudifyClientError, 'visibility'):
+            # deployment with this id already exists in another tenant,
+            # can't set global
+            self.client.deployments.set_visibility(
+                dep.id, VisibilityState.GLOBAL)
+        deps = models.Deployment.query.all()
+        assert len(deps) == 2
 
     def test_set_visibility_same_node_ids_succeed(self):
         self.put_deployment(

--- a/rest-service/manager_rest/test/endpoints/test_plugins.py
+++ b/rest-service/manager_rest/test/endpoints/test_plugins.py
@@ -487,3 +487,32 @@ plugins:
             # already has wider visibility, can't move back from global!
             self.client.plugins.set_visibility(plug.id, VisibilityState.TENANT)
         assert plug.visibility == VisibilityState.GLOBAL
+
+    def test_update_plugin_set_visibility_already_exists(self):
+        other_tenant = models.Tenant(name='other')
+        db.session.add(other_tenant)
+        plug = models.Plugin(
+            id='plug1',
+            archive_name='',
+            package_name='',
+            uploaded_at=datetime.utcnow(),
+            visibility=VisibilityState.PRIVATE,
+            tenant=self.tenant,
+            creator=self.user,
+        )
+        models.Plugin(
+            id=plug.id,
+            archive_name='',
+            package_name='',
+            uploaded_at=datetime.utcnow(),
+            visibility=VisibilityState.PRIVATE,
+            tenant=other_tenant,
+            creator=self.user,
+        )
+        with self.assertRaisesRegex(CloudifyClientError, 'visibility'):
+            # plugin with this id already exists in another tenant,
+            # can't set global
+            self.client.plugins.set_visibility(
+                plug.id, VisibilityState.GLOBAL)
+        plugs = models.Plugin.query.all()
+        assert len(plugs) == 2


### PR DESCRIPTION
sm.update will try to remove items (if they're not part of the current session cache) if they're duplicating tenant resources, and that includes resources that were just set to global, if their id is duplicated in another tenant.

Long story short, setting visibility to global, not only threw a 4xx in case of conflict, but also deleted your resource. Funny.

Do that under a transaction so that doesn't happen. The resource is considered persisted, and nothing actually happens.

This is the same thing done for all 4 kinds of set-visibility (note, deployments already do run under a transaction for that), and a test for each.