### PR TITLE
_validate_execution_update: allow no-op update

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -536,6 +536,9 @@ class ResourceManager(object):
         return None, None
 
     def _validate_execution_update(self, current_status, future_status):
+        if current_status == future_status:
+            return True
+
         if current_status in ExecutionState.END_STATES:
             return False
 

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -236,6 +236,8 @@ class ExecutionsTestCase(BaseServerTestCase):
 
         for last_status, status_list in invalid_status_map.items():
             for next_status in status_list:
+                if next_status == last_status:
+                    continue
                 assert_invalid_update()
 
     def test_bad_update_execution_status_client_exception(self):


### PR DESCRIPTION
This is important notably for snapshot-restore