### PR TITLE
NE-48822 fix rest conf file access rights

### DIFF
--- a/rest-service/manager_rest/update_rest_db_config.py
+++ b/rest-service/manager_rest/update_rest_db_config.py
@@ -214,6 +214,7 @@ def update_db_address(restservice_config_path, commit):
     if commit:
         with open(restservice_config_path, 'w') as f:
             f.write(serialized)
+        os.chmod(restservice_config_path, 0o660)
         logging.info('Stored the new config in %s', restservice_config_path)
     else:
         logging.info('Dry-run: did not store the new config')


### PR DESCRIPTION
Change /opt/manager/cloudify-rest.conf file access permissions to 660