### PR TITLE
Fix blueprint API - in some cases the visibility parameter is optional

### DIFF
--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -100,7 +100,7 @@ class BlueprintsId(resources_v2.BlueprintsId):
         created_at = args.get('created_at')
         created_by = args.get('created_by')
 
-        visibility = args.get('visibility')
+        visibility = args.get('visibility', None)
         private_resource = args.get('private_resource')
         application_file_name = args.get('application_file_name', '')
         skip_execution = args.get('skip_execution', False)
@@ -421,10 +421,10 @@ class BlueprintsIdValidate(BlueprintsId):
         if form_params:
             args = json.loads(form_params)
         if not args:
-            args = request.args.to_dict(flat=False)
+            args = request.args.to_dict()
 
         rest_utils.validate_inputs({'blueprint_id': blueprint_id})
-        visibility = args.pop('visibility')
+        visibility = args.pop('visibility', None)
         if visibility is not None:
             rest_utils.validate_visibility(
                 visibility, valid_values=VisibilityState.STATES)

--- a/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
+++ b/rest-service/manager_rest/rest/resources_v3_1/blueprints.py
@@ -100,7 +100,7 @@ class BlueprintsId(resources_v2.BlueprintsId):
         created_at = args.get('created_at')
         created_by = args.get('created_by')
 
-        visibility = args.get('visibility', None)
+        visibility = args.get('visibility')
         private_resource = args.get('private_resource')
         application_file_name = args.get('application_file_name', '')
         skip_execution = args.get('skip_execution', False)


### PR DESCRIPTION
Fixes blueprint API (blueprint validate and blueprint upload) so the visibility argument is truly optional when parameters are passed as a form parameters. Additional fix for blueprint validate API endpoint to pass further parameter values as strings (not as one element list of strings which later fails validation).