### PR TITLE
NE-16615 mgmtworker: parametrize wf/op workers separately

### DIFF
--- a/mgmtworker/Dockerfile
+++ b/mgmtworker/Dockerfile
@@ -9,6 +9,7 @@ ENV LOCAL_REST_CERT_FILE=/etc/cloudify/ssl/cloudify_internal_ca_cert.pem
 ENV AGENT_WORK_DIR=/opt/mgmtworker
 ENV MANAGER_NAME=cloudify-manager
 ENV MAX_WORKERS=10
+ENV MAX_OPERATION_WORKERS=20
 
 RUN --mount=type=cache,target=/root/.cache \
     apt-get update \

--- a/mgmtworker/mgmtworker/worker.py
+++ b/mgmtworker/mgmtworker/worker.py
@@ -393,14 +393,14 @@ def prepare_broker_config():
 
 
 def _get_default_max_workers():
-    env_value = os.environ.get('MGMTWORKER_MAX_WORKERS')
+    env_value = os.environ.get('MAX_WORKERS')
     if env_value:
         return int(env_value)
     return DEFAULT_MAX_WORKERS
 
 
 def _get_default_operation_workers():
-    env_value = os.environ.get('MGMTWORKER_OPERATION_WORKERS')
+    env_value = os.environ.get('MAX_OPERATION_WORKERS')
     if env_value:
         return int(env_value)
     return DEFAULT_OPERATION_WORKERS


### PR DESCRIPTION
In this, we keep the default max_workers at 10 for workflows, but now we have a separate amount for operations.

Note that the operations count should be larger than the workflows count in order to avoid deadlocks: notably, with Components, it's common that an operation on component runs a workflow on that component's deployment.

So for example, if we have 10 components, we have 10 operations, each runs a workflow, so 10 workflows, and... none of those workflows can run operations of their own, because there's no operation workers left! So we're stuck waiting forever in a deadlock.

If there's more operation workers than workflow workers, then there's going to be a free slot for those workflows' operations.

Additionally, with this change, all of the mgmtworker command line parameters will be able to be passed via envvars as well, which is making it easier to configure them from a k8s deployment. (command line still takes precedence over env)