### PR TITLE
NE-41573, upgrade rabbitmq

### DIFF
--- a/packaging/cloudify-rabbitmq.spec
+++ b/packaging/cloudify-rabbitmq.spec
@@ -15,7 +15,7 @@ URL:            https://github.com/cloudify-cosmo/cloudify-manager
 Vendor:         Cloudify Platform Ltd.
 Packager:       Cloudify Platform Ltd.
 
-Requires:       rabbitmq-server = 3.10.7
+Requires:       rabbitmq-server = 3.11.28
 
 
 %define _user rabbitmq


### PR DESCRIPTION
Update rabbitmq version from 3.10.7 to 3.11.28 (tested on customer deployment but upgraded with difficulty on existing deployment)