### PR TITLE
Python dockerfiles: use -bookworm for the base image

### DIFF
--- a/api-service/Dockerfile
+++ b/api-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 
 ARG username=cfyuser
 ARG groupname=cfyuser

--- a/execution-scheduler/Dockerfile
+++ b/execution-scheduler/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 
 ARG username=cfyuser
 ARG groupname=cfyuser

--- a/mgmtworker/Dockerfile
+++ b/mgmtworker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 
 ARG username=cfyuser
 ARG groupname=cfyuser

--- a/rest-service/Dockerfile
+++ b/rest-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 
 ARG username=cfyuser
 ARG groupname=cfyuser


### PR DESCRIPTION
It's cleaner on vuln scans than the base 3.11-slim