### PR TITLE
Deployments create: don't attempt to delete nonexistent deps

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -309,15 +309,11 @@ class DeploymentsId(resources_v1.DeploymentsId):
                         labels=labels,
                         display_name=request_dict.get('display_name'),
                     )
-                try:
-                    messages = rm.prepare_executions(
-                        [create_execution],
-                        bypass_maintenance=bypass_maintenance,
-                        commit=False
-                    )
-                except manager_exceptions.ExistingRunningExecutionError:
-                    rm.delete_deployment(deployment)
-                    raise
+                messages = rm.prepare_executions(
+                    [create_execution],
+                    bypass_maintenance=bypass_maintenance,
+                    commit=False
+                )
         except ValueError as e:
             raise manager_exceptions.BadParametersError(e)
         workflow_executor.execute_workflow(messages)


### PR DESCRIPTION
We used to delete the deployment if it failed creating / sending the create-dep-env message. Although now we do all this in a transaction, so if this fails, there's nothing to delete, the deployment just doesn't exist.

Attempting to delete here just throws an unreadable SQL error