### PR TITLE
NE-31415 Rename executions related fields

### DIFF
--- a/rest-service/manager_rest/resource_manager.py
+++ b/rest-service/manager_rest/resource_manager.py
@@ -141,7 +141,7 @@ class ResourceManager(object):
 
         dep = latest_execution.deployment
         dep.installation_status = installation_status
-        dep.latest_execution = latest_execution
+        dep.latest_execution_relationship = latest_execution
         dep.deployment_status = dep.evaluate_deployment_status()
         self.sm.update(dep)
 
@@ -186,7 +186,8 @@ class ResourceManager(object):
                 if deployment:
                     execution.deployment.deployment_status = \
                         DeploymentState.IN_PROGRESS
-                    execution.deployment.latest_execution = execution
+                    execution.deployment.latest_execution_relationship = \
+                        execution
                     self.sm.update(deployment)
 
             if status in ExecutionState.END_STATES:
@@ -301,8 +302,9 @@ class ResourceManager(object):
         self.sm.refresh(execution.deployment)
         try:
             if execution and execution.deployment and \
-                    execution.deployment.create_execution:
-                create_execution = execution.deployment.create_execution
+                    execution.deployment.create_execution_relationship:
+                create_execution = \
+                    execution.deployment.create_execution_relationship
                 delete_dep_env = 'delete_deployment_environment'
                 if (create_execution.status == ExecutionState.FAILED and
                         execution.workflow_id != delete_dep_env):
@@ -1520,7 +1522,7 @@ class ResourceManager(object):
                 execution = self.sm.update(execution)
                 if execution.deployment_id:
                     dep = execution.deployment
-                    dep.latest_execution = execution
+                    dep.latest_execution_relationship = execution
                     dep.deployment_status = \
                         dep.evaluate_deployment_status()
                     self.sm.update(dep)
@@ -2330,11 +2332,11 @@ class ResourceManager(object):
         return prepared_relationships
 
     def verify_deployment_environment_created_successfully(self, deployment):
-        if not deployment.create_execution:
+        if not deployment.create_execution_relationship:
             # the user removed the execution, let's assume they knew
             # what they were doing and allow this
             return
-        status = deployment.create_execution.status
+        status = deployment.create_execution_relationship.status
         if status == ExecutionState.TERMINATED:
             return
         elif status == ExecutionState.PENDING:
@@ -2348,7 +2350,7 @@ class ResourceManager(object):
                     'Deployment environment creation is still in progress, '
                     'try again in a minute')
         elif status == ExecutionState.FAILED:
