### PR TITLE
NE-6694 scheduler: remove nonexistent `components`

### DIFF
--- a/execution-scheduler/execution_scheduler/main.py
+++ b/execution-scheduler/execution_scheduler/main.py
@@ -8,8 +8,7 @@ from datetime import datetime, timedelta
 
 from cloudify.models_states import ExecutionState
 
-from flask import current_app
-from manager_rest import config, workflow_executor, components
+from manager_rest import config, workflow_executor
 from manager_rest.storage import models
 from manager_rest.flask_utils import setup_flask_app, query_service_settings
 from manager_rest.maintenance import get_maintenance_state
@@ -150,8 +149,6 @@ def main():
 def cli():
     with setup_flask_app().app_context():
         config.instance.load_configuration()
-
-        components.setup_components(current_app)
     parser = argparse.ArgumentParser()
     parser.add_argument('--logfile', default=DEFAULT_LOG_PATH,
                         help='Path to the log file')
@@ -163,7 +160,6 @@ def cli():
                         format="%(asctime)s %(message)s")
     logging.getLogger('pika').setLevel(logging.WARNING)
     with setup_flask_app().app_context():
-        components.setup_components(current_app)
         main()
 
 


### PR DESCRIPTION
The `components` import was backported here, although in cloudify 7.1.0 or 7.0.3, it doesn't exist.

The backport in #4302 moved the whole PR by mistake, but it should have only moved the `slip` commit