### PR TITLE
NE-9690 plugin resolver: download all plugin yamls

### DIFF
--- a/mgmtworker/cloudify_system_workflows/dsl_import_resolver/resolver_with_catalog_support.py
+++ b/mgmtworker/cloudify_system_workflows/dsl_import_resolver/resolver_with_catalog_support.py
@@ -30,7 +30,6 @@ from cloudify.exceptions import InvalidBlueprintImport
 from cloudify_rest_client.exceptions import CloudifyClientError
 
 from dsl_parser import parser
-from dsl_parser.version import DSL_VERSION_PREFIX
 from dsl_parser.import_resolver.default_import_resolver import (
     DefaultImportResolver)
 
@@ -237,15 +236,8 @@ class ResolverWithCatalogSupport(DefaultImportResolver):
         # Download plugin files
         try:
             yaml_url = None
-            if dsl_version:
-                dsl_version = DSL_VERSION_PREFIX + dsl_version
-                for p_yaml in yaml_urls:
-                    if p_yaml['dsl_version'] == dsl_version:
-                        yaml_url = p_yaml['url']
-                        break
-            if not dsl_version or not yaml_url:
-                yaml_url = yaml_urls[0]['url']
-            self._download_file(yaml_url, plugin_target_path)
+            for yaml_url in yaml_urls:
+                self._download_file(yaml_url['url'], plugin_target_path)
             self._download_file(wagon_url, plugin_target_path)
             if logo_url:
                 self._download_file(logo_url, plugin_target_path, 'icon.png')

--- a/mgmtworker/cloudify_system_workflows/tests/blueprint_upload/test_blueprint_upload_autoupload_plugins.py
+++ b/mgmtworker/cloudify_system_workflows/tests/blueprint_upload/test_blueprint_upload_autoupload_plugins.py
@@ -173,20 +173,20 @@ class TestPluginAutoupload:
         assert plugin.package_name == 'cloudify-openstack-plugin'
         assert plugin.package_version == '3.2.21'
 
-    def test_autoupload_plugins_picks_correct_dsl_yaml(self, mock_client):
+    def test_autoupload_fetches_all(self, mock_client):
         plugin = self._parse_plugin_import(
             mock_client,
             'plugin:cloudify-openstack-plugin', dsl_version='1_3')
         assert plugin.package_name == 'cloudify-openstack-plugin'
         assert plugin.package_version == '3.2.21'
-        assert plugin_yamls == ['plugin.yaml']
+        assert set(plugin_yamls) == {'v2_plugin.yaml', 'plugin.yaml'}
 
         plugin = self._parse_plugin_import(
             mock_client,
             'plugin:cloudify-openstack-plugin', dsl_version='1_4')
         assert plugin.package_name == 'cloudify-openstack-plugin'
         assert plugin.package_version == '3.2.21'
-        assert plugin_yamls == ['v2_plugin.yaml']
+        assert set(plugin_yamls) == {'v2_plugin.yaml', 'plugin.yaml'}
 
     def test_autoupload_plugins_bad_version(self, mock_client):
         with pytest.raises(


### PR DESCRIPTION
When fetching a plugin from the marketplace, fetch all the plugin versions, not just the one for the current blueprint. Other blueprints might want to use this blueprint afterwards with other dsl versions.