### PR TITLE
Fix POST executions timeout (nginx's 499 response)

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -547,7 +547,7 @@ class ResourceManager(object):
             workflow_id != 'create_snapshot'
         ):
             # A `create_snapshot` can (and should) be marked as `terminated`
-            # after it has been successfuly restored
+            # after it has been successfully restored
             return False
 
         invalid_cancel_statuses = ExecutionState.ACTIVE_STATES + [
@@ -1329,16 +1329,16 @@ class ResourceManager(object):
         execution_ids = [
             e.id
             for e in self.list_executions(is_include_system_workflows=True,
+                                          include=['id'],
                                           filters=filters,
-                                          all_tenants=True,
-                                          get_all_results=True).items
+                                          all_tenants=True).items
         ]
         if execution_ids and queue:
             return True
         elif execution_ids:
             raise manager_exceptions.ExistingRunningExecutionError(
                 f'Cannot start execution because there are other executions '
-                f'running: { ", ".join(execution_ids) }'
+                f'running e.g.: { ", ".join(execution_ids) }'
             )
         else:
             return False
@@ -1466,8 +1466,12 @@ class ResourceManager(object):
         # Prepare a dict of execution storage_id:(kill_execution, execution_id)
         # int-tuple pairs for executions to be cancelled.
         execution_storage_id_kill = {}
+        execution_include_fields = [
+            '_storage_id', 'id', 'status', 'error', 'deployment_id'
+        ]
         with self.sm.transaction():
             executions = self.sm.list(models.Execution,
+                                      include=execution_include_fields,
                                       filters={'id': lambda col:
                                                col.in_(execution_ids)},
                                       get_all_results=True)
@@ -1504,7 +1508,9 @@ class ResourceManager(object):
         # Do the cancelling for a list of DB-transaction-locked executions.
         with self.sm.transaction():
             for execution in self.sm.list(
-                    models.Execution, locking=True,
+                    models.Execution,
+                    include=execution_include_fields,
+                    locking=True,
                     filters={'_storage_id': lambda col:
                              col.in_(execution_storage_id_kill.keys())},
                     get_all_results=True):

--- a/rest-service/manager_rest/utils.py
+++ b/rest-service/manager_rest/utils.py
@@ -268,6 +268,9 @@ def extract_host_agent_plugins_from_plan(plan):
 
 def get_amqp_client(tenant=None, connect_timeout=None):
     vhost = '/' if tenant is None else tenant.rabbitmq_vhost
+    kwargs = {}
+    if connect_timeout is not None:
+        kwargs['connect_timeout'] = connect_timeout
     return get_client(
         amqp_host=config.instance.amqp_host,
         amqp_user=config.instance.amqp_username,
@@ -276,7 +279,7 @@ def get_amqp_client(tenant=None, connect_timeout=None):
         amqp_vhost=vhost,
         ssl_enabled=True,
         ssl_cert_data=config.instance.amqp_ca,
-        connect_timeout=connect_timeout,
+        **kwargs,
     )
 
 


### PR DESCRIPTION
* Get amqp client with its default timout if one was not provided This patch passes `connect_timeout` parameter only in case it is set to a value different than `None` (the default).

* Limit the amount of data retrieved when updating execution's status

---

This is a cherry-pick of https://github.com/cloudify-cosmo/cloudify-manager/pull/4425