### PR TITLE
snapshot: only allow 'new' snapshots on k8s

### DIFF
--- a/mgmtworker/cloudify_system_workflows/snapshot.py
+++ b/mgmtworker/cloudify_system_workflows/snapshot.py
@@ -15,6 +15,9 @@
 
 from cloudify.decorators import workflow
 from cloudify.workflows import ctx
+from cloudify_system_workflows.snapshots.utils import (
+    is_split_services_environment,
+)
 from cloudify_system_workflows.snapshots.snapshot_create import SnapshotCreate
 from cloudify_system_workflows.snapshots.snapshot_create_legacy import \
     LegacySnapshotCreate
@@ -31,6 +34,12 @@ def create(snapshot_id, config, **kwargs):
     include_events = kwargs.get('include_events', True)
     tempdir_path = kwargs.get('tempdir_path')
     legacy = kwargs.get('legacy', False)
+
+    if is_split_services_environment():
+        # in k8s, we cannot create a legacy snapshot at all, because we have
+        # no direct access to pg_dump and the postgres pod in general
+        legacy = False
+
     if legacy:
         create_snapshot = LegacySnapshotCreate(
                 snapshot_id,

--- a/mgmtworker/cloudify_system_workflows/snapshots/utils.py
+++ b/mgmtworker/cloudify_system_workflows/snapshots/utils.py
@@ -394,3 +394,14 @@ def get_stage_client(base_url: str | None = None) -> StageClient:
         stage_port = os.environ.get('STAGE_BACKEND_SERVICE_PORT') or 8088
         base_url = f'http://{stage_host}:{stage_port}/console'
     return StageClient(base_url)
+
+
+def is_split_services_environment():
+    """Are we running in a split-services / k8s environment?
+
+    In the k8s deployment, we can only use the "new" snapshot format.
+    """
+    return os.environ.get('RUNTIME_ENVIRONMENT', 'legacy').lower() in [
+        'k8s',
+        'kubernetes',
+    ]


### PR DESCRIPTION
Using k8s means we can only use the new snapshot, never the 'legacy' form of them.