### PR TITLE
If system execs are running, defer other execs instead of failing

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -1244,7 +1244,11 @@ class ResourceManager(object):
             and this is set, queue the execution. Otherwise, throw.
         """
         system_exec_running = self._check_for_running_executions(
-            self._active_system_wide_execution_filter(), queue)
+            self._active_system_wide_execution_filter(),
+            # even if we didn't want to queue, if there's a system execution
+            # running - too bad, we'll have to queue that either way
+            queue=True,
+        )
         if system_exec_running:
             return True
         if force:

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -1585,11 +1585,9 @@ class ExecutionQueueingTests(BaseServerTestCase):
         )
         self.sm.put(exc1)
         exc2 = self._make_execution(status=ExecutionState.PENDING)
-        with self.assertRaises(
-                manager_exceptions.ExistingRunningExecutionError):
-            self.rm.prepare_executions([exc2])
-
-        self.rm.prepare_executions([exc2], queue=True)
+        # queue not passed, but this is still queued, because a system wf
+        # is running
+        self.rm.prepare_executions([exc2])
         assert exc2.status == ExecutionState.QUEUED
 
     @mock.patch('manager_rest.workflow_executor.send_hook', mock.Mock())


### PR DESCRIPTION
Rather than failing, just queue the executions. System workflows take priority here