### PR TITLE
NE-7791 dockerfile: parametrize postgres host in entrypoints

### DIFF
--- a/api-service/docker/entrypoint.sh
+++ b/api-service/docker/entrypoint.sh
@@ -2,7 +2,7 @@
 
 /opt/api-service/docker/prepare_secrets.sh
 
-python -m manager_rest.configure_manager --db-wait postgresql
+python -m manager_rest.configure_manager --db-wait $POSTGRES_HOST
 
 exec gunicorn \
   --worker-class uvicorn.workers.UvicornWorker \

--- a/rest-service/docker/entrypoint.sh
+++ b/rest-service/docker/entrypoint.sh
@@ -2,7 +2,7 @@
 
 /opt/rest-service/docker/prepare_secrets.sh
 
-python -m manager_rest.configure_manager --db-wait postgresql
+python -m manager_rest.configure_manager --db-wait $POSTGRES_HOST
 python -m manager_rest.configure_manager --rabbitmq-wait rabbitmq
 
 exec gunicorn \


### PR DESCRIPTION
In the entrypoint, stop hardcoding the postgresql host as `postgresql`. Instead, use the envvar