### PR TITLE
NE-31415 storage_manager: use joinedload for associationproxy

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -397,7 +397,7 @@ class DeploymentsId(resources_v1.DeploymentsId):
         return deployment
 
     @authorize('deployment_get')
-    @rest_decorators.marshal_with(models.Deployment)
+    @rest_decorators.marshal_with(models.Deployment, force_get_data=True)
     def get(self, deployment_id, _include=None, **kwargs):
         args = rest_utils.get_args_and_verify_arguments([
             Argument('all_sub_deployments', type=boolean, default=True),

--- a/rest-service/manager_rest/storage/relationships.py
+++ b/rest-service/manager_rest/storage/relationships.py
@@ -70,7 +70,7 @@ def one_to_many_relationship(child_class,
 
 def many_to_many_relationship(current_class, other_class, table_prefix=None,
                               primary_key_tuple=False, ondelete=None,
-                              unique=False, **relationship_kwargs):
+                              unique=False, backref=None, **relationship_kwargs):
     """Return a many-to-many SQL relationship object
 
     Notes:
@@ -118,10 +118,12 @@ def many_to_many_relationship(current_class, other_class, table_prefix=None,
         unique=unique,
         ondelete=ondelete
     )
+    if not backref:
+        backref = db.backref(backref_name)
     return db.relationship(
         other_class,
         secondary=secondary_table,
-        backref=db.backref(backref_name),
+        backref=backref,
         **relationship_kwargs
     )
 

--- a/rest-service/manager_rest/storage/relationships.py
+++ b/rest-service/manager_rest/storage/relationships.py
@@ -68,9 +68,16 @@ def one_to_many_relationship(child_class,
     )
 
 
-def many_to_many_relationship(current_class, other_class, table_prefix=None,
-                              primary_key_tuple=False, ondelete=None,
-                              unique=False, backref=None, **relationship_kwargs):
+def many_to_many_relationship(
+    current_class,
+    other_class,
+    table_prefix=None,
+    primary_key_tuple=False,
+    ondelete=None,
+    unique=False,
+    backref=None,
+    **relationship_kwargs,
+):
     """Return a many-to-many SQL relationship object
 
     Notes:

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -620,11 +620,11 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         return ['id', 'blueprint_id', 'created_by', 'site_name', 'schedules',
                 'tenant_name', 'display_name', 'installation_status']
 
-    def to_response(self, include=None, **kwargs):
+    def to_response(self, include=None, get_data=False, **kwargs):
         include = include or self.response_fields
         dep_dict = super(Deployment, self).to_response(
             include=include, **kwargs)
-        if 'workflows' in include:
+        if get_data and 'workflows' in include:
             dep_dict['workflows'] = self._list_workflows()
         if 'labels' in include:
             dep_dict['labels'] = self.list_labels(self.labels)

--- a/rest-service/manager_rest/storage/resource_models.py
+++ b/rest-service/manager_rest/storage/resource_models.py
@@ -552,6 +552,7 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         'latest_execution', 'total_operations')
     latest_execution_workflow_id = association_proxy(
         'latest_execution', 'workflow_id')
+    create_execution_id = association_proxy('create_execution', 'id')
 
     drifted_instances =\
         db.Column(db.Integer, server_default='0', nullable=False, default=0)
@@ -596,13 +597,13 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
             fields = super(Deployment, cls).response_fields
             fields['labels'] = flask_fields.List(
                 flask_fields.Nested(Label.resource_fields))
-            fields.pop('deployment_group_id', None)
             fields['workflows'] = flask_fields.List(
                 flask_fields.Nested(Workflow.resource_fields)
             )
-            fields['deployment_groups'] = \
+            fields['deployment_group_id'] = \
                 flask_fields.List(flask_fields.String)
             fields['latest_execution_id'] = flask_fields.String()
+            fields['create_execution_id'] = flask_fields.String()
             fields['latest_execution_status'] = flask_fields.String()
             fields['latest_execution_total_operations'] = \
                 flask_fields.Integer()
@@ -610,8 +611,6 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
                 flask_fields.Integer()
             fields['latest_execution_workflow_id'] = flask_fields.String()
             fields['has_sub_deployments'] = flask_fields.Boolean()
-            fields['create_execution'] = flask_fields.String()
-            fields['latest_execution'] = flask_fields.String()
             cls._cached_deployment_fields = fields
         return cls._cached_deployment_fields
 
@@ -644,10 +643,9 @@ class Deployment(CreatedAtMixin, SQLResourceBase):
         if 'latest_execution_finished_operations' in include:
             dep_dict['latest_execution_finished_operations'] = \
                 self.latest_execution_finished_operations
-        if 'create_execution' in include:
-            dep_dict['create_execution'] = \
-                self.create_execution.id if self.create_execution else None
-        if 'latest_execution' in include:
+        if 'create_execution_id' in include:
+            dep_dict['create_execution'] = self.create_execution_id
+        if 'latest_execution_id' in include:
             dep_dict['latest_execution'] = self.latest_execution_id
         return dep_dict
 

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -238,10 +238,10 @@ class SQLStorageManager(object):
 
             if isinstance(field, AssociationProxyInstance):
                 jl = db
-                for _, col, field in self._traverse_association_proxy(field):
+                for _, col, proxyfield in self._traverse_association_proxy(field):
                     jl = jl.joinedload(col, innerjoin=False)
-                    if hasattr(field, 'name'):
-                        jl = jl.load_only(field.name)
+                    if hasattr(proxyfield, 'name'):
+                        jl = jl.load_only(proxyfield.name)
 
                 query = query.options(jl)
 

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -238,8 +238,11 @@ class SQLStorageManager(object):
 
             if isinstance(field, AssociationProxyInstance):
                 jl = db
-                for _, col, _ in self._traverse_association_proxy(field):
+                for _, col, field in self._traverse_association_proxy(field):
                     jl = jl.joinedload(col, innerjoin=False)
+                    if hasattr(field, 'name'):
+                        jl = jl.load_only(field.name)
+
                 query = query.options(jl)
 
             elif not hasattr(field, 'prop'):

--- a/rest-service/manager_rest/storage/storage_manager.py
+++ b/rest-service/manager_rest/storage/storage_manager.py
@@ -236,12 +236,13 @@ class SQLStorageManager(object):
             if field is None:
                 continue
 
+            resolved_fields[field_name] = field
             if isinstance(field, AssociationProxyInstance):
                 jl = db
-                for _, col, proxyfield in self._traverse_association_proxy(field):
+                for _, col, pfield in self._traverse_association_proxy(field):
                     jl = jl.joinedload(col, innerjoin=False)
-                    if hasattr(proxyfield, 'name'):
-                        jl = jl.load_only(proxyfield.name)
+                    if hasattr(pfield, 'name'):
+                        jl = jl.load_only(pfield.name)
 
                 query = query.options(jl)
 
@@ -249,7 +250,6 @@ class SQLStorageManager(object):
                 continue
             elif isinstance(field.prop, RelationshipProperty):
                 rels.add(field)
-            resolved_fields[field_name] = field
 
         for rel in rels:
             query = query.options(db.joinedload(rel))


### PR DESCRIPTION
The main change here is that in _resolve_included_fields, we now use [db.joinedload](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#sqlalchemy.orm.joinedload) rather than outerjoin. This populates the assoc-proxy correctly, so that there's no longer 1+N queries when listing deployments including the blueprint_id.

And so, other places that do require the attribute to e.g. sort on it, do need an outerjoin, because assocproxies cant be used for sorting.

Also, rewrite the summarize function. This is the only place that does grouping or with_entities, so let's avoid it polluting the _get_query func