-            error_line = deployment.create_execution.error\
+            error_line = deployment.create_execution_relationship.error\
                 .strip().split('\n')[-1]
             raise manager_exceptions.DeploymentCreationError(
                 "Can't launch executions since environment creation for "

--- a/rest-service/manager_rest/rest/resources_v1/executions.py
+++ b/rest-service/manager_rest/rest/resources_v1/executions.py
@@ -238,14 +238,18 @@ class Executions(SecuredResource):
 
         if deployment:
             exec_relations_set = False
-            if _should_update(execution, deployment, 'latest_execution'):
-                deployment.latest_execution = execution
+            if _should_update(
+                    execution, deployment, 'latest_execution_relationship'
+            ):
+                deployment.latest_execution_relationship = execution
                 exec_relations_set = True
 
             if execution.workflow_id == \
                     'create_deployment_environment':
-                if _should_update(execution, deployment, 'create_execution'):
-                    deployment.create_execution = execution
+                if _should_update(
+                        execution, deployment, 'create_execution_relationship'
+                ):
+                    deployment.create_execution_relationship = execution
                     exec_relations_set = True
 
             if exec_relations_set:

--- a/rest-service/manager_rest/rest/resources_v3_1/deployments.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/deployments.py
@@ -159,7 +159,7 @@ class DeploymentsId(resources_v1.DeploymentsId):
     def _is_create_execution(self, deployment):
         """Are we running in deployment's create execution?"""
         return current_execution and \
-            current_execution == deployment.create_execution
+            current_execution == deployment.create_execution_relationship
 
     def _add_existing_labels(self, deployment, new_labels):
         """Add existing deployment labels to new_labels.
@@ -318,9 +318,12 @@ class DeploymentsId(resources_v1.DeploymentsId):
             raise manager_exceptions.BadParametersError(e)
         workflow_executor.execute_workflow(messages)
         if not args.async_create:
-            rest_utils.wait_for_execution(sm, deployment.create_execution.id)
-            if deployment.create_execution.status != ExecutionState.TERMINATED:
-                raise self._error_from_create(deployment.create_execution)
+            rest_utils.wait_for_execution(
+                sm, deployment.create_execution_relationship.id)
+            if deployment.create_execution_relationship.status != \
+                    ExecutionState.TERMINATED:
+                raise self._error_from_create(
+                    deployment.create_execution_relationship)
         return deployment, 201
 
     @authorize('deployment_update')
@@ -1244,7 +1247,8 @@ class DeploymentGroupsId(SecuredResource):
                 dep = self._make_new_group_deployment(
                     rm, group, new_dep_spec, deployment_count, group.labels)
                 group.deployments.append(dep)
-                create_exec_group.executions.append(dep.create_execution)
+                create_exec_group.executions.append(
+                    dep.create_execution_relationship)
                 deployment_count += 1
             messages = create_exec_group.start_executions(sm, rm)
         workflow_executor.execute_workflow(messages)

--- a/rest-service/manager_rest/snapshot_utils.py
+++ b/rest-service/manager_rest/snapshot_utils.py
@@ -30,7 +30,7 @@ PICKLE_TO_JSON_MIGRATION_BATCH_SIZE = 1000
 
 
 def _set_latest_execution():
-    """Set .latest_execution for all deployments
+    """Set .latest_execution_relationshipfor all deployments
 
     Find the latest execution based on the created_at field, and set it
     for each deployment.

--- a/rest-service/manager_rest/test/base_test.py
+++ b/rest-service/manager_rest/test/base_test.py
@@ -779,22 +779,26 @@ class BaseServerTestCase(unittest.TestCase):
         m.deployment = client.deployments.get(deployment.id)
         m.blueprint = blueprint
         m.tenant_name = deployment.tenant_name
-        deployment.create_execution.status = ExecutionState.STARTED
-        sm.update(deployment.create_execution)
+        deployment.create_execution_relationship.status = \
+            ExecutionState.STARTED
+        sm.update(deployment.create_execution_relationship)
         get_rest_client_target = \
             'cloudify_system_workflows.deployment_environment.get_rest_client'
         with patch(get_rest_client_target, return_value=client), \
                 patch('cloudify_system_workflows.deployment_environment.'
                       'os.makedirs'):
             try:
-                create(m, **deployment.create_execution.parameters)
+                create(
+                    m, **deployment.create_execution_relationship.parameters)
             except Exception:
                 client.executions.update(
-                    deployment.create_execution.id, ExecutionState.FAILED)
+                    deployment.create_execution_relationship.id,
+                    ExecutionState.FAILED)
                 raise
             else:
                 client.executions.update(
-                    deployment.create_execution.id, ExecutionState.TERMINATED)
+                    deployment.create_execution_relationship.id,
+                    ExecutionState.TERMINATED)
 
     def delete_deployment(self, deployment_id):
         """Delete the deployment from the database.

--- a/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployment_groups.py
@@ -211,7 +211,7 @@ class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
         assert sm_group.creation_counter == 1
         deps = sm_group.deployments
         assert len(deps) == 1
-        create_exec_params = deps[0].create_execution.parameters
+        create_exec_params = deps[0].create_execution_relationship.parameters
         assert create_exec_params['inputs'] == inputs
         assert create_exec_params['labels'] == [
             {'key': 'label1', 'value': 'label-value',
@@ -575,7 +575,7 @@ class DeploymentGroupsTestCase(base_test.BaseServerTestCase):
         dep_id = group.deployment_ids[0]
         dep = self.sm.get(models.Deployment, dep_id)
         assert set((label['key'], label['value'])
-                   for label in dep.create_execution.parameters['labels']) == {
+                   for label in dep.create_execution_relationship.parameters['labels']) == {  # noqa
             # from new_deployments:
             ('label1', 'value1'),
             ('label1', 'value2'),

--- a/rest-service/manager_rest/test/endpoints/test_deployments.py
+++ b/rest-service/manager_rest/test/endpoints/test_deployments.py
@@ -1782,7 +1782,7 @@ class DeploymentsTestCase(base_test.BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        dep.latest_execution = exc
+        dep.latest_execution_relationship = exc
 
         retrieved = self.client.deployments.get(dep.id)
         assert retrieved.latest_execution_id == exc.id

--- a/rest-service/manager_rest/test/endpoints/test_executions.py
+++ b/rest-service/manager_rest/test/endpoints/test_executions.py
@@ -476,15 +476,15 @@ class ExecutionsTestCase(BaseServerTestCase):
             with self.subTest():
                 dep_id = f'dep_{state}'
                 deployment = self._deployment(dep_id)
-                assert self.sm.get(
-                    models.Deployment, dep_id).latest_execution is None
+                assert not self.sm.get(
+                    models.Deployment, dep_id).latest_execution_relationship
                 self.client.executions.create(
                     deployment_id=dep_id,
                     workflow_id='some_workflow',
                     force_status=state,
                     started_at="2122-11-25T15:13:17.930Z",
                 )
-                assert deployment.latest_execution is None, \
+                assert deployment.latest_execution_relationship is None, \
                     f'Latest execution should not be set for {state}'
 
     def test_restore_set_latest_from_none(self):
@@ -492,8 +492,8 @@ class ExecutionsTestCase(BaseServerTestCase):
             with self.subTest():
                 dep_id = f'dep_{state}'
                 deployment = self._deployment(dep_id)
-                assert self.sm.get(
-                    models.Deployment, dep_id).latest_execution is None
+                assert not self.sm.get(
+                    models.Deployment, dep_id).latest_execution_relationship
                 timestamp = "2122-11-25T15:13:17.930Z"
                 self.client.executions.create(
                     deployment_id=dep_id,
@@ -501,8 +501,8 @@ class ExecutionsTestCase(BaseServerTestCase):
                     force_status=state,
                     started_at=timestamp,
                 )
-                assert deployment.latest_execution.started_at == timestamp, \
-                    f'Latest execution should be set for {state}'
+                assert deployment.latest_execution_relationship.started_at == \
+                       timestamp, f'Latest execution should be set for {state}'
 
     def test_restore_not_set_latest_with_older_not_running(self):
         """We should not set latest execution when provided an execution
@@ -518,7 +518,7 @@ class ExecutionsTestCase(BaseServerTestCase):
                 deployment = self._deployment(dep_id)
                 execution = self._execution(id=old_execution_id,
                                             started_at=prev_timestamp)
-                deployment.latest_execution = execution
+                deployment.latest_execution_relationship = execution
 
                 self.client.executions.create(
                     execution_id=new_execution_id,
@@ -528,8 +528,8 @@ class ExecutionsTestCase(BaseServerTestCase):
                     started_at=timestamp,
                 )
 
-                assert deployment.latest_execution.id == old_execution_id, \
-                    f'Latest execution should not be changed for {state}'
+                assert deployment.latest_execution_relationship.id == \
+                       old_execution_id, f'Latest execution should not be changed for {state}'  # noqa
 
     def test_restore_set_latest_with_older(self):
         """We should update the latest execution if we see a create_dep_env
@@ -545,7 +545,7 @@ class ExecutionsTestCase(BaseServerTestCase):
                 deployment = self._deployment(dep_id)
                 execution = self._execution(id=old_execution_id,
                                             started_at=prev_timestamp)
-                deployment.latest_execution = execution
+                deployment.latest_execution_relationship = execution
 
                 self.client.executions.create(
                     execution_id=new_execution_id,
@@ -555,8 +555,8 @@ class ExecutionsTestCase(BaseServerTestCase):
                     started_at=timestamp,
                 )
 
-                assert deployment.latest_execution.id == new_execution_id, \
-                    f'Latest execution should be changed for {state}'
+                assert deployment.latest_execution_relationship.id == \
+                       new_execution_id, f'Latest execution should be changed for {state}'  # noqa
 
     def test_restore_not_set_latest_with_newer(self):
         """We should never update the latest execution if it is newer than the
@@ -571,7 +571,7 @@ class ExecutionsTestCase(BaseServerTestCase):
                 deployment = self._deployment(dep_id)
                 execution = self._execution(id=old_execution_id,
                                             started_at=prev_timestamp)
-                deployment.latest_execution = execution
+                deployment.latest_execution_relationship = execution
 
                 self.client.executions.create(
                     deployment_id=dep_id,
@@ -580,8 +580,8 @@ class ExecutionsTestCase(BaseServerTestCase):
                     started_at=timestamp,
                 )
 
-                assert deployment.latest_execution.id == old_execution_id, \
-                    f'Latest execution should not be changed for {state}'
+                assert deployment.latest_execution_relationship.id == \
+                       old_execution_id, f'Latest execution should not be changed for {state}'  # noqa
 
     def test_restore_not_set_create_exec_from_none(self):
         for state in self.EXEC_NOT_SET_STATES:
@@ -599,7 +599,7 @@ class ExecutionsTestCase(BaseServerTestCase):
                     started_at=timestamp,
                 )
 
-                assert deployment.create_execution is None, \
+                assert deployment.create_execution_relationship is None, \
                     f'Create execution should not be set for {state}'
 
     def test_restore_set_create_exec_from_none(self):
@@ -618,8 +618,8 @@ class ExecutionsTestCase(BaseServerTestCase):
                     started_at=timestamp,
                 )
 
-                assert deployment.create_execution.id == execution_id, \
-                    f'Create execution should be set for {state}'
+                assert deployment.create_execution_relationship.id == \
+                       execution_id, f'Create execution should be set for {state}'  # noqa
 
     def test_restore_not_set_create_with_older_not_running(self):
         """We should not set create execution when provided an execution
@@ -636,7 +636,7 @@ class ExecutionsTestCase(BaseServerTestCase):
                 execution = self._execution(id=old_execution_id,
                                             status=ExecutionState.TERMINATED,
                                             started_at=prev_timestamp)
-                deployment.create_execution = execution
+                deployment.create_execution_relationship = execution
 
                 self.client.executions.create(
                     execution_id=new_execution_id,
@@ -646,8 +646,8 @@ class ExecutionsTestCase(BaseServerTestCase):
                     started_at=timestamp,
                 )
 
-                assert deployment.create_execution.id == old_execution_id, \
-                    f'Create execution should not be changed for {state}'
+                assert deployment.create_execution_relationship.id == \
+                       old_execution_id, f'Create execution should not be changed for {state}'  # noqa
 
     def test_restore_set_create_with_older(self):
         """We should update the create execution if we see a create_dep_env
@@ -664,7 +664,7 @@ class ExecutionsTestCase(BaseServerTestCase):
                 execution = self._execution(id=old_execution_id,
                                             status=ExecutionState.TERMINATED,
                                             started_at=prev_timestamp)
-                deployment.create_execution = execution
+                deployment.create_execution_relationship = execution
 
                 self.client.executions.create(
                     execution_id=new_execution_id,
@@ -674,8 +674,8 @@ class ExecutionsTestCase(BaseServerTestCase):
                     started_at=timestamp,
                 )
 
-                assert deployment.create_execution.id == new_execution_id, \
-                    f'Create execution should be changed for {state}'
+                assert deployment.create_execution_relationship.id == \
+                       new_execution_id, f'Create execution should be changed for {state}'  # noqa
 
     def test_restore_not_set_create_with_newer(self):
         """We should never update the create execution if it is newer than the
@@ -691,7 +691,7 @@ class ExecutionsTestCase(BaseServerTestCase):
                 execution = self._execution(id=old_execution_id,
                                             status=ExecutionState.TERMINATED,
                                             started_at=prev_timestamp)
-                deployment.create_execution = execution
+                deployment.create_execution_relationship = execution
 
                 self.client.executions.create(
                     deployment_id=dep_id,
@@ -700,8 +700,8 @@ class ExecutionsTestCase(BaseServerTestCase):
                     started_at=timestamp,
                 )
 
-                assert deployment.create_execution.id == old_execution_id, \
-                    f'Create execution should not be changed for {state}'
+                assert deployment.create_execution_relationship.id == \
+                       old_execution_id, f'Create execution should not be changed for {state}'  # noqa
 
     def test_restore_not_set_upload_from_none(self):
         for state in self.EXEC_NOT_SET_STATES:
@@ -1704,8 +1704,8 @@ class ExecutionQueueingTests(BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        old_dep.create_execution = create_exc
-        old_dep.latest_execution = create_exc
+        old_dep.create_execution_relationship = create_exc
+        old_dep.latest_execution_relationship = create_exc
         create_group.executions.append(create_exc)
 
         new_dep = models.Deployment(
@@ -1722,8 +1722,8 @@ class ExecutionQueueingTests(BaseServerTestCase):
             creator=self.user,
             tenant=self.tenant,
         )
-        new_dep.create_execution = create_exc
-        new_dep.latest_execution = create_exc
+        new_dep.create_execution_relationship = create_exc
+        new_dep.latest_execution_relationship = create_exc
         create_group.executions.append(create_exc)
         models.Execution(
             id=f'install_{new_dep.id}',

--- a/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
+++ b/rest-service/manager_rest/test/endpoints/test_inter_deployment_dependencies.py
@@ -355,7 +355,7 @@ class RecalcAncestorsTest(_DependencyTestUtils, BaseServerTestCase):
         d1 = self._deployment(id='d1')
         d2 = self._deployment(id='d2')
         self._label_dependency(d1, d2)
-        d2.latest_execution = models.Execution(
+        d2.latest_execution_relationship = models.Execution(
             status='failed',
             workflow_id='',
             tenant=self.tenant,

--- a/rest-service/manager_rest/test/infrastructure/test_snapshot_utils.py
+++ b/rest-service/manager_rest/test/infrastructure/test_snapshot_utils.py
@@ -133,7 +133,7 @@ class TestSnapshotDeploymentStatus(SnapshotUtilsTestBase):
         dep = self._make_deployment()
         populate_deployment_statuses()
         dep = models.Deployment.query.get(dep._storage_id)
-        assert dep.latest_execution is None
+        assert dep.latest_execution_relationship is None
 
     def test_latest_execution_one(self):
         dep = self._make_deployment()
@@ -142,7 +142,7 @@ class TestSnapshotDeploymentStatus(SnapshotUtilsTestBase):
         db.session.flush()
         populate_deployment_statuses()
         db.session.refresh(dep)
-        assert dep.latest_execution == exc
+        assert dep.latest_execution_relationship == exc
 
     def test_latest_execution_multiple(self):
         dep1 = self._make_deployment()
@@ -157,8 +157,8 @@ class TestSnapshotDeploymentStatus(SnapshotUtilsTestBase):
         populate_deployment_statuses()
         db.session.refresh(dep1)
         db.session.refresh(dep2)
-        assert dep1.latest_execution == exc1
-        assert dep2.latest_execution == exc2
+        assert dep1.latest_execution_relationship == exc1
+        assert dep2.latest_execution_relationship == exc2
 
     def test_node_instances_empty(self):
         dep = self._make_deployment()


### PR DESCRIPTION
We need to still return create_execution and latest_execution in a response instead of create_execution_id and latest_execution_id