### PR TITLE
Constrain flask-migrate to under 4.0.6

### DIFF
--- a/rest-service/setup.py
+++ b/rest-service/setup.py
@@ -26,7 +26,7 @@ install_requires = [
     'cryptography',
     'distro',
     'email-validator>1,<2',
-    'flask-migrate>3',
+    'flask-migrate>3,<4.0.6',
     'flask-restful',
     'flask-security',
     'flask-sqlalchemy>=2.5,<2.6',


### PR DESCRIPTION
Currently 4.0.6 has an issue where it just doesnt work when called programatically. Let's stick to 4.0.5 for now