### PR TITLE
NE-7791 configure_manager: use hostname for the admin token

### DIFF
--- a/rest-service/manager_rest/configure_manager.py
+++ b/rest-service/manager_rest/configure_manager.py
@@ -2,6 +2,7 @@ import argparse
 import datetime
 import logging
 import os
+import platform
 import socket
 import sys
 import time
@@ -647,7 +648,7 @@ def _load_user_config(paths):
 
 
 def _create_admin_token(target):
-    description = 'csys-mgmtworker'
+    description = f'csys-{platform.node()}'
     # Don't leak existing Mgmtworker tokens
     db.session.execute(
         models.Token.__table__


### PR DESCRIPTION
This is going to be more pleasant to work with. In the k8s deployment we'll be able to use a statefulset, with repeatable hostnames, which will make it so we're not leaking tokens.

On aio, the name is going to be always the same then, which is also going to make it so we're not leaking random tokens