### PR TITLE
 NE-15504 execution scheduler: parametrize postgres host for dbwait

### DIFF
--- a/execution-scheduler/docker/entrypoint.sh
+++ b/execution-scheduler/docker/entrypoint.sh
@@ -18,7 +18,7 @@ if [ ! -e "/opt/manager/rest-security.conf" ]; then
 fi
 set -x
 
-python -m manager_rest.configure_manager --db-wait postgresql
+python -m manager_rest.configure_manager --db-wait $POSTGRES_HOST
 python -m manager_rest.configure_manager --rabbitmq-wait rabbitmq
 
 exec cloudify-execution-scheduler


### PR DESCRIPTION
 Don't use a hardcoded "postgresql" here, users will want to use
 different db hostnames.

 This was missed in #4340