### PR TITLE
CYBL-2089 migrate_pickle_to_json: use sqlalchemy core, not ORM

### DIFF
--- a/rest-service/manager_rest/test/infrastructure/test_snapshot_utils.py
+++ b/rest-service/manager_rest/test/infrastructure/test_snapshot_utils.py
@@ -512,6 +512,22 @@ class TestPickleToJSON(SnapshotUtilsTestBase):
         assert silly_deployments_to_update == pu1.deployments_to_update \
                == pu2.deployments_to_update
 
+    def test_invalid_parameters(self):
+        dep1 = self._make_deployment(
+            id='dep',
+            workflows={'test': {'mapping': 'a.b.c'}},
+        )
+        # this execution's parameters aren't valid, because this dep doesn't
+        # have a capability named 'cap1', so if the migration tries to
+        # set .parameters via ORM, the re-evaluation will fail.
+        # This test can only pass, if the ORM level isn't used
+        exc = self._make_execution(
+            deployment=dep1,
+            parameters_p={'param1': {'get_capability': ['dep', 'cap1']}},
+        )
+        migrate_pickle_to_json(batch_size=1)
+        assert exc.parameters == exc.parameters_p
+
 
 class TestBlueprintRequirements(SnapshotUtilsTestBase):
     def test_no_requirements(self):


### PR DESCRIPTION
Instead of re-setting the parameters using the ORM, emit direct UPDATE queries (via sqlalchemy core).

This way it will be much faster, but the point is, it'll not fire any setter functions.

In this case, the setter we DON'T want to fire, is execution's parameter re-evaluation (`merge_workflow_parameters`), because that'll run the whole intrinsic function unnecessarily, and that can fail.

Instead, we want to migrate data directly, just set whatever was set before.