### PR TITLE
RND-1205 create-dep-env: don't require inputs with required=false 

### DIFF
--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -830,7 +830,12 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         allowed_inputs = set(blueprint_inputs)
         required_inputs = {
             name for name, input_spec in blueprint_inputs.items()
-            if 'default' not in input_spec
+            # an input is required if it has no default...
+            if 'default' not in input_spec and \
+            # ...and doesn't explicitly say that it's not required
+            not ('required' in input_spec and not input_spec['required'])
+            # (if it's not required but has no default, it'll have the default
+            # of None)
         }
         provided_inputs = set(inputs)
         missing_inputs = required_inputs - provided_inputs

--- a/tests/integration_tests/tests/agentless_tests/test_blueprint_parsing.py
+++ b/tests/integration_tests/tests/agentless_tests/test_blueprint_parsing.py
@@ -72,3 +72,21 @@ outputs:
         assert ['sec2', 'attr'] in required_secrets
         assert 'sec3' in required_secrets
         assert {'get_secret': 'sec3'} in required_secrets
+
+    def test_non_required_no_default_input(self):
+        bp = """
+tosca_definitions_version: cloudify_dsl_1_5
+imports:
+  - cloudify/types/types.yaml
+inputs:
+    inp1:
+        required: false
+outputs:
+    out1:
+        value: {get_input: inp1}
+"""
+        dep = self.deploy(
+            dsl_path=self.make_yaml_file(bp),
+        )
+        response = self.client.deployments.outputs.get(dep.id)
+        assert response['outputs'] == {'out1': None}


### PR DESCRIPTION
If inputs have no default, but are still marked as `required=false`, then don't require those inputs, but instead make the default be just None.

Note: we want _explicit_ required=false, not just a missing required field.

Also, add an inte-test to check just this behaviour.