### PR TITLE
CYBL-2097 Execution start/restore fixup

### DIFF
--- a/rest-service/manager_rest/rest/resources_v1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v1/executions.py
@@ -232,7 +232,7 @@ class Executions(SecuredResource):
                 return True
             else:
                 target_time = parse_datetime_string(attr.started_at)
-                if target_time < execution.started_at:
+                if execution.started_at and target_time < execution.started_at:
                     return True
             return False
 


### PR DESCRIPTION
Do not attempt to compare `datetime.datetime` with `NoneType` (otherwise we got an exception)

This is a cherry-pick of https://github.com/cloudify-cosmo/cloudify-manager/pull/4316