### PR TITLE
Fixed Improper Method Call: Replaced `mktemp`

### DIFF
--- a/rest-service/manager_rest/shell/common.py
+++ b/rest-service/manager_rest/shell/common.py
@@ -2,9 +2,9 @@ import difflib
 import shutil
 import typing
 from datetime import datetime, timezone
-from os import chdir, chmod, environ, listdir, stat
+from os import chdir, chmod, environ, listdir, stat, close
 from os.path import exists, isfile, join
-from tempfile import TemporaryDirectory, mktemp
+from tempfile import TemporaryDirectory, mkstemp
 
 import yaml
 
@@ -254,7 +254,8 @@ def update_archive(blueprint: models.Blueprint, updated_file_name: str):
                     join(working_dir,
                          archive_base_dir,
                          blueprint.main_file_name))
-        new_archive_base = mktemp()
+        fd, new_archive_base = mkstemp()
+        close(fd)
         new_archive_file_name = shutil.make_archive(new_archive_base,
                                                     archive_format,
                                                     root_dir=working_dir)


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [common.py](https://github.com/cloudify-cosmo/cloudify-manager/blob/master/rest-service/manager_rest/shell/common.py#L257), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the [Python documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using `mkstemp` which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp). iCR replaced the usage of mktemp with `mkstemp`.


## Changes
Replaced `mktemp()` method with `mkstemp()`


## Previously Found & Fixed
- https://www.github.com/invesalius/invesalius3/pull/679
- https://www.github.com/Azure/azure-linux-extensions/pull/1816
- https://www.github.com/celery/billiard/pull/394


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
