### PR TITLE
NE-9865 deployment delete: remove files from s3

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -2,7 +2,6 @@ import os
 import uuid
 import yaml
 import json
-import shutil
 import itertools
 from collections import defaultdict, namedtuple
 from copy import deepcopy
@@ -1010,14 +1009,13 @@ class ResourceManager(object):
             self.delete_deployment_from_labels_graph([deployment], parents)
             parent_storage_ids = {p._storage_id for p in parents}
 
-        deployment_folder = os.path.join(
-            config.instance.file_server_root,
-            FILE_SERVER_DEPLOYMENTS_FOLDER,
-            utils.current_tenant.name,
-            deployment.id)
-        if os.path.exists(deployment_folder):
-            shutil.rmtree(deployment_folder)
-
+        self.sh.delete(
+            os.path.join(
+                FILE_SERVER_DEPLOYMENTS_FOLDER,
+                utils.current_tenant.name,
+                deployment.id,
+            )
+        )
         self.sm.delete(deployment)
         return parent_storage_ids
 


### PR DESCRIPTION
Deployment delete used to be tied to the filesystem, but now, we also need to delete files from s3.
Let's just use the storage handler, to remove deployment directory from wherever it is actually stored